### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-13 - HTTP Security Headers Added Manually
+**Vulnerability:** Missing basic HTTP security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) because Flask-Talisman was dropped due to CSP incompatibility with inline styles.
+**Learning:** Dropping a security library (Flask-Talisman) due to one incompatible feature (CSP breaking inline styles) shouldn't result in abandoning the other independent security benefits (like basic HTTP headers). It is important to implement what is feasible manually if a library approach is rejected.
+**Prevention:** Evaluate the individual security features provided by a library and implement the compatible ones manually if the entire library cannot be used.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def set_security_headers(response):
+        """Add standard HTTP security headers to all responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,11 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+def test_security_headers_present(client):
+    """Test that HTTP security headers are applied to all responses."""
+    response = client.get("/test-404-nonexistent-route")
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application previously lacked basic HTTP security headers, leaving it potentially vulnerable to common web-based attacks such as clickjacking and MIME-type sniffing. While CSP was correctly rejected previously due to inline style incompatibility, the basic headers were inadvertently skipped.
🎯 Impact: Attackers could potentially embed the application in a malicious site (clickjacking) or trick browsers into interpreting files as unexpected types (MIME-sniffing).
🔧 Fix: Added an `@application.after_request` hook in the `app.py` factory to ensure `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` are applied to all responses.
✅ Verification: Added a new unit test in `tests/test_app_factory.py` to ensure the headers are present on all responses (even 404s). Executed the test suite, linting, and formatting successfully.

---
*PR created automatically by Jules for task [6413689200275801116](https://jules.google.com/task/6413689200275801116) started by @pterw*