### PR TITLE
Clarify process_albums return docstring

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -56,7 +56,10 @@ def process_albums(
     decade: Optional[str] = None,
     release_year: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
-    """Enrich albums with Spotify metadata and calculate totals."""
+    """Enrich albums with Spotify metadata and calculate totals.
+
+    Returns the processed album list.
+    """
 
     async def inner() -> List[Dict[str, Any]]:
         token = await fetch_spotify_access_token()


### PR DESCRIPTION
## Summary
- clarify process_albums() docstring to mention the processed album list

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869d954e4fc832d8159c1680af2cb7d