### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-03-08 - Added Global HTTP Security Headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy)
+
+**Vulnerability:** The application was missing basic defense-in-depth HTTP security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+**Learning:** These standard headers were absent, leaving the app vulnerable to clickjacking and MIME-sniffing. A previous attempt to add `Content-Security-Policy` via Flask-Talisman (Batch 17 WP-5) was abandoned because it broke inline styles required by the templates.
+**Prevention:** Rather than using a third-party extension like Flask-Talisman, standard security headers can be globally applied via a simple `@application.after_request` hook, avoiding the complexities and breakages associated with overly strict Content-Security-Policies while still applying essential protections.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def add_security_headers(response):
+        """Apply standard HTTP security headers to all responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -4,9 +4,33 @@ import logging
 
 import pytest
 
-from app import _validate_secret_key
+from app import _validate_secret_key, create_app
 
 _STRONG_KEY = "a" * 64
+
+
+class TestSecurityHeaders:
+    @pytest.fixture
+    def client(self):
+        app = create_app()
+        app.config["TESTING"] = True
+        app.config["WTF_CSRF_ENABLED"] = False
+        with app.test_client() as client:
+            yield client
+
+    def test_security_header_x_frame_options(self, client):
+        response = client.get("/")
+        assert response.headers.get("X-Frame-Options") == "DENY"
+
+    def test_security_header_x_content_type_options(self, client):
+        response = client.get("/")
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+
+    def test_security_header_referrer_policy_present(self, client):
+        response = client.get("/")
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )
 
 
 class TestValidateSecretKey:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was missing basic defense-in-depth HTTP security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
🎯 Impact: Left the app vulnerable to attacks such as clickjacking and MIME-sniffing.
🔧 Fix: Added an `@application.after_request` hook in `app.py`'s `create_app` factory to explicitly set `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin`. Note that `Content-Security-Policy` and `Flask-Talisman` were avoided as they conflict with inline styling requirements in `templates/`.
✅ Verification: `pytest` passes with 3 new tests asserting the presence of these headers. Run `python3 app.py`, perform a normal search, and verify the correct headers are set in the network tab in the browser console.

---
*PR created automatically by Jules for task [11320715105302226515](https://jules.google.com/task/11320715105302226515) started by @pterw*