### PR TITLE
🛡️ Sentinel: [MEDIUM] Add basic security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-23 - [Missing Foundational Security Headers]
+**Vulnerability:** The Flask application lacked foundational security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), exposing it to clickjacking, MIME-type sniffing, and unintended cross-origin referrer leakage.
+**Learning:** This gap existed because these headers were not applied globally as part of the application factory pattern, and CSP was specifically omitted per repository guidelines without replacing it with adequate alternative headers.
+**Prevention:** Always implement an `after_request` hook (or use a library like Flask-Talisman, if not otherwise restricted) to enforce baseline security headers defensively on all responses.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,17 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def set_security_headers(response):
+        """Add basic security headers to all responses.
+
+        Note: CSP and Talisman are intentionally omitted per YAGNI guidelines.
+        """
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -34,6 +34,7 @@ class TestValidateSecretKey:
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
 
+
 def test_security_headers(monkeypatch):
     """GIVEN the Flask application factory
     WHEN a request is made to an endpoint
@@ -42,13 +43,14 @@ def test_security_headers(monkeypatch):
     monkeypatch.setenv("SECRET_KEY", _STRONG_KEY)
 
     from app import create_app
+
     app = create_app()
     app.testing = True
 
     with app.test_client() as client:
         # Requesting a non-existent route just to get a response
         # that passes through after_request hooks
-        response = client.get('/non_existent_route_for_headers_test')
+        response = client.get("/non_existent_route_for_headers_test")
 
         headers = response.headers
         assert headers.get("X-Frame-Options") == "SAMEORIGIN"

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,24 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+def test_security_headers(monkeypatch):
+    """GIVEN the Flask application factory
+    WHEN a request is made to an endpoint
+    THEN the response should contain the required security headers.
+    """
+    monkeypatch.setenv("SECRET_KEY", _STRONG_KEY)
+
+    from app import create_app
+    app = create_app()
+    app.testing = True
+
+    with app.test_client() as client:
+        # Requesting a non-existent route just to get a response
+        # that passes through after_request hooks
+        response = client.get('/non_existent_route_for_headers_test')
+
+        headers = response.headers
+        assert headers.get("X-Frame-Options") == "SAMEORIGIN"
+        assert headers.get("X-Content-Type-Options") == "nosniff"
+        assert headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
* 🚨 Severity: MEDIUM
* 💡 Vulnerability: The Flask application lacked foundational security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), exposing it to clickjacking, MIME-type sniffing, and cross-origin referrer leakage.
* 🎯 Impact: Attackers could potentially frame the site (clickjacking) or sniff MIME types to bypass Content-Type protections. Referrer leakage could expose internal application flow to external domains.
* 🔧 Fix: Added a global `@application.after_request` hook in the `app.py` application factory to set these headers defensively on all outgoing HTTP responses. (CSP remains intentionally omitted per repository guidelines).
* ✅ Verification: Run `python3 -m pytest tests/test_app_factory.py::test_security_headers` to verify the headers are correctly applied. The full test suite was run and passed. A record was logged in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8060355818234945047](https://jules.google.com/task/8060355818234945047) started by @pterw*