### PR TITLE
Refactor into services and tasks

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,36 +1,43 @@
-from __future__ import annotations
+"""Flask application factory and public interface."""
 
-import importlib.util
 from datetime import datetime
-from pathlib import Path
 
 from flask import Flask
 
+from config import Config, ensure_api_keys
 
-def create_app():
-    """Application factory."""
+from .routes.main import main_bp
+from .routes.results import results_bp
+from .services.lastfm_service import check_user_exists
+from .state import close_session, get_session
+from .utils import normalize_name
+
+
+def create_app(testing: bool = False) -> Flask:
+    """Construct and configure the Flask application."""
+
+    if not testing:
+        ensure_api_keys()
     app = Flask(__name__)
-    app.config['SECRET_KEY'] = __import__('os').getenv('SECRET_KEY', 'dev')
+    app.config["SECRET_KEY"] = Config.SECRET_KEY
+
+    if not testing:
+
+        @app.before_serving
+        async def startup() -> None:
+            await get_session()
+
+        @app.after_serving
+        async def shutdown() -> None:
+            await close_session()
 
     @app.context_processor
-    def inject_current_year():
+    def inject_current_year() -> dict[str, int]:
         return {"current_year": datetime.now().year}
 
-    # Register blueprints (currently empty)
-    from .routes.main import main_bp
-
     app.register_blueprint(main_bp)
+    app.register_blueprint(results_bp)
     return app
 
 
-# Load legacy functions for tests from the root app.py
-_root_path = Path(__file__).resolve().parent.parent / "app.py"
-spec = importlib.util.spec_from_file_location("legacy_app", _root_path)
-legacy_app = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(legacy_app)
-
-check_user_exists = legacy_app.check_user_exists
-normalize_name = legacy_app.normalize_name
-
-# Provide the legacy app object for backward compatibility
-app = legacy_app.app
+__all__ = ["create_app", "check_user_exists", "normalize_name"]

--- a/app/cache.py
+++ b/app/cache.py
@@ -1,0 +1,42 @@
+"""In-memory caching helpers for API requests."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, Optional, Tuple
+
+# Cache dictionary maps keys to ``(timestamp, data)`` tuples
+REQUEST_CACHE: Dict[str, Tuple[float, Any]] = {}
+
+# How long cached responses remain valid
+REQUEST_CACHE_TIMEOUT = 3600
+
+
+def get_cache_key(url: str, params: Optional[Dict[str, Any]] = None) -> str:
+    """Return a unique cache key for the given request."""
+    key = url
+    if params:
+        key += "_" + "_".join(f"{k}:{v}" for k, v in sorted(params.items()))
+    return key
+
+
+def get_cached_response(
+    url: str, params: Optional[Dict[str, Any]] = None
+) -> Optional[Any]:
+    """Return cached data for the request if it hasn't expired."""
+    key = get_cache_key(url, params)
+    if key in REQUEST_CACHE:
+        timestamp, data = REQUEST_CACHE[key]
+        if time.time() - timestamp < REQUEST_CACHE_TIMEOUT:
+            logging.debug("Cache hit for %s", key)
+            return data
+    return None
+
+
+def set_cached_response(
+    url: str, data: Any, params: Optional[Dict[str, Any]] = None
+) -> None:
+    """Store ``data`` in the cache for the given request."""
+    key = get_cache_key(url, params)
+    REQUEST_CACHE[key] = (time.time(), data)

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,8 +1,45 @@
-from flask import Blueprint, render_template
+"""Flask blueprint containing the core routes."""
+
+from copy import deepcopy
+
+from flask import Blueprint, jsonify, render_template
+
+from ..state import UNMATCHED, current_progress, progress_lock, unmatched_lock
 
 main_bp = Blueprint("main", __name__)
 
 
 @main_bp.route("/")
 def home():
+    """Render the home page."""
+
     return render_template("index.html")
+
+
+@main_bp.route("/progress")
+def progress():
+    """Return JSON progress information for the front end."""
+
+    with progress_lock:
+        return jsonify(current_progress)
+
+
+@main_bp.route("/unmatched")
+def unmatched():
+    """Expose unmatched album information as JSON."""
+
+    with unmatched_lock:
+        data = deepcopy(UNMATCHED)
+        count = len(data)
+    return jsonify({"count": count, "data": data})
+
+
+@main_bp.route("/reset_progress", methods=["POST"])
+def reset_progress():
+    """Reset background task progress."""
+
+    with progress_lock:
+        current_progress.update(
+            {"progress": 0, "message": "Reset successful", "error": False}
+        )
+    return jsonify({"status": "success"})

--- a/app/routes/results.py
+++ b/app/routes/results.py
@@ -1,0 +1,135 @@
+"""Routes related to processing and displaying results."""
+
+from __future__ import annotations
+
+import copy
+
+from flask import Blueprint, render_template, request
+
+from ..state import (
+    UNMATCHED,
+    completed_results,
+    current_progress,
+    progress_lock,
+    unmatched_lock,
+)
+from ..tasks import background_task
+
+results_bp = Blueprint("results", __name__)
+
+
+@results_bp.route("/results_loading", methods=["POST"])
+def results_loading():
+    """Start the background task and render the loading page."""
+    username = request.form.get("username")
+    year = int(request.form.get("year"))
+    sort_mode = request.form.get("sort_by", "playcount")
+    release_scope = request.form.get("release_scope", "same")
+    decade = request.form.get("decade") if release_scope == "decade" else None
+    release_year = (
+        int(request.form.get("release_year"))
+        if release_scope == "custom" and request.form.get("release_year")
+        else None
+    )
+    min_plays = int(request.form.get("min_plays", "10"))
+    min_tracks = int(request.form.get("min_tracks", "3"))
+
+    with progress_lock:
+        current_progress.update(
+            {"progress": 0, "message": "Initializing...", "error": False}
+        )
+    background_task(
+        username,
+        year,
+        sort_mode,
+        release_scope,
+        decade,
+        release_year,
+        min_plays,
+        min_tracks,
+    )
+
+    with unmatched_lock:
+        UNMATCHED.clear()
+
+    return render_template(
+        "loading.html",
+        username=username,
+        year=year,
+        sort_by=sort_mode,
+        release_scope=release_scope,
+        decade=decade,
+        release_year=release_year,
+        min_plays=min_plays,
+        min_tracks=min_tracks,
+    )
+
+
+@results_bp.route("/results_complete", methods=["POST"])
+def results_complete():
+    """Render the results page after processing."""
+    username = request.form.get("username")
+    year = int(request.form.get("year"))
+    sort_mode = request.form.get("sort_by", "playcount")
+    release_scope = request.form.get("release_scope", "same")
+    decade = request.form.get("decade")
+    release_year = request.form.get("release_year")
+    if release_year:
+        release_year = int(release_year)
+    min_plays = int(request.form.get("min_plays", "10"))
+    min_tracks = int(request.form.get("min_tracks", "3"))
+
+    cache_key = (
+        username,
+        year,
+        sort_mode,
+        release_scope,
+        decade,
+        release_year,
+        min_plays,
+        min_tracks,
+    )
+    data = completed_results.get(cache_key, [])
+    filtered = [album for album in data if album.get("play_time_seconds", 0) > 0]
+
+    with unmatched_lock:
+        unmatched_count = len(UNMATCHED)
+
+    return render_template(
+        "results.html",
+        username=username,
+        year=year,
+        data=filtered,
+        release_scope=release_scope,
+        decade=decade,
+        release_year=release_year,
+        sort_by=sort_mode,
+        min_plays=min_plays,
+        min_tracks=min_tracks,
+        unmatched_count=unmatched_count,
+        no_matches=not filtered,
+    )
+
+
+@results_bp.route("/unmatched_view", methods=["POST"])
+def unmatched_view():
+    """Show details for unmatched albums."""
+    username = request.form.get("username")
+    year = request.form.get("year")
+    with unmatched_lock:
+        unmatched_data = copy.deepcopy(UNMATCHED)
+
+    reasons = {}
+    for item in unmatched_data.values():
+        reasons.setdefault(item.get("reason", "Unknown"), []).append(item)
+    reason_counts = {r: len(a) for r, a in reasons.items()}
+
+    return render_template(
+        "unmatched.html",
+        username=username,
+        year=year,
+        unmatched_data=unmatched_data,
+        reasons=reasons,
+        reason_counts=reason_counts,
+        total_count=len(unmatched_data),
+    )

--- a/app/services/lastfm_service.py
+++ b/app/services/lastfm_service.py
@@ -1,0 +1,152 @@
+"""Functions for interacting with the Last.fm API."""
+
+import asyncio
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+import aiohttp
+
+from config import Config
+
+from ..cache import get_cached_response, set_cached_response
+from ..state import get_lastfm_limiter, get_session
+from ..utils import normalize_name, normalize_track_name
+
+
+async def check_user_exists(username: str) -> bool:
+    """Return ``True`` if the Last.fm user exists."""
+
+    url = "https://ws.audioscrobbler.com/2.0/"
+    params = {
+        "method": "user.getinfo",
+        "user": username,
+        "api_key": Config.LASTFM_API_KEY,
+        "format": "json",
+    }
+    session = await get_session()
+    async with session.get(url, params=params) as resp:
+        if resp.status == 200:
+            return True
+        if resp.status == 404:
+            return False
+        resp.raise_for_status()
+        return False
+
+
+async def fetch_recent_tracks_page_async(
+    session: aiohttp.ClientSession,
+    username: str,
+    from_ts: int,
+    to_ts: int,
+    page: int,
+    retries: int = 3,
+) -> Optional[Dict[str, Any]]:
+    """Fetch a single page of recent tracks from Last.fm."""
+    url = "https://ws.audioscrobbler.com/2.0/"
+    params = {
+        "method": "user.getrecenttracks",
+        "user": username,
+        "api_key": Config.LASTFM_API_KEY,
+        "format": "json",
+        "from": from_ts,
+        "to": to_ts,
+        "limit": 200,
+        "page": page,
+    }
+
+    cached = get_cached_response(url, params)
+    if cached:
+        return cached
+
+    limiter = get_lastfm_limiter()
+    for attempt in range(retries):
+        try:
+            async with limiter:
+                async with session.get(url, params=params) as resp:
+                    if resp.status == 429:
+                        retry_after = int(resp.headers.get("Retry-After", "1"))
+                        await asyncio.sleep(retry_after)
+                        continue
+                    if resp.status == 404:
+                        raise ValueError(f"User '{username}' not found on Last.fm")
+                    if resp.status != 200:
+                        break
+                    data = await resp.json()
+                    set_cached_response(url, data, params)
+                    return data
+        except Exception:
+            await asyncio.sleep(2**attempt)
+    return None
+
+
+async def fetch_pages_batch_async(
+    session: aiohttp.ClientSession,
+    username: str,
+    from_ts: int,
+    to_ts: int,
+    pages: Iterable[int],
+) -> List[Optional[Dict[str, Any]]]:
+    """Fetch a batch of pages concurrently."""
+    tasks = [
+        fetch_recent_tracks_page_async(session, username, from_ts, to_ts, p)
+        for p in pages
+    ]
+    return await asyncio.gather(*tasks)
+
+
+async def fetch_all_recent_tracks_async(
+    username: str, from_ts: int, to_ts: int
+) -> List[Dict[str, Any]]:
+    """Retrieve all recent tracks for the given time range."""
+    session = await get_session()
+    first = await fetch_recent_tracks_page_async(session, username, from_ts, to_ts, 1)
+    if not first or "recenttracks" not in first:
+        return []
+
+    total_pages = int(first["recenttracks"]["@attr"]["totalPages"])
+    pages = [first]
+    batch_size = 20
+    for start in range(2, total_pages + 1, batch_size):
+        end = min(start + batch_size, total_pages + 1)
+        batch = await fetch_pages_batch_async(
+            session, username, from_ts, to_ts, range(start, end)
+        )
+        pages.extend([p for p in batch if p])
+    return pages
+
+
+async def fetch_top_albums_async(
+    username: str, year: int, min_plays: int = 10, min_tracks: int = 3
+) -> Dict[tuple[str, str], Dict[str, Any]]:
+    """Return a mapping of normalized album keys to play statistics."""
+    from_ts = int(datetime(year, 1, 1).timestamp())
+    to_ts = int(datetime(year, 12, 31, 23, 59, 59).timestamp())
+    pages = await fetch_all_recent_tracks_async(username, from_ts, to_ts)
+    albums: Dict[tuple[str, str], Dict[str, Any]] = defaultdict(
+        lambda: {"play_count": 0, "track_counts": defaultdict(int)}
+    )
+    for page in pages:
+        for t in page.get("recenttracks", {}).get("track", []):
+            alb = t.get("album", {}).get("#text", "...")
+            art = t.get("artist", {}).get("#text", "...")
+            name = t.get("name", "...")
+            date = t.get("date", {}).get("uts")
+            if not date:
+                continue
+            ts = int(date)
+            if ts < from_ts or ts > to_ts:
+                continue
+            if alb and art and name:
+                key = normalize_name(art, alb)
+                if "original_artist" not in albums[key]:
+                    albums[key]["original_artist"] = art
+                    albums[key]["original_album"] = alb
+                albums[key]["play_count"] += 1
+                n = normalize_track_name(name)
+                albums[key]["track_counts"][n] += 1
+    return {
+        k: v
+        for k, v in albums.items()
+        if v["play_count"] >= min_plays and len(v["track_counts"]) >= min_tracks
+    }

--- a/app/services/spotify_service.py
+++ b/app/services/spotify_service.py
@@ -1,0 +1,114 @@
+"""Helper functions for interacting with the Spotify API."""
+
+import asyncio
+from typing import Any, Dict, Optional
+
+import aiohttp
+
+from config import Config
+
+from ..cache import get_cached_response, set_cached_response
+from ..state import get_spotify_limiter
+from ..utils import normalize_name, normalize_track_name
+
+spotify_token_cache = {"token": None, "expires_at": 0.0}
+
+
+async def fetch_spotify_access_token() -> Optional[str]:
+    """Retrieve an application access token from Spotify."""
+    if spotify_token_cache["expires_at"] > asyncio.get_event_loop().time():
+        return spotify_token_cache["token"]
+
+    url = "https://accounts.spotify.com/api/token"
+    auth = aiohttp.BasicAuth(Config.SPOTIFY_CLIENT_ID, Config.SPOTIFY_CLIENT_SECRET)
+    data = {"grant_type": "client_credentials"}
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, data=data, auth=auth) as resp:
+            if resp.status == 200:
+                token_data = await resp.json()
+                spotify_token_cache.update(
+                    {
+                        "token": token_data["access_token"],
+                        "expires_at": (
+                            asyncio.get_event_loop().time() + token_data["expires_in"]
+                        ),
+                    }
+                )
+                return spotify_token_cache["token"]
+    return None
+
+
+async def fetch_spotify_track_durations(
+    session: aiohttp.ClientSession, album_id: str, token: str
+) -> Dict[str, int]:
+    """Return a mapping of normalized track names to their duration in seconds."""
+    url = f"https://api.spotify.com/v1/albums/{album_id}"
+    headers = {"Authorization": f"Bearer {token}"}
+    async with session.get(url, headers=headers) as resp:
+        if resp.status == 200:
+            album_data = await resp.json()
+            tracks = {}
+            for t in album_data.get("tracks", {}).get("items", []):
+                name_norm = normalize_track_name(t.get("name", ""))
+                tracks[name_norm] = t.get("duration_ms", 0) // 1000
+            return tracks
+    return {}
+
+
+async def fetch_spotify_album_release_date(
+    session: aiohttp.ClientSession, artist: str, album: str, token: str
+) -> Dict[str, Any]:
+    """Search Spotify for an album and return metadata if found."""
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {"q": f"artist:{artist} album:{album}", "type": "album", "limit": 1}
+    limiter = get_spotify_limiter()
+    for attempt in range(3):
+        try:
+            async with limiter:
+                async with session.get(
+                    "https://api.spotify.com/v1/search", params=params, headers=headers
+                ) as resp:
+                    if resp.status == 429:
+                        retry_after = int(resp.headers.get("Retry-After", "1"))
+                        await asyncio.sleep(retry_after)
+                        continue
+                    if resp.status != 200:
+                        break
+                    data = await resp.json()
+                    items = data.get("albums", {}).get("items", [])
+                    if not items:
+                        relaxed_q = {
+                            "q": f"{artist} {album}",
+                            "type": "album",
+                            "limit": 1,
+                        }
+                        async with session.get(
+                            "https://api.spotify.com/v1/search",
+                            params=relaxed_q,
+                            headers=headers,
+                        ) as fallback:
+                            relaxed_data = await fallback.json()
+                            relaxed_items = relaxed_data.get("albums", {}).get(
+                                "items", []
+                            )
+                            if not relaxed_items:
+                                key = "|".join(normalize_name(artist, album))
+                                set_cached_response(key, {"reason": "No Spotify match"})
+                                return {}
+                            album_info = relaxed_items[0]
+                            return {
+                                "release_date": album_info.get("release_date"),
+                                "album_image": album_info.get("images", [{}])[0].get(
+                                    "url"
+                                ),
+                            }
+                    album_info = items[0]
+                    return {
+                        "release_date": album_info.get("release_date"),
+                        "album_image": album_info.get("images", [{}])[0].get("url"),
+                        "id": album_info.get("id"),
+                    }
+        except Exception:
+            await asyncio.sleep(2**attempt)
+    return {}

--- a/app/state.py
+++ b/app/state.py
@@ -1,0 +1,64 @@
+"""Shared application state and synchronization primitives."""
+
+import contextvars
+import threading
+from typing import Optional
+
+import aiohttp
+
+# Progress tracking
+current_progress = {"progress": 0, "message": "Initializing...", "error": False}
+progress_lock = threading.Lock()
+
+# Unmatched album tracking
+unmatched_lock = threading.Lock()
+UNMATCHED: dict[str, dict] = {}
+
+# Completed results cache
+completed_results: dict[tuple, list] = {}
+
+# Shared aiohttp session
+http_session: Optional[aiohttp.ClientSession] = None
+
+# Rate limiter contexts used by services
+_lastfm_limiter = contextvars.ContextVar("lastfm_limiter", default=None)
+_spotify_limiter = contextvars.ContextVar("spotify_limiter", default=None)
+
+
+async def get_session() -> aiohttp.ClientSession:
+    """Return the global ``aiohttp.ClientSession``, creating it if necessary."""
+
+    global http_session
+    if http_session is None or http_session.closed:
+        http_session = aiohttp.ClientSession()
+    return http_session
+
+
+async def close_session() -> None:
+    """Close the global ``aiohttp.ClientSession`` if open."""
+
+    global http_session
+    if http_session and not http_session.closed:
+        await http_session.close()
+    http_session = None
+
+
+from aiolimiter import AsyncLimiter
+
+
+def get_lastfm_limiter() -> AsyncLimiter:
+    """Return a shared rate limiter for Last.fm requests."""
+    limiter = _lastfm_limiter.get()
+    if limiter is None:
+        limiter = AsyncLimiter(20, 1)
+        _lastfm_limiter.set(limiter)
+    return limiter
+
+
+def get_spotify_limiter() -> AsyncLimiter:
+    """Return a shared rate limiter for Spotify requests."""
+    limiter = _spotify_limiter.get()
+    if limiter is None:
+        limiter = AsyncLimiter(20, 1)
+        _spotify_limiter.set(limiter)
+    return limiter

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,0 +1,183 @@
+"""Background job helpers for ScrobbleScope."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from .services.lastfm_service import fetch_top_albums_async
+from .services.spotify_service import (
+    fetch_spotify_access_token,
+    fetch_spotify_album_release_date,
+    fetch_spotify_track_durations,
+)
+from .state import (
+    UNMATCHED,
+    completed_results,
+    current_progress,
+    progress_lock,
+    unmatched_lock,
+)
+from .utils import format_seconds, normalize_name
+
+
+def run_async_in_thread(coro: Any) -> Any:
+    """Run an async coroutine in a background thread."""
+    result: List[Any] = []
+    error: List[Exception] = []
+
+    def runner() -> None:
+        try:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            result.append(loop.run_until_complete(coro()))
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            error.append(exc)
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=runner)
+    thread.start()
+    thread.join()
+
+    if error:
+        raise error[0]
+    return result[0]
+
+
+def process_albums(
+    filtered_albums: Dict[tuple[str, str], Dict[str, Any]],
+    year: int,
+    sort_mode: str,
+    release_scope: str,
+    decade: Optional[str] = None,
+    release_year: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Enrich albums with Spotify metadata and calculate totals."""
+
+    async def inner() -> List[Dict[str, Any]]:
+        token = await fetch_spotify_access_token()
+        if not token:
+            return []
+
+        def matches_release(release_date: str) -> bool:
+            if not release_date:
+                return False
+            rel_year = int(release_date.split("-")[0])
+            if release_scope == "same":
+                return rel_year == year
+            if release_scope == "previous":
+                return rel_year == year - 1
+            if release_scope == "decade" and decade:
+                decade_start = int(decade[:3] + "0")
+                return decade_start <= rel_year < decade_start + 10
+            if release_scope == "custom" and release_year:
+                return rel_year == release_year
+            return True
+
+        async with aiohttp.ClientSession() as session:
+            results: List[Dict[str, Any]] = []
+            for (artist, album), data in filtered_albums.items():
+                details = await fetch_spotify_album_release_date(
+                    session, artist, album, token
+                )
+                release = details.get("release_date", "")
+                album_id = details.get("id")
+                if details and matches_release(release) and album_id:
+                    durations = await fetch_spotify_track_durations(
+                        session, album_id, token
+                    )
+                    play_time_sec = sum(
+                        durations.get(t, 0) * c for t, c in data["track_counts"].items()
+                    )
+                    results.append(
+                        {
+                            "artist": data["original_artist"],
+                            "album": data["original_album"],
+                            "play_count": data["play_count"],
+                            "play_time": format_seconds(play_time_sec),
+                            "play_time_seconds": play_time_sec,
+                            "different_songs": len(data["track_counts"]),
+                            "release_date": release,
+                            "album_image": details.get("album_image"),
+                        }
+                    )
+                elif details and not matches_release(release):
+                    reason = (
+                        f"Released in {release.split('-')[0]} does not match filter"
+                    )
+                    with unmatched_lock:
+                        key = "|".join(
+                            normalize_name(
+                                data["original_artist"], data["original_album"]
+                            )
+                        )
+                        UNMATCHED[key] = {
+                            "artist": data["original_artist"],
+                            "album": data["original_album"],
+                            "reason": reason,
+                        }
+                else:
+                    with unmatched_lock:
+                        key = "|".join(
+                            normalize_name(
+                                data["original_artist"], data["original_album"]
+                            )
+                        )
+                        UNMATCHED[key] = {
+                            "artist": data["original_artist"],
+                            "album": data["original_album"],
+                            "reason": "No match found on Spotify",
+                        }
+
+            if sort_mode == "playtime":
+                results.sort(key=lambda x: x["play_time_seconds"], reverse=True)
+            else:
+                results.sort(key=lambda x: x["play_count"], reverse=True)
+            return results
+
+    return run_async_in_thread(inner)
+
+
+def background_task(
+    username: str,
+    year: int,
+    sort_mode: str,
+    release_scope: str,
+    decade: Optional[str] = None,
+    release_year: Optional[int] = None,
+    min_plays: int = 10,
+    min_tracks: int = 3,
+) -> List[Dict[str, Any]]:
+    """Run the full processing flow in a background thread."""
+
+    async def fetch_and_process() -> List[Dict[str, Any]]:
+        with progress_lock:
+            current_progress.update(
+                {"progress": 5, "message": "Fetching scrobbles...", "error": False}
+            )
+        albums = await fetch_top_albums_async(username, year, min_plays, min_tracks)
+        with progress_lock:
+            current_progress.update({"progress": 40, "message": "Processing albums..."})
+        results = process_albums(
+            albums, year, sort_mode, release_scope, decade, release_year
+        )
+        with progress_lock:
+            current_progress.update({"progress": 100, "message": "Done"})
+        key = (
+            username,
+            year,
+            sort_mode,
+            release_scope,
+            decade,
+            release_year,
+            min_plays,
+            min_tracks,
+        )
+        completed_results[key] = results
+        return results
+
+    return run_async_in_thread(fetch_and_process)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,61 @@
+"""Utility helpers used across the application."""
+
+import string
+import unicodedata
+
+
+def normalize_name(artist: str, album: str) -> tuple[str, str]:
+    """Return normalized artist and album names for reliable matching."""
+
+    safe_to_remove_words = {
+        "deluxe",
+        "edition",
+        "remastered",
+        "version",
+        "expanded",
+        "anniversary",
+        "special",
+        "bonus",
+        "tracks",
+        "ep",
+        "remaster",
+    }
+
+    def clean(text: str) -> str:
+        cleaned = (
+            unicodedata.normalize("NFKD", text)
+            .encode("ascii", "ignore")
+            .decode("utf-8")
+            .lower()
+        )
+        translator = str.maketrans(string.punctuation, " " * len(string.punctuation))
+        cleaned = cleaned.translate(translator)
+        words = cleaned.split()
+        filtered = [w for w in words if w not in safe_to_remove_words]
+        return " ".join(filtered).strip()
+
+    return clean(artist), clean(album)
+
+
+def normalize_track_name(name: str) -> str:
+    """Simplify a track name for fuzzy matching across services."""
+
+    n = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode().lower()
+    translator = str.maketrans(
+        {
+            c: " "
+            for c in [":", "-", "(", ")", "[", "]", "/", "\\", ".", ",", "!", "?", "'"]
+        }
+    )
+    n = n.translate(translator)
+    return " ".join(n.split()).strip()
+
+
+def format_seconds(seconds: int) -> str:
+    """Convert a duration in seconds to a human-readable string."""
+
+    minutes, sec = divmod(int(seconds), 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours:d}h {minutes:02d}m {sec:02d}s"
+    return f"{minutes:d}m {sec:02d}s"

--- a/config.py
+++ b/config.py
@@ -1,0 +1,29 @@
+"""Application configuration and environment loading."""
+
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class Config:
+    """Base configuration loaded from environment variables."""
+
+    SECRET_KEY = os.getenv("SECRET_KEY", "dev")
+    LASTFM_API_KEY = os.getenv("LASTFM_API_KEY")
+    SPOTIFY_CLIENT_ID = os.getenv("SPOTIFY_CLIENT_ID")
+    SPOTIFY_CLIENT_SECRET = os.getenv("SPOTIFY_CLIENT_SECRET")
+
+
+def ensure_api_keys() -> None:
+    """Raise an error if required API keys are missing."""
+
+    if not all(
+        [
+            Config.LASTFM_API_KEY,
+            Config.SPOTIFY_CLIENT_ID,
+            Config.SPOTIFY_CLIENT_SECRET,
+        ]
+    ):
+        raise RuntimeError("Missing API keys! Check your .env file.")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,38 +1,34 @@
 # tests/test_app.py
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-# Imports from your application
-from app import check_user_exists, create_app, normalize_name
+from app import create_app
+from app.services.lastfm_service import check_user_exists
+from app.utils import normalize_name
 
 
 @pytest.fixture
 def client():
     """Create a test client for the Flask application."""
-    app = create_app()
+
+    app = create_app(testing=True)
     app.config["TESTING"] = True
     with app.test_client() as client:
         yield client
 
 
 def test_home_page(client):
-    """
-    GIVEN a Flask application configured for testing
-    WHEN the '/' page is requested (GET)
-    THEN check that the response is valid and contains key content.
-    """
+    """Ensure the index page renders correctly."""
+
     response = client.get("/")
     assert response.status_code == 200
     assert b"Filter Your Album Scrobbles!" in response.data
 
 
 def test_normalize_name_simple():
-    """
-    GIVEN an artist and album with common suffixes and punctuation
-    WHEN normalize_name is called
-    THEN check that the names are correctly stripped and lowercased.
-    """
+    """normalize_name should strip punctuation and metadata words."""
+
     artist, album = normalize_name("The Beatles.", "Let It Be (Deluxe Edition)")
     assert artist == "the beatles"
     assert album == "let it be"
@@ -40,38 +36,29 @@ def test_normalize_name_simple():
 
 @pytest.mark.asyncio
 async def test_check_user_exists_success():
-    """
-    GIVEN a username that exists
-    WHEN check_user_exists is called
-    THEN it should return True by mocking a successful API response.
-    """
-    # Patch 'aiohttp.ClientSession.get'. Its return value must be an
-    # object that supports the `async with` protocol.
-    with patch("aiohttp.ClientSession.get") as mock_get:
-        # Create a mock for the response object itself.
-        mock_response = AsyncMock()
-        mock_response.status = 200
-        mock_response.json.return_value = {"user": {"name": "testuser"}}
+    """check_user_exists returns True on 200 responses."""
 
-        # This is the key: Configure the return value of the mock's __aenter__
-        # method. This correctly simulates the object `async with` will use.
-        mock_get.return_value.__aenter__.return_value = mock_response
+    async_session = Mock()
+    mock_response = AsyncMock(status=200)
+    cm = AsyncMock()
+    cm.__aenter__.return_value = mock_response
+    async_session.get.return_value = cm
 
+    with patch("app.services.lastfm_service.get_session", return_value=async_session):
         result = await check_user_exists("any_user")
-        assert result is True
+    assert result is True
 
 
 @pytest.mark.asyncio
 async def test_check_user_does_not_exist():
-    """
-    GIVEN a username that does NOT exist
-    WHEN check_user_exists is called
-    THEN it should return False by mocking a 404 API response.
-    """
-    with patch("aiohttp.ClientSession.get") as mock_get:
-        mock_response = AsyncMock()
-        mock_response.status = 404
-        mock_get.return_value.__aenter__.return_value = mock_response
+    """check_user_exists returns False on 404 responses."""
 
-        result = await check_user_exists("nonexistent_user")
-        assert result is False
+    async_session = Mock()
+    mock_response = AsyncMock(status=404)
+    cm = AsyncMock()
+    cm.__aenter__.return_value = mock_response
+    async_session.get.return_value = cm
+
+    with patch("app.services.lastfm_service.get_session", return_value=async_session):
+        result = await check_user_exists("missing_user")
+    assert result is False


### PR DESCRIPTION
## Summary
- add cache module for in-memory request caching
- implement Last.fm and Spotify service helpers
- create background task utilities
- register new results blueprint
- update state with shared rate limiters

## Testing
- `pre-commit run --files app/cache.py app/state.py app/services/lastfm_service.py app/services/spotify_service.py app/tasks.py app/routes/results.py app/__init__.py tests/test_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68696e89457c832da87601b6da19ac1a