### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure os.system usage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - [Insecure OS Command Usage for Console Formatting]
+**Vulnerability:** Use of `os.system("")` hack to enable ANSI escape codes on Windows.
+**Learning:** `os.system()` relies on the system shell, introducing a risk of command injection if arguments are ever dynamically formatted or influenced by untrusted input, and generally exposes the application to unnecessary shell execution. Even with an empty string, executing system shells is bad practice.
+**Prevention:** Use direct Win32 API calls (`ctypes.windll.kernel32.SetConsoleMode`) instead of shell-based hacks to achieve console formatting effects on Windows.

--- a/app.py
+++ b/app.py
@@ -27,8 +27,12 @@ csrf = CSRFProtect()
 if isinstance(sys.stderr, io.TextIOWrapper):
     sys.stderr.reconfigure(encoding="utf-8")
 
-# Enable ANSI escape codes on Windows cmd
-os.system("")
+# Enable ANSI escape codes on Windows cmd safely
+if sys.platform == "win32":
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
 
 # Ensure the logs directory exists
 os.makedirs("logs", exist_ok=True)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Use of `os.system("")` to enable ANSI escape codes on Windows executes the system shell unnecessarily. While not immediately exploitable without untrusted inputs, executing shells is insecure and bad practice.
🎯 Impact: Defense-in-depth security enhancement. Reduces attack surface by not relying on the system shell for console formatting, preventing potential future command injection if the surrounding code were ever to dynamically format inputs for the shell call.
🔧 Fix: Replaced `os.system("")` with `ctypes.windll.kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)`, making direct Win32 API calls instead. Added a platform check (`sys.platform == "win32"`) to ensure it only runs on Windows systems.
✅ Verification: Ran pre-commit hooks and full test suite (`python3 -m pytest`) which passed successfully.

---
*PR created automatically by Jules for task [5888960711099451934](https://jules.google.com/task/5888960711099451934) started by @pterw*