### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Standard Security Headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-16 - Add Standard Security Headers
+**Vulnerability:** Missing standard HTTP security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+**Learning:** Default Flask application does not set secure HTTP headers, leaving the application vulnerable to clickjacking and MIME-type sniffing.
+**Prevention:** Always implement an `@application.after_request` hook to set baseline security headers for all responses.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,13 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def add_security_headers(response):
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,20 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_global_security_headers(self, client):
+        """Verify that standard security headers are applied to all responses,
+        even 404s for non-existent routes."""
+        response = client.get("/test-404-nonexistent-route")
+
+        # We expect a 404 because the route doesn't exist, but the after_request
+        # hook should still attach the headers.
+        assert response.status_code == 404
+
+        assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The Flask application was previously not setting standard security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), potentially leaving the application vulnerable to clickjacking and MIME-type sniffing.
🎯 Impact: While an outright exploit requires external factors, these missing headers are a foundational security defense mechanism. Without them, browsers can make insecure choices rendering the site or allowing malicious embedding.
🔧 Fix: Implemented an `@application.after_request` hook inside `create_app` in `app.py` to globally append the headers `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin`. Note: CSP was intentionally omitted per project context.
✅ Verification: Successfully verified with a new unit test in `tests/test_app_factory.py` that checks for the presence of these headers on all routes (including 404s). Also verified by running `pre-commit run --all-files` and the full `pytest` suite.

---
*PR created automatically by Jules for task [9672692876180033777](https://jules.google.com/task/9672692876180033777) started by @pterw*