### PR TITLE
Add application factory

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime
+from pathlib import Path
+
+from flask import Flask
+
+
+def create_app():
+    """Application factory."""
+    app = Flask(__name__)
+
+    @app.context_processor
+    def inject_current_year():
+        return {"current_year": datetime.now().year}
+
+    # Register blueprints (currently empty)
+    from .routes.main import main_bp
+
+    app.register_blueprint(main_bp)
+    return app
+
+
+# Load legacy functions for tests from the root app.py
+_root_path = Path(__file__).resolve().parent.parent / "app.py"
+spec = importlib.util.spec_from_file_location("legacy_app", _root_path)
+legacy_app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(legacy_app)
+
+check_user_exists = legacy_app.check_user_exists
+normalize_name = legacy_app.normalize_name
+
+# Provide the legacy app object for backward compatibility
+app = legacy_app.app

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,0 +1,8 @@
+from flask import Blueprint, render_template
+
+main_bp = Blueprint("main", __name__)
+
+
+@main_bp.route("/")
+def home():
+    return render_template("index.html")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,12 +4,13 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 # Imports from your application
-from app import app, check_user_exists, normalize_name
+from app import check_user_exists, create_app, normalize_name
 
 
 @pytest.fixture
 def client():
     """Create a test client for the Flask application."""
+    app = create_app()
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client


### PR DESCRIPTION
## Summary
- implement application factory in `app/__init__.py`
- expose legacy functions for tests
- add a minimal blueprint with a home route
- update tests to use the factory

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68695ed88f10832d98a63de058919933