### PR TITLE
🛡️ Sentinel: [MEDIUM] Add basic security headers to application responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-05 - Add Security Headers
+**Vulnerability:** Missing standard security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+**Learning:** The application was missing basic defense-in-depth headers, making it slightly more susceptible to Clickjacking and MIME-sniffing.
+**Prevention:** In Flask apps, always add an `@app.after_request` hook to inject standard security headers.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add basic security headers to all responses."""
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,11 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+def test_security_headers_are_present(client):
+    """Verify that the after_request hook adds required security headers."""
+    response = client.get("/")
+    assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
Added an `@application.after_request` hook in `app.py` to inject standard HTTP security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy) into all application responses. Added a corresponding unit test to verify their presence and updated the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [13219026371562359651](https://jules.google.com/task/13219026371562359651) started by @pterw*