### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Missing Global Security Headers
+**Vulnerability:** The application was missing standard HTTP security headers such as `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` across all responses.
+**Learning:** These headers were omitted, leaving the application vulnerable to clickjacking (`X-Frame-Options` missing), MIME-type sniffing (`X-Content-Type-Options` missing), and potentially leaking sensitive referrer information (`Referrer-Policy` missing). The decision to skip a strict CSP due to inline styles did not preclude adding these standard protections.
+**Prevention:** Implement security headers using a global framework hook (e.g., Flask's `@application.after_request`) early in the development lifecycle to ensure all responses (including errors like 404s) are protected by default.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def set_security_headers(response):
+        """Add global HTTP security headers to all responses."""
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,13 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_security_headers_are_applied_globally(self, client):
+        # We test a 404 route to ensure the after_request hook
+        # runs independently of specific route logic.
+        response = client.get("/test-404-nonexistent-route")
+        assert response.headers["X-Frame-Options"] == "SAMEORIGIN"
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"


### PR DESCRIPTION
Added a global `after_request` hook in the Flask app factory to set standard security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), preventing clickjacking and MIME-sniffing vulnerabilities. Includes a unit test to ensure these headers are applied to all routes. Logged the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17778122351618875134](https://jules.google.com/task/17778122351618875134) started by @pterw*