### PR TITLE
Fly.io deploy setup

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,13 @@
+# Deploying to Fly.io
+
+Use the following commands to deploy the application:
+
+```
+fly auth signup # or: fly auth login
+fly launch --internal-port 8080
+fly secrets set LASTFM_API_KEY=... SPOTIFY_CLIENT_ID=... SPOTIFY_CLIENT_SECRET=... SECRET_KEY=...
+fly deploy
+fly status
+fly logs
+fly apps open
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--workers", "1", "app:app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.6
 MarkupSafe==3.0.2
 multidict==6.1.0
+gunicorn==23.0.0
 pdf2image==1.17.0
 pillow==11.1.0
 platformdirs==4.3.6


### PR DESCRIPTION
## Summary
- add gunicorn dependency to support running the Flask app with gunicorn
- add a Dockerfile to build and run the app on Fly.io using gunicorn on port 8080
- document Fly.io deployment commands in DEPLOY.md

## Testing
- pre-commit run --all-files
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69573d7ad8cc832d87030a15576426e2)