### PR TITLE
🛡️ Sentinel: [HIGH] Add standard security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-11 - Missing HTTP Security Headers
+**Vulnerability:** The application was missing standard HTTP security response headers (`X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`), leaving it vulnerable to clickjacking, MIME-type sniffing, and cross-origin referrer leakage.
+**Learning:** Security headers like CSP and Flask-Talisman were intentionally omitted because a strict CSP was deemed not currently viable and broke inline styles. However, basic headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) were also overlooked or dropped as part of this decision, missing an opportunity for easy defense-in-depth without breaking functionality.
+**Prevention:** Implement standard, non-breaking security headers (e.g., via a global `@application.after_request` hook) even if more complex headers like CSP are deferred. Defense in depth means layering protections where possible.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add basic global security headers."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,25 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_security_header_x_frame_options(self, client):
+        """GET / returns response with X-Frame-Options: DENY"""
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.headers.get("X-Frame-Options") == "DENY"
+
+    def test_security_header_x_content_type_options(self, client):
+        """GET / returns response with X-Content-Type-Options: nosniff"""
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+
+    def test_security_header_referrer_policy(self, client):
+        """GET / returns response with Referrer-Policy: strict-origin-when-cross-origin"""
+        response = client.get("/")
+        assert response.status_code == 200
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Missing HTTP security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`)
🎯 **Impact:** Application left open to clickjacking and MIME-type sniffing attacks.
🔧 **Fix:** Implemented an `@application.after_request` hook in `app.py` to globally set standard security headers.
✅ **Verification:** Verified by `pytest tests/test_app_factory.py` with 3 new test cases checking that the headers are correctly sent on HTTP responses.

Also added an entry in the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [7427420563585886737](https://jules.google.com/task/7427420563585886737) started by @pterw*