### PR TITLE
Refactor templates to use base layout

### DIFF
--- a/static/css/unmatched.css
+++ b/static/css/unmatched.css
@@ -1,0 +1,214 @@
+:root {
+    --bars-color: #6a4baf;
+    --text-color: #333333;
+    --bg-color: #f8f9fa;
+    --info-bg: rgba(106, 75, 175, 0.1);
+    --header-bg: #6a4baf;
+}
+
+.dark-mode {
+    --bars-color: #9370DB;
+    --text-color: #f8f9fa;
+    --bg-color: #121212;
+    --info-bg: rgba(147, 112, 219, 0.1);
+    --header-bg: #9370DB;
+}
+
+body {
+    transition: background-color 0.3s ease, color 0.3s ease;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    padding-bottom: 2rem;
+}
+
+.dark-mode .card {
+    background-color: #1e1e1e;
+    color: var(--text-color);
+    border: 1px solid #444;
+}
+
+.dark-mode .table {
+    color: var(--text-color);
+}
+
+.dark-mode .table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: rgba(255, 255, 255, 0.15);
+    color: var(--text-color);
+}
+
+.dark-mode .table-striped > tbody > tr:nth-of-type(even) {
+    background-color: rgba(30, 30, 30, 0.7);
+    color: var(--text-color);
+}
+
+.dark-mode .table-hover > tbody > tr:hover {
+    background-color: rgba(147, 112, 219, 0.2);
+    color: var(--text-color);
+}
+
+.dark-mode .alert-info {
+    background-color: var(--info-bg);
+    border-color: rgba(147, 112, 219, 0.2);
+    color: var(--text-color);
+}
+
+.dark-mode .table-light,
+.dark-mode .table-dark {
+    background-color: #2a2a2a;
+    color: var(--text-color);
+}
+
+.dark-mode .table-light th,
+.dark-mode .table-dark th,
+.dark-mode thead th {
+    color: var(--text-color) !important;
+}
+
+.dark-mode svg .cls-1 {
+    stroke: var(--bars-color);
+}
+
+.dark-mode svg #logo-text path,
+.dark-mode svg #tagline path {
+    fill: var(--text-color);
+}
+
+#darkModeToggle {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    z-index: 1000;
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem;
+    border-radius: 5px;
+    background-color: rgba(255, 255, 255, 0.8);
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    transition: background-color 0.3s ease;
+}
+
+.dark-mode #darkModeToggle {
+    background-color: rgba(30, 30, 30, 0.8);
+}
+
+#darkModeToggle .form-check-input,
+#darkModeToggle .form-check-label {
+    margin: 0;
+}
+
+#darkSwitch {
+    width: 3rem;
+    height: 1.5rem;
+    background-color: #ccc;
+    border-radius: 999px;
+    appearance: none;
+    outline: none;
+    cursor: pointer;
+    position: relative;
+    transition: background-color 0.3s ease;
+}
+
+#darkSwitch::before {
+    content: "";
+    position: absolute;
+    width: 1.2rem;
+    height: 1.2rem;
+    border-radius: 50%;
+    top: 0.15rem;
+    left: 0.15rem;
+    background-color: white;
+    transition: transform 0.3s ease;
+}
+
+#darkSwitch:checked {
+    background-color: var(--bars-color);
+}
+
+#darkSwitch:checked::before {
+    transform: translateX(1.5rem);
+}
+
+.reason-section {
+    margin-bottom: 2rem;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.dark-mode .reason-section {
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+}
+
+.reason-header {
+    background-color: var(--header-bg);
+    color: white;
+    padding: 0.75rem 1rem;
+    font-weight: 500;
+}
+
+.reason-count {
+    background-color: rgba(255, 255, 255, 0.2);
+    border-radius: 20px;
+    padding: 0.1rem 0.75rem;
+    margin-left: 0.5rem;
+    font-size: 0.9rem;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.fade-in {
+    animation: fadeIn 0.5s ease forwards;
+}
+
+#logo-wrapper svg {
+    width: 100%;
+    height: auto;
+    max-height: 120px;
+    opacity: 0;
+    animation: fadeIn 2s ease forwards;
+}
+
+.action-buttons {
+    position: sticky;
+    top: 1rem;
+    z-index: 100;
+    background-color: rgba(248, 249, 250, 0.9);
+    border-radius: 8px;
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    text-align: center;
+    backdrop-filter: blur(5px);
+}
+
+.dark-mode .action-buttons {
+    background-color: rgba(30, 30, 30, 0.9);
+}
+
+.info-card {
+    background-color: var(--info-bg);
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 1.5rem;
+    transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.dark-mode .info-card {
+    background-color: var(--info-bg);
+}
+
+.dark-mode .table thead th {
+    background-color: #343a40 !important;
+    color: white !important;
+    border-color: #444;
+}
+
+.dark-mode .table tbody td,
+.dark-mode .table tbody th {
+    color: var(--text-color) !important;
+}

--- a/static/js/results.js
+++ b/static/js/results.js
@@ -1,0 +1,193 @@
+// Dark mode toggle
+const darkSwitch = document.getElementById('darkSwitch');
+if (localStorage.getItem('darkMode') === 'true') {
+    document.body.classList.add('dark-mode');
+    darkSwitch.checked = true;
+}
+
+darkSwitch.addEventListener('change', function () {
+    document.body.classList.toggle('dark-mode', this.checked);
+    localStorage.setItem('darkMode', this.checked);
+
+    const svgElement = document.querySelector('#logo-wrapper svg');
+    if (svgElement) {
+        const bars = svgElement.querySelectorAll('.cls-1');
+        const textPaths = svgElement.querySelectorAll('#logo-text path, #tagline path');
+
+        if (this.checked) {
+            bars.forEach(bar => bar.setAttribute('stroke', '#9370DB'));
+            textPaths.forEach(path => path.setAttribute('fill', '#f8f9fa'));
+        } else {
+            bars.forEach(bar => bar.setAttribute('stroke', '#6a4baf'));
+            textPaths.forEach(path => path.setAttribute('fill', '#333333'));
+        }
+    }
+});
+
+function showToast(message, type = 'info', duration = 3000) {
+    const toastContainer = document.getElementById('toastContainer');
+    const toastId = 'toast-' + Date.now();
+    const toastHtml = `
+        <div id="${toastId}" class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
+            <div class="toast-header${type === 'error' ? ' bg-danger text-white' : ''}">
+                <strong class="me-auto">ScrobbleScope</strong>
+                <small>Just now</small>
+                <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+            </div>
+            <div class="toast-body${type === 'error' ? ' bg-danger text-white' : ''}">
+                ${message}
+            </div>
+        </div>
+    `;
+    toastContainer.insertAdjacentHTML('beforeend', toastHtml);
+    setTimeout(() => {
+        const toast = document.getElementById(toastId);
+        if (toast) {
+            toast.classList.remove('show');
+            setTimeout(() => toast.remove(), 500);
+        }
+    }, duration);
+}
+
+function fetchUnmatchedAlbums() {
+    const unmatchedList = document.getElementById('unmatched-list');
+    fetch('/unmatched')
+        .then(response => response.json())
+        .then(unmatchedData => {
+            let html = '';
+            if (!unmatchedData || Object.keys(unmatchedData.data || unmatchedData).length === 0) {
+                html = '<p>No unmatched albums found.</p>';
+            } else {
+                const data = unmatchedData.data || unmatchedData;
+                const count = unmatchedData.count || Object.keys(data).length;
+                html = `<p>Found ${count} unmatched albums:</p>`;
+                html += '<div class="table-responsive"><table class="table table-sm">';
+                html += '<thead><tr><th>Artist</th><th>Album</th><th>Reason</th></tr></thead><tbody>';
+                for (const key in data) {
+                    const item = data[key];
+                    html += `<tr><td>${item.artist}</td><td>${item.album}</td><td>${item.reason}</td></tr>`;
+                }
+                html += '</tbody></table></div>';
+            }
+            unmatchedList.innerHTML = html;
+        })
+        .catch(error => {
+            unmatchedList.innerHTML = `<div class="alert alert-danger">Error loading unmatched albums: ${error}</div>`;
+        });
+}
+
+document.getElementById('view-unmatched-quick').addEventListener('click', fetchUnmatchedAlbums);
+if (document.getElementById('view-unmatched')) {
+    document.getElementById('view-unmatched').addEventListener('click', fetchUnmatchedAlbums);
+}
+
+document.getElementById('export-csv').addEventListener('click', function () {
+    try {
+        const table = document.querySelector('.table');
+        if (!table) {
+            showToast('No data available to export', 'error');
+            return;
+        }
+        let csvContent = [];
+        const headerRow = [];
+        const headers = table.querySelectorAll('thead th');
+        headers.forEach(header => {
+            headerRow.push('"' + header.textContent.trim().replace(/"/g, '""') + '"');
+        });
+        csvContent.push(headerRow.join(','));
+        const rows = table.querySelectorAll('tbody tr');
+        for (let i = 0; i < rows.length; i++) {
+            const row = [];
+            const cells = Array.from(rows[i].querySelectorAll('th, td'));
+            for (let j = 0; j < cells.length; j++) {
+                let content = '';
+                if (j === 1 && cells[j].classList.contains('album-title')) {
+                    const albumInfo = cells[j].querySelector('.album-info');
+                    content = albumInfo ? albumInfo.textContent.trim() : '';
+                } else {
+                    content = cells[j].textContent.trim();
+                }
+                content = content.replace(/\s+/g, ' ');
+                if (content.includes(',') || content.includes('"') || content.includes('\n')) {
+                    content = '"' + content.replace(/"/g, '""') + '"';
+                }
+                row.push(content);
+            }
+            csvContent.push(row.join(','));
+        }
+        const csvString = csvContent.join('\n');
+        const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        const username = window.RESULTS.username;
+        const year = window.RESULTS.year;
+        link.setAttribute('href', url);
+        link.setAttribute('download', `scrobblescope_${username}_${year}_albums.csv`);
+        link.style.display = 'none';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+        showToast('CSV file downloaded successfully!');
+    } catch (error) {
+        console.error('Error exporting CSV:', error);
+        showToast('Error creating CSV file: ' + error.message, 'error');
+    }
+});
+
+document.getElementById('save-image').addEventListener('click', function () {
+    showToast('Creating image... Please wait.');
+    const targetElement = document.getElementById('results-table-wrapper');
+    if (!targetElement) {
+        showToast('No content to save as image', 'error');
+        return;
+    }
+    const isDarkMode = document.body.classList.contains('dark-mode');
+    html2canvas(targetElement, {
+        backgroundColor: isDarkMode ? '#121212' : '#ffffff',
+        allowTaint: true,
+        useCORS: true,
+        scale: 2,
+        onclone: function(clonedDoc) {
+            const clonedTable = clonedDoc.querySelector('.table');
+            if (clonedTable && isDarkMode) {
+                clonedTable.style.color = '#f8f9fa';
+                clonedTable.style.backgroundColor = '#121212';
+                clonedTable.querySelectorAll('tr').forEach((row, index) => {
+                    if (index % 2 === 1) {
+                        row.style.backgroundColor = 'rgba(255, 255, 255, 0.1)';
+                    } else if (index > 0) {
+                        row.style.backgroundColor = 'rgba(30, 30, 30, 0.7)';
+                    }
+                    row.querySelectorAll('th, td').forEach(cell => {
+                        cell.style.color = '#f8f9fa';
+                        cell.style.borderColor = 'rgba(255, 255, 255, 0.1)';
+                    });
+                });
+                const header = clonedTable.querySelector('thead');
+                if (header) {
+                    header.style.backgroundColor = '#343a40';
+                    header.style.color = '#ffffff';
+                }
+            }
+        }
+    }).then(function(canvas) {
+        try {
+            const link = document.createElement('a');
+            const username = window.RESULTS.username;
+            const year = window.RESULTS.year;
+            link.download = `scrobblescope_${username}_${year}.jpg`;
+            link.href = canvas.toDataURL('image/jpeg', 0.95);
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            showToast('Image saved successfully!');
+        } catch (err) {
+            console.error('Error saving image:', err);
+            showToast('Failed to save image: ' + err.message, 'error');
+        }
+    }).catch(function(err) {
+        console.error('Error capturing image:', err);
+        showToast('Failed to create image: ' + err.message, 'error');
+    });
+});

--- a/static/js/unmatched.js
+++ b/static/js/unmatched.js
@@ -1,0 +1,56 @@
+// Dark mode persistence and switch sync
+const darkSwitch = document.getElementById('darkSwitch');
+const prefersDark = localStorage.getItem('darkMode') === 'true';
+
+if (prefersDark) {
+    document.body.classList.add('dark-mode');
+    darkSwitch.checked = true;
+}
+
+darkSwitch.addEventListener('change', () => {
+    const isDark = darkSwitch.checked;
+    document.body.classList.toggle('dark-mode', isDark);
+    localStorage.setItem('darkMode', isDark);
+
+    const svgElement = document.querySelector('#logo-wrapper svg');
+    if (svgElement) {
+        const bars = svgElement.querySelectorAll('.cls-1');
+        const textPaths = svgElement.querySelectorAll('#logo-text path, #tagline path');
+
+        if (isDark) {
+            bars.forEach(bar => bar.setAttribute('stroke', '#9370DB'));
+            textPaths.forEach(path => path.setAttribute('fill', '#f8f9fa'));
+        } else {
+            bars.forEach(bar => bar.setAttribute('stroke', '#6a4baf'));
+            textPaths.forEach(path => path.setAttribute('fill', '#333333'));
+        }
+    }
+
+    if (isDark) {
+        document.querySelectorAll('.table tbody tr td, .table tbody tr th').forEach(cell => {
+            cell.style.color = '#f8f9fa';
+        });
+        document.querySelectorAll('.table thead th').forEach(header => {
+            header.style.color = '#ffffff';
+            header.style.backgroundColor = '#343a40';
+        });
+    } else {
+        document.querySelectorAll('.table tbody tr td, .table tbody tr th').forEach(cell => {
+            cell.style.color = '';
+        });
+        document.querySelectorAll('.table thead th').forEach(header => {
+            header.style.color = '';
+            header.style.backgroundColor = '';
+        });
+    }
+});
+
+if (prefersDark) {
+    document.querySelectorAll('.table tbody tr td, .table tbody tr th').forEach(cell => {
+        cell.style.color = '#f8f9fa';
+    });
+    document.querySelectorAll('.table thead th').forEach(header => {
+        header.style.color = '#ffffff';
+        header.style.backgroundColor = '#343a40';
+    });
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% block meta %}{% endblock %}
+    <title>{% block title %}ScrobbleScope{% endblock %}</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css" rel="stylesheet">
+    {% block extra_css %}{% endblock %}
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='images/favicon.svg') }}" />
+    <link rel="shortcut icon" type="image/x-icon" href="{{ url_for('static', filename='images/favicon.ico') }}" />
+    <link rel="icon" type="image/png" sizes="32x32" href="{{ url_for('static', filename='images/favicon-32x32.png') }}" />
+    <link rel="icon" type="image/png" sizes="16x16" href="{{ url_for('static', filename='images/favicon-16x16.png') }}" />
+</head>
+<body>
+    <div id="darkModeToggle" class="form-check form-switch">
+        <input class="form-check-input" type="checkbox" id="darkSwitch">
+        <label class="form-check-label" for="darkSwitch">Dark Mode</label>
+    </div>
+
+    {% block content %}{% endblock %}
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/js/bootstrap.bundle.min.js"></script>
+    {% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,44 +1,12 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Error | ScrobbleScope</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/error.css') }}">
-    <!--favicon-->
-    <!--SVG-->
-    <link
-    rel="icon"
-    type="image/svg+xml"
-    href="{{ url_for('static', filename='images/favicon.svg') }}"
-    />
-    <!--ICO fallback-->
-    <link
-        rel="shortcut icon"
-        type="image/x-icon"
-        href="{{ url_for('static', filename='images/favicon.ico') }}"
-    />
-    <!--PNG fallbacks (both 16x16 and 32x32-->
-    <link
-        rel="icon"
-        type="image/png"
-        sizes="32x32"
-        href="{{ url_for('static', filename='images/favicon-32x32.png') }}"
-    />
-    <link
-        rel="icon"
-        type="image/png"
-        sizes="16x16"
-        href="{{ url_for('static', filename='images/favicon-16x16.png') }}"
-    />
-</head>
-<body>
-    <div id="darkModeToggle" class="form-check form-switch">
-        <input class="form-check-input" type="checkbox" id="darkSwitch">
-        <label class="form-check-label" for="darkSwitch">Dark Mode</label>
-    </div>
+{% extends 'base.html' %}
 
+{% block title %}Error | ScrobbleScope{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/error.css') }}">
+{% endblock %}
+
+{% block content %}
     <div class="error-container">
         <div class="error-card">
             <div class="col-md-9 text-center mx-auto mb-4" id="logo-wrapper">
@@ -46,31 +14,33 @@
                     {% include 'inline/scrobble_scope_inline.svg' ignore missing %}
                 </div>
             </div>
-            
+
             <div class="error-icon">
                 <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="currentColor" viewBox="0 0 16 16">
                     <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
                     <path d="M7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995z"/>
                 </svg>
             </div>
-            
+
             <h1 class="mb-3">{{ error|default('Error') }} <span class="error-code">{{ status_code|default('400') }}</span></h1>
-            
+
             <p class="lead mb-4">{{ message|default('Something went wrong.') }}</p>
-            
+
             {% if details %}
             <div class="error-details">
                 <h5>Additional Information:</h5>
                 <p>{{ details }}</p>
             </div>
             {% endif %}
-            
+
             <div class="actions">
                 <a href="/" class="btn btn-primary">Back to Home</a>
                 <button onclick="window.history.back()" class="btn btn-outline-secondary">Go Back</button>
             </div>
         </div>
     </div>
+{% endblock %}
+
+{% block extra_js %}
 <script src="{{ url_for('static', filename='js/error.js') }}"></script>
-</body>
-</html>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,48 +1,14 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="ScrobbleScope - Filter your Last.fm album scrobbles by release date and play count.">
-  <title>ScrobbleScope</title>
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/index.css') }}">
-  <!--SVG-->
-  <link
-  rel="icon"
-  type="image/svg+xml"
-  href="{{ url_for('static', filename='images/favicon.svg') }}"
-  />
+{% extends 'base.html' %}
 
-  <!--ICO fallback-->
-  <link
-    rel="shortcut icon"
-    type="image/x-icon"
-    href="{{ url_for('static', filename='images/favicon.ico') }}"
-  />
+{% block meta %}
+<meta name="description" content="ScrobbleScope - Filter your Last.fm album scrobbles by release date and play count.">
+{% endblock %}
 
-  <!-- PNG fallbacks (both 16x16 and 32x32-->
-  <link
-    rel="icon"
-    type="image/png"
-    sizes="32x32"
-    href="{{ url_for('static', filename='images/favicon-32x32.png') }}"
-  />
-  <link
-    rel="icon"
-    type="image/png"
-    sizes="16x16"
-    href="{{ url_for('static', filename='images/favicon-16x16.png') }}"
-  />
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/index.css') }}">
+{% endblock %}
 
-</head>
-<body>
-  <!-- Dark mode toggle -->
-  <div id="darkModeToggle" class="form-check form-switch">
-    <input class="form-check-input" type="checkbox" id="darkSwitch">
-    <label class="form-check-label" for="darkSwitch">Dark Mode</label>
-  </div>
-
+{% block content %}
   <div class="container mt-5">
     <div class="row justify-content-center">
       <div class="col-md-8 text-center mb-4" id="logo-wrapper">
@@ -106,7 +72,6 @@
                 <div class="form-text">Pick if you want to sort your top albums by play count, or total listening time.</div>
               </div>
 
-              <!-- Define Album Thresholds toggle -->
               <div class="mb-3 form-check form-switch">
                 <input class="form-check-input" type="checkbox" id="thresholdSwitch">
                 <label class="form-check-label" for="thresholdSwitch">Define Album Thresholds</label>
@@ -149,6 +114,8 @@
       </div>
     </div>
   </div>
-  <script src="{{ url_for('static', filename='js/index.js') }}" defer></script>
-</body>
-</html>
+{% endblock %}
+
+{% block extra_js %}
+<script src="{{ url_for('static', filename='js/index.js') }}" defer></script>
+{% endblock %}

--- a/templates/loading.html
+++ b/templates/loading.html
@@ -1,40 +1,18 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Loading | ScrobbleScope</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
-    <meta name="description" content="ScrobbleScope - Loading your Last.fm album scrobbles. Please wait...">
-    <!--favicon-->
-    <!--SVG-->
-    <link
-    rel="icon"
-    type="image/svg+xml"
-    href="{{ url_for('static', filename='images/favicon.svg') }}"
-    />
-    <!--ICO fallback-->
-    <link
-        rel="shortcut icon"
-        type="image/x-icon"
-        href="{{ url_for('static', filename='images/favicon.ico') }}"
-    />
-    <!--PNG fallbacks (both 16x16 and 32x32-->
-    <link
-        rel="icon"
-        type="image/png"
-        sizes="32x32"
-        href="{{ url_for('static', filename='images/favicon-32x32.png') }}"
-    />
-    <link
-        rel="icon"
-        type="image/png"
-        sizes="16x16"
-        href="{{ url_for('static', filename='images/favicon-16x16.png') }}"
-    />
-      <!--Bridge script: define window.SCROBBLE with all needed values (in backend app.py too)-->
-  <script>
+{% extends 'base.html' %}
+
+{% block title %}Loading | ScrobbleScope{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/loading.css') }}">
+{% endblock %}
+
+{% block meta %}
+<meta name="description" content="ScrobbleScope - Loading your Last.fm album scrobbles. Please wait...">
+{% endblock %}
+
+{% block content %}
+    <!-- Bridge script to expose parameters to JS -->
+    <script>
     window.SCROBBLE = {
       username: "{{ username }}",
       year: "{{ year }}",
@@ -42,24 +20,14 @@
       release_scope: "{{ release_scope }}",
       {% if decade %}
       decade: "{{ decade }}",
-      {% else %}
-      // no decade in data
       {% endif %}
       {% if release_year %}
       release_year: "{{ release_year }}",
-      {% else %}
-      // no release year in data
       {% endif %}
       min_plays: "{{ min_plays|default('10') }}",
       min_tracks: "{{ min_tracks|default('3') }}"
     };
-  </script>
-</head>
-<body>
-    <div id="darkModeToggle" class="form-check form-switch">
-        <input class="form-check-input" type="checkbox" id="darkSwitch">
-        <label class="form-check-label" for="darkSwitch">Dark Mode</label>
-    </div>
+    </script>
 
     <div class="loading-container">
         <div class="col-md-9 text-center mx-auto mb-4" id="logo-wrapper">
@@ -67,14 +35,14 @@
                 {% include 'inline/scrobble_scope_inline.svg' ignore missing %}
             </div>
         </div>
-        
+
         <h2>Loading your results...</h2>
         <div class="progress mt-4">
             <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%;" id="progress-bar"></div>
         </div>
         <p id="step-text" class="step-text">Initializing...</p>
         <p id="step-details" class="step-details">This might take a few minutes, especially for active Last.fm users</p>
-        
+
         <div class="request-info">
             <h4>Your Search Parameters</h4>
             <table class="info-table">
@@ -118,13 +86,15 @@
                 </tr>
             </table>
         </div>
-        
+
         <div id="error-container" class="d-none">
             <div class="error-message">
                 <p id="error-text">An error occurred while processing your request.</p>
             </div>
         </div>
     </div>
-    <script src="{{ url_for('static', filename='js/loading.js') }}"></script>
-</body>
-</html>
+{% endblock %}
+
+{% block extra_js %}
+<script src="{{ url_for('static', filename='js/loading.js') }}"></script>
+{% endblock %}

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,65 +1,23 @@
-<!-- templates/results.html -->
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Results | ScrobbleScope</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/results.css') }}">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
-      <!--SVG-->
-  <link
-  rel="icon"
-  type="image/svg+xml"
-  href="{{ url_for('static', filename='images/favicon.svg') }}"
-  />
+{% extends 'base.html' %}
 
-  <!--ICO fallback-->
-  <link
-    rel="shortcut icon"
-    type="image/x-icon"
-    href="{{ url_for('static', filename='images/favicon.ico') }}"
-  />
+{% block title %}Results | ScrobbleScope{% endblock %}
 
-  <!-- PNG fallbacks (both 16x16 and 32x32-->
-  <link
-    rel="icon"
-    type="image/png"
-    sizes="32x32"
-    href="{{ url_for('static', filename='images/favicon-32x32.png') }}"
-  />
-  <link
-    rel="icon"
-    type="image/png"
-    sizes="16x16"
-    href="{{ url_for('static', filename='images/favicon-16x16.png') }}"
-  />
-</head>
-<body>
-    <!-- Dark mode toggle -->
-    <div id="darkModeToggle" class="form-check form-switch">
-        <input class="form-check-input" type="checkbox" id="darkSwitch">
-        <label class="form-check-label" for="darkSwitch">Dark Mode</label>
-    </div>
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/results.css') }}">
+{% endblock %}
 
-    <!-- Toast container for notifications -->
-    <div class="toast-container" id="toastContainer"></div>
-
+{% block content %}
     <div class="container mt-5 mb-5">
         <div class="row justify-content-center">
             <div class="col-md-10">
-                <!-- Logo -->
                 <div class="col-md-8 text-center mx-auto mb-4" id="logo-wrapper">
                     <div aria-label="ScrobbleScope logo visualization" role="img">
                         {% include 'inline/scrobble_scope_inline.svg' ignore missing %}
                     </div>
                 </div>
-                
-                <!-- Main content card -->
+
                 <div class="card shadow">
                     <div class="card-body">
-                        <!-- Dynamic title based on filter -->
                         <h2 class="text-center mb-3">
                             {% if release_scope == "same" %}
                                 {{ username }}'s Top Albums Played in {{ year }}
@@ -77,15 +35,13 @@
                                 {{ username }}'s Top Albums Played in {{ year }}
                             {% endif %}
                         </h2>
-                        
-                        <!-- Action buttons at the top -->
+
                         <div class="text-center mb-4">
                             <a href="/" class="btn btn-primary">New Search</a>
                             <button id="export-csv" class="btn btn-outline-secondary ms-2">Export to CSV</button>
                             <button id="save-image" class="btn btn-outline-secondary ms-2">Save as Image</button>
                         </div>
-                        
-                        <!-- Summary box -->
+
                         <div class="summary-box">
                             <div class="row">
                                 <div class="col-md-6">
@@ -96,7 +52,7 @@
                                 </div>
                                 <div class="col-md-6">
                                     <h5>Filter Applied</h5>
-                                    <p><strong>Release Filter:</strong> 
+                                    <p><strong>Release Filter:</strong>
                                     {% if release_scope == "same" %}
                                         Same as Listening Year ({{ year }})
                                     {% elif release_scope == "previous" %}
@@ -109,7 +65,7 @@
                                         All Years
                                     {% endif %}
                                     </p>
-                                    <p><strong>Sort By:</strong> 
+                                    <p><strong>Sort By:</strong>
                                     {% if sort_by == "playtime" %}
                                         Total Listening Time
                                     {% else %}
@@ -121,7 +77,6 @@
                             </div>
                         </div>
 
-                        <!-- Content area -->
                         {% if no_matches %}
                             <div class="alert alert-info text-center" role="alert">
                                 <h4 class="alert-heading">No Albums Found</h4>
@@ -129,7 +84,7 @@
                                 <hr>
                                 <p class="mb-0">
                                     {% if unmatched_count > 0 %}
-                                        We found {{ unmatched_count }} albums that didn't match your filters. 
+                                        We found {{ unmatched_count }} albums that didn't match your filters.
                                         <a href="#" id="view-unmatched" data-bs-toggle="modal" data-bs-target="#unmatched-modal">
                                             View these albums
                                         </a>
@@ -197,12 +152,11 @@
                             </div>
                         {% endif %}
 
-                        <!-- Unmatched albums buttons -->
                         <div class="d-flex flex-column align-items-center mt-4 mb-3">
                             <button id="view-unmatched-quick" class="btn btn-outline-secondary mb-2 w-auto" data-bs-toggle="modal" data-bs-target="#unmatched-modal">
                                 Quick View of Unmatched Albums
                             </button>
-                            
+
                             <form action="/unmatched_view" method="post" class="mb-2">
                                 <input type="hidden" name="username" value="{{ username }}">
                                 <input type="hidden" name="year" value="{{ year }}">
@@ -226,7 +180,6 @@
         </div>
     </div>
 
-    <!-- Unmatched Albums Modal -->
     <div class="modal fade" id="unmatched-modal" tabindex="-1" aria-labelledby="unmatched-modal-label" aria-hidden="true">
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
@@ -248,261 +201,15 @@
             </div>
         </div>
     </div>
+{% endblock %}
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/js/bootstrap.bundle.min.js"></script>
-    <script>
-        // Dark mode toggle
-        const darkSwitch = document.getElementById('darkSwitch');
-        
-        // Check for saved dark mode preference
-        if (localStorage.getItem('darkMode') === 'true') {
-            document.body.classList.add('dark-mode');
-            darkSwitch.checked = true;
-        }
-        
-        // Add event listener for dark mode toggle
-        darkSwitch.addEventListener('change', function() {
-            document.body.classList.toggle('dark-mode', this.checked);
-            localStorage.setItem('darkMode', this.checked);
-            
-            // Update SVG colors
-            const svgElement = document.querySelector('#logo-wrapper svg');
-            if (svgElement) {
-                const bars = svgElement.querySelectorAll('.cls-1');
-                const textPaths = svgElement.querySelectorAll('#logo-text path, #tagline path');
-                
-                if (this.checked) {
-                    bars.forEach(bar => bar.setAttribute('stroke', '#9370DB'));
-                    textPaths.forEach(path => path.setAttribute('fill', '#f8f9fa'));
-                } else {
-                    bars.forEach(bar => bar.setAttribute('stroke', '#6a4baf'));
-                    textPaths.forEach(path => path.setAttribute('fill', '#333333'));
-                }
-            }
-        });
-
-        // Toast notification helper function
-        function showToast(message, type = 'info', duration = 3000) {
-            const toastContainer = document.getElementById('toastContainer');
-            const toastId = 'toast-' + Date.now();
-            const toastHtml = `
-                <div id="${toastId}" class="toast show" role="alert" aria-live="assertive" aria-atomic="true">
-                    <div class="toast-header${type === 'error' ? ' bg-danger text-white' : ''}">
-                        <strong class="me-auto">ScrobbleScope</strong>
-                        <small>Just now</small>
-                        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
-                    </div>
-                    <div class="toast-body${type === 'error' ? ' bg-danger text-white' : ''}">
-                        ${message}
-                    </div>
-                </div>
-            `;
-            
-            toastContainer.insertAdjacentHTML('beforeend', toastHtml);
-            
-            // Remove toast after duration
-            setTimeout(() => {
-                const toast = document.getElementById(toastId);
-                if (toast) {
-                    toast.classList.remove('show');
-                    setTimeout(() => toast.remove(), 500);
-                }
-            }, duration);
-        }
-
-        // Fetch unmatched albums
-        function fetchUnmatchedAlbums() {
-            const unmatchedList = document.getElementById('unmatched-list');
-            
-            fetch('/unmatched')
-                .then(response => response.json())
-                .then(unmatchedData => {
-                    let html = '';
-                    if (!unmatchedData || Object.keys(unmatchedData.data || unmatchedData).length === 0) {
-                        html = '<p>No unmatched albums found.</p>';
-                    } else {
-                        const data = unmatchedData.data || unmatchedData;
-                        const count = unmatchedData.count || Object.keys(data).length;
-                        
-                        html = `<p>Found ${count} unmatched albums:</p>`;
-                        html += '<div class="table-responsive"><table class="table table-sm">';
-                        html += '<thead><tr><th>Artist</th><th>Album</th><th>Reason</th></tr></thead><tbody>';
-                        
-                        for (const key in data) {
-                            const item = data[key];
-                            html += `<tr>
-                                <td>${item.artist}</td>
-                                <td>${item.album}</td>
-                                <td>${item.reason}</td>
-                            </tr>`;
-                        }
-                        
-                        html += '</tbody></table></div>';
-                    }
-                    
-                    unmatchedList.innerHTML = html;
-                })
-                .catch(error => {
-                    unmatchedList.innerHTML = `<div class="alert alert-danger">Error loading unmatched albums: ${error}</div>`;
-                });
-        }
-
-        // Attach event listeners for view unmatched buttons
-        document.getElementById('view-unmatched-quick').addEventListener('click', fetchUnmatchedAlbums);
-        
-        if (document.getElementById('view-unmatched')) {
-            document.getElementById('view-unmatched').addEventListener('click', fetchUnmatchedAlbums);
-        }
-
-        // Fixed Export to CSV function
-        document.getElementById('export-csv').addEventListener('click', function() {
-            try {
-                const table = document.querySelector('.table');
-                if (!table) {
-                    showToast('No data available to export', 'error');
-                    return;
-                }
-                
-                let csvContent = [];
-                
-                // Get headers
-                const headerRow = [];
-                const headers = table.querySelectorAll('thead th');
-                headers.forEach(header => {
-                    headerRow.push('"' + header.textContent.trim().replace(/"/g, '""') + '"');
-                });
-                csvContent.push(headerRow.join(','));
-                
-                // Get data rows
-                const rows = table.querySelectorAll('tbody tr');
-                for (let i = 0; i < rows.length; i++) {
-                    const row = [];
-                    const cells = Array.from(rows[i].querySelectorAll('th, td'));
-                    
-                    // Process each cell in the row
-                    for (let j = 0; j < cells.length; j++) {
-                        let content = '';
-                        
-                        // Special handling for album cell which contains image + text
-                        if (j === 1 && cells[j].classList.contains('album-title')) {
-                            const albumInfo = cells[j].querySelector('.album-info');
-                            content = albumInfo ? albumInfo.textContent.trim() : '';
-                        } else {
-                            // Regular cells, just get the text content
-                            content = cells[j].textContent.trim();
-                        }
-                        
-                        // Clean up and escape for CSV
-                        content = content.replace(/\s+/g, ' ');
-                        if (content.includes(',') || content.includes('"') || content.includes('\n')) {
-                            content = '"' + content.replace(/"/g, '""') + '"';
-                        }
-                        
-                        row.push(content);
-                    }
-                    
-                    csvContent.push(row.join(','));
-                }
-                
-                // Create and trigger download
-                const csvString = csvContent.join('\n');
-                const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8;' });
-                const url = URL.createObjectURL(blob);
-                
-                const link = document.createElement('a');
-                const username = '{{ username }}';
-                const year = '{{ year }}';
-                link.setAttribute('href', url);
-                link.setAttribute('download', `scrobblescope_${username}_${year}_albums.csv`);
-                link.style.display = 'none';
-                
-                document.body.appendChild(link);
-                link.click();
-                document.body.removeChild(link);
-                URL.revokeObjectURL(url);
-                
-                showToast('CSV file downloaded successfully!');
-            } catch (error) {
-                console.error('Error exporting CSV:', error);
-                showToast('Error creating CSV file: ' + error.message, 'error');
-            }
-        });
-        
-        // Save as image function
-        document.getElementById('save-image').addEventListener('click', function() {
-            showToast('Creating image... Please wait.');
-            
-            // Target the table wrapper for saving
-            const targetElement = document.getElementById('results-table-wrapper');
-            if (!targetElement) {
-                showToast('No content to save as image', 'error');
-                return;
-            }
-            
-            const isDarkMode = document.body.classList.contains('dark-mode');
-            
-            // Capture the element with improved settings
-            html2canvas(targetElement, {
-                backgroundColor: isDarkMode ? '#121212' : '#ffffff',
-                allowTaint: true,
-                useCORS: true,
-                scale: 2, // Higher quality
-                onclone: function(clonedDoc) {
-                    // Fix styling issues in the clone
-                    const clonedTable = clonedDoc.querySelector('.table');
-                    if (clonedTable) {
-                        if (isDarkMode) {
-                            clonedTable.style.color = '#f8f9fa';
-                            clonedTable.style.backgroundColor = '#121212';
-                            
-                            // Fix row styling
-                            clonedTable.querySelectorAll('tr').forEach((row, index) => {
-                                if (index % 2 === 1) { // Odd rows (0-indexed)
-                                    row.style.backgroundColor = 'rgba(255, 255, 255, 0.1)';
-                                } else if (index > 0) { // Even rows, but not the header
-                                    row.style.backgroundColor = 'rgba(30, 30, 30, 0.7)';
-                                }
-                                
-                                // Ensure all text is visible
-                                row.querySelectorAll('th, td').forEach(cell => {
-                                    cell.style.color = '#f8f9fa';
-                                    cell.style.borderColor = 'rgba(255, 255, 255, 0.1)';
-                                });
-                            });
-                            
-                            // Fix header styling
-                            const header = clonedTable.querySelector('thead');
-                            if (header) {
-                                header.style.backgroundColor = '#343a40';
-                                header.style.color = '#ffffff';
-                            }
-                        }
-                    }
-                }
-            }).then(function(canvas) {
-                try {
-                    // Create a link to download the image
-                    const link = document.createElement('a');
-                    const username = '{{ username }}';
-                    const year = '{{ year }}';
-                    
-                    // Use JPEG instead of PNG for smaller file size
-                    link.download = `scrobblescope_${username}_${year}.jpg`;
-                    link.href = canvas.toDataURL('image/jpeg', 0.95); // Higher quality
-                    document.body.appendChild(link);
-                    link.click();
-                    document.body.removeChild(link);
-                    
-                    showToast('Image saved successfully!');
-                } catch (err) {
-                    console.error('Error saving image:', err);
-                    showToast('Failed to save image: ' + err.message, 'error');
-                }
-            }).catch(function(err) {
-                console.error('Error capturing image:', err);
-                showToast('Failed to create image: ' + err.message, 'error');
-            });
-        });
-    </script>
-</body>
-</html>
+{% block extra_js %}
+<script>
+window.RESULTS = {
+  username: "{{ username }}",
+  year: "{{ year }}"
+};
+</script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+<script src="{{ url_for('static', filename='js/results.js') }}"></script>
+{% endblock %}

--- a/templates/unmatched.html
+++ b/templates/unmatched.html
@@ -1,262 +1,12 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Unmatched Albums | ScrobbleScope</title>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css">
-    <!--favicon-->
-    <!--SVG-->
-    <link
-    rel="icon"
-    type="image/svg+xml"
-    href="{{ url_for('static', filename='images/favicon.svg') }}"
-    />
-    <!--ICO fallback-->
-    <link
-        rel="shortcut icon"
-        type="image/x-icon"
-        href="{{ url_for('static', filename='images/favicon.ico') }}"
-    />
-    <!--PNG fallbacks (both 16x16 and 32x32-->
-    <link
-        rel="icon"
-        type="image/png"
-        sizes="32x32"
-        href="{{ url_for('static', filename='images/favicon-32x32.png') }}"
-    />
-    <link
-        rel="icon"
-        type="image/png"
-        sizes="16x16"
-        href="{{ url_for('static', filename='images/favicon-16x16.png') }}"
-    />
-    <style>
-        :root {
-            --bars-color: #6a4baf;
-            --text-color: #333333;
-            --bg-color: #f8f9fa;
-            --info-bg: rgba(106, 75, 175, 0.1);
-            --header-bg: #6a4baf;
-        }
-        
-        .dark-mode {
-            --bars-color: #9370DB;
-            --text-color: #f8f9fa;
-            --bg-color: #121212;
-            --info-bg: rgba(147, 112, 219, 0.1);
-            --header-bg: #9370DB;
-        }
-        
-        body {
-            transition: background-color 0.3s ease, color 0.3s ease;
-            background-color: var(--bg-color);
-            color: var(--text-color);
-            padding-bottom: 2rem;
-        }
-        
-        .dark-mode .card {
-            background-color: #1e1e1e;
-            color: var(--text-color);
-            border: 1px solid #444;
-        }
-        
-        .dark-mode .table {
-            color: var(--text-color);
-        }
-        
-        .dark-mode .table-striped > tbody > tr:nth-of-type(odd) {
-            background-color: rgba(255, 255, 255, 0.15);
-            color: var(--text-color);
-        }
-        
-        .dark-mode .table-striped > tbody > tr:nth-of-type(even) {
-            background-color: rgba(30, 30, 30, 0.7);
-            color: var(--text-color);
-        }
-        
-        .dark-mode .table-hover > tbody > tr:hover {
-            background-color: rgba(147, 112, 219, 0.2);
-            color: var(--text-color);
-        }
-        
-        .dark-mode .alert-info {
-            background-color: var(--info-bg);
-            border-color: rgba(147, 112, 219, 0.2);
-            color: var(--text-color);
-        }
-        
-        .dark-mode .table-light,
-        .dark-mode .table-dark {
-            background-color: #2a2a2a;
-            color: var(--text-color);
-        }
+{% extends 'base.html' %}
 
-        .dark-mode .table-light th,
-        .dark-mode .table-dark th,
-        .dark-mode thead th {
-            color: var(--text-color) !important;
-        }
-        
-        .dark-mode svg .cls-1 {
-            stroke: var(--bars-color);
-        }
-        
-        .dark-mode svg #logo-text path, 
-        .dark-mode svg #tagline path {
-            fill: var(--text-color);
-        }
-        
-        /* Dark-mode toggle switch */
-        #darkModeToggle {
-            position: fixed;
-            top: 1rem;
-            right: 1rem;
-            z-index: 1000;
-            display: flex;
-            flex-direction: row-reverse;
-            align-items: center;
-            gap: 1rem;
-            padding: 0.5rem;
-            border-radius: 5px;
-            background-color: rgba(255, 255, 255, 0.8);
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-            transition: background-color 0.3s ease;
-        }
+{% block title %}Unmatched Albums | ScrobbleScope{% endblock %}
 
-        .dark-mode #darkModeToggle {
-            background-color: rgba(30, 30, 30, 0.8);
-        }
-        
-        #darkModeToggle .form-check-input,
-        #darkModeToggle .form-check-label {
-            margin: 0;
-        }
-            
-        #darkSwitch {
-            width: 3rem;
-            height: 1.5rem;
-            background-color: #ccc;
-            border-radius: 999px;
-            appearance: none;
-            outline: none;
-            cursor: pointer;
-            position: relative;
-            transition: background-color 0.3s ease;
-        }
-        
-        #darkSwitch::before {
-            content: "";
-            position: absolute;
-            width: 1.2rem;
-            height: 1.2rem;
-            border-radius: 50%;
-            top: 0.15rem;
-            left: 0.15rem;
-            background-color: white;
-            transition: transform 0.3s ease;
-        }
-        
-        #darkSwitch:checked {
-            background-color: var(--bars-color);
-        }
-        
-        #darkSwitch:checked::before {
-            transform: translateX(1.5rem);
-        }
-        
-        .reason-section {
-            margin-bottom: 2rem;
-            border-radius: 8px;
-            overflow: hidden;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-        }
-        
-        .dark-mode .reason-section {
-            box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-        }
-        
-        .reason-header {
-            background-color: var(--header-bg);
-            color: white;
-            padding: 0.75rem 1rem;
-            font-weight: 500;
-        }
-        
-        .reason-count {
-            background-color: rgba(255, 255, 255, 0.2);
-            border-radius: 20px;
-            padding: 0.1rem 0.75rem;
-            margin-left: 0.5rem;
-            font-size: 0.9rem;
-        }
-        
-        @keyframes fadeIn {
-            from { opacity: 0; transform: translateY(20px); }
-            to { opacity: 1; transform: translateY(0); }
-        }
-        
-        .fade-in {
-            animation: fadeIn 0.5s ease forwards;
-        }
-        
-        #logo-wrapper svg {
-            width: 100%;
-            height: auto;
-            max-height: 120px;
-            opacity: 0;
-            animation: fadeIn 2s ease forwards;
-        }
-        
-        .action-buttons {
-            position: sticky;
-            top: 1rem;
-            z-index: 100;
-            background-color: rgba(248, 249, 250, 0.9);
-            border-radius: 8px;
-            padding: 1rem;
-            margin-bottom: 1.5rem;
-            box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-            text-align: center;
-            backdrop-filter: blur(5px);
-        }
-        
-        .dark-mode .action-buttons {
-            background-color: rgba(30, 30, 30, 0.9);
-        }
-        
-        .info-card {
-            background-color: var(--info-bg);
-            border-radius: 8px;
-            padding: 20px;
-            margin-bottom: 1.5rem;
-            transition: background-color 0.3s ease, color 0.3s ease;
-        }
-        
-        .dark-mode .info-card {
-            background-color: var(--info-bg);
-        }
-        
-        /* Fix for table header in dark mode */
-        .dark-mode .table thead th {
-            background-color: #343a40 !important;
-            color: white !important;
-            border-color: #444;
-        }
-        
-        /* Fix for table cells in dark mode */
-        .dark-mode .table tbody td,
-        .dark-mode .table tbody th {
-            color: var(--text-color) !important;
-        }
-    </style>
-</head>
-<body>
-    <div id="darkModeToggle" class="form-check form-switch">
-        <input class="form-check-input" type="checkbox" id="darkSwitch">
-        <label class="form-check-label" for="darkSwitch">Dark Mode</label>
-    </div>
+{% block extra_css %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/unmatched.css') }}">
+{% endblock %}
 
+{% block content %}
     <div class="container mt-5 mb-5">
         <div class="row justify-content-center">
             <div class="col-md-10">
@@ -265,14 +15,14 @@
                         {% include 'inline/scrobble_scope_inline.svg' ignore missing %}
                     </div>
                 </div>
-                
+
                 <h1 class="text-center mb-4">Albums That Didn't Match Your Filter</h1>
-                
+
                 <div class="action-buttons">
                     <button onclick="window.history.back()" class="btn btn-primary">Back to Results</button>
                     <a href="/" class="btn btn-outline-secondary ms-2">New Search</a>
                 </div>
-                
+
                 <div class="card shadow-sm fade-in">
                     <div class="card-body">
                         <div class="info-card">
@@ -286,7 +36,7 @@
                             </ul>
                             <p>Total albums that didn't match: <strong>{{ total_count }}</strong></p>
                         </div>
-                        
+
                         {% for reason, albums in reasons.items() %}
                         <div class="reason-section">
                             <div class="reason-header">
@@ -319,68 +69,8 @@
             </div>
         </div>
     </div>
+{% endblock %}
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/js/bootstrap.bundle.min.js"></script>
-    <script>
-        // Dark mode persistence + switch sync
-        const darkSwitch = document.getElementById('darkSwitch');
-        const prefersDark = localStorage.getItem('darkMode') === 'true';
-        
-        if (prefersDark) {
-            document.body.classList.add('dark-mode');
-            darkSwitch.checked = true;
-        }
-        
-        darkSwitch.addEventListener('change', () => {
-            const isDark = darkSwitch.checked;
-            document.body.classList.toggle('dark-mode', isDark);
-            localStorage.setItem('darkMode', isDark);
-            
-            // Manually update SVG colors when dark mode changes
-            const svgElement = document.querySelector('#logo-wrapper svg');
-            if (svgElement) {
-                const bars = svgElement.querySelectorAll('.cls-1');
-                const textPaths = svgElement.querySelectorAll('#logo-text path, #tagline path');
-                
-                if (isDark) {
-                    bars.forEach(bar => bar.setAttribute('stroke', '#9370DB'));
-                    textPaths.forEach(path => path.setAttribute('fill', '#f8f9fa'));
-                } else {
-                    bars.forEach(bar => bar.setAttribute('stroke', '#6a4baf'));
-                    textPaths.forEach(path => path.setAttribute('fill', '#333333'));
-                }
-            }
-            
-            // Force color update for table cells in dark mode
-            if (isDark) {
-                document.querySelectorAll('.table tbody tr td, .table tbody tr th').forEach(cell => {
-                    cell.style.color = '#f8f9fa';
-                });
-                document.querySelectorAll('.table thead th').forEach(header => {
-                    header.style.color = '#ffffff';
-                    header.style.backgroundColor = '#343a40';
-                });
-            } else {
-                document.querySelectorAll('.table tbody tr td, .table tbody tr th').forEach(cell => {
-                    cell.style.color = '';
-                });
-                document.querySelectorAll('.table thead th').forEach(header => {
-                    header.style.color = '';
-                    header.style.backgroundColor = '';
-                });
-            }
-        });
-        
-        // Initialize dark mode table styling if needed
-        if (prefersDark) {
-            document.querySelectorAll('.table tbody tr td, .table tbody tr th').forEach(cell => {
-                cell.style.color = '#f8f9fa';
-            });
-            document.querySelectorAll('.table thead th').forEach(header => {
-                header.style.color = '#ffffff';
-                header.style.backgroundColor = '#343a40';
-            });
-        }
-    </script>
-</body>
-</html>
+{% block extra_js %}
+<script src="{{ url_for('static', filename='js/unmatched.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create base.html for shared layout
- refactor pages to extend base template
- move results and unmatched scripts to static files
- extract unmatched page styles to new CSS file

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685382b3f54c832db1d6a927cdde1f12