### PR TITLE
🛡️ Sentinel: [MEDIUM] Add global HTTP security response headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [Add Global HTTP Security Response Headers]
+**Vulnerability:** The application was not transmitting standard HTTP security response headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), potentially enabling client-side attacks like clickjacking and MIME-type sniffing.
+**Learning:** Found that basic HTTP security enhancements were overlooked, likely due to focusing heavily on API keys and CSRF protection.
+**Prevention:** Implement a standard setup for HTTP security headers globally on all web frameworks, utilizing a dedicated response handler like `@application.after_request` in Flask, before deploying to production.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add standard HTTP security headers to all responses."""
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,11 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+class TestSecurityHeaders:
+    def test_security_headers_present(self, client):
+        """Verify that standard security headers are added to all responses."""
+        response = client.get("/")
+        assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -34,10 +34,13 @@ class TestValidateSecretKey:
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
 
+
 class TestSecurityHeaders:
     def test_security_headers_present(self, client):
         """Verify that standard security headers are added to all responses."""
         response = client.get("/")
         assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
-        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add global HTTP security response headers

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application was missing standard HTTP security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`).
🎯 **Impact:** Without these headers, the application is more susceptible to client-side attacks, including clickjacking (if embedded in malicious frames) and MIME-type sniffing vulnerabilities.
🔧 **Fix:** Implemented an `@application.after_request` hook in `app.py` to globally inject standard security headers (`SAMEORIGIN`, `nosniff`, `strict-origin-when-cross-origin`) on all responses.
✅ **Verification:** Added `TestSecurityHeaders` in `tests/test_app_factory.py`. Run `pytest tests/test_app_factory.py` to verify the headers are correctly applied. A journal entry was added to `.jules/sentinel.md` documenting the fix.

---
*PR created automatically by Jules for task [10788460543760317031](https://jules.google.com/task/10788460543760317031) started by @pterw*