### PR TITLE
🛡️ Sentinel: Add HTTP security response headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-07 - Add Global HTTP Security Response Headers
+**Vulnerability:** Missing security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) could leave the application vulnerable to Clickjacking and MIME-type sniffing attacks.
+**Learning:** These headers weren't defined in the Flask application factory. This is a common gap for Flask applications, relying on a reverse proxy to set these headers when they should be set by the application itself as defense in depth.
+**Prevention:** Ensured the headers are set globally on all responses using an `@application.after_request` hook in `app.py`. Next time verify standard security headers exist out-of-the-box or define them initially.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def set_security_headers(response):
+        """Add global HTTP security response headers."""
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The Flask application lacked standard global security response headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), potentially leaving it vulnerable to Clickjacking and MIME-type sniffing attacks.
🎯 **Impact:** Browsers may incorrectly render responses in embedded contexts (e.g. iframes) or infer MIME types incorrectly, leading to cross-site risks.
🔧 **Fix:** Added an `@application.after_request` hook in `app.py` to set standard security headers globally on all outgoing HTTP responses. Also recorded a log in `.jules/sentinel.md`.
✅ **Verification:** Verified locally that responses now return `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` without causing regressions in functionality. Tested via curl and existing unit test suite.

---
*PR created automatically by Jules for task [18425592947360249852](https://jules.google.com/task/18425592947360249852) started by @pterw*