### PR TITLE
🛡️ Sentinel: [HIGH] Add standard HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-23 - Missing Default Security Headers
+**Vulnerability:** ScrobbleScope was sending responses without standard HTTP security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy), leaving it susceptible to clickjacking, MIME-sniffing, and referrer leakage.
+**Learning:** Frameworks like Flask do not configure these baseline headers by default. Even when advanced headers like CSP are explicitly opted-out or deemed unnecessary for a given context, fundamental security headers should still be explicitly applied via application-wide request hooks (e.g., `@after_request`).
+**Prevention:** Implement a global `@after_request` hook in the application factory to ensure security headers are automatically attached to all outbound responses, including error pages (e.g., 404s).

--- a/app.py
+++ b/app.py
@@ -114,6 +114,17 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def set_security_headers(response):
+        """Add standard HTTP security headers globally.
+
+        Note: CSP and Flask-Talisman intentionally omitted as YAGNI (Batch 17 WP-5).
+        """
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,29 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    @pytest.fixture
+    def app(self):
+        from app import create_app
+        import os
+        os.environ["SECRET_KEY"] = _STRONG_KEY
+        return create_app()
+
+    @pytest.fixture
+    def client(self, app):
+        return app.test_client()
+
+    def test_security_headers_present_on_valid_route(self, client):
+        response = client.get("/")
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+
+    def test_security_headers_present_on_404_route(self, client):
+        response = client.get("/test-404-nonexistent-route")
+        assert response.status_code == 404
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -38,8 +38,10 @@ class TestValidateSecretKey:
 class TestSecurityHeaders:
     @pytest.fixture
     def app(self):
-        from app import create_app
         import os
+
+        from app import create_app
+
         os.environ["SECRET_KEY"] = _STRONG_KEY
         return create_app()
 
@@ -51,11 +53,15 @@ class TestSecurityHeaders:
         response = client.get("/")
         assert response.headers.get("X-Frame-Options") == "DENY"
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
-        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )
 
     def test_security_headers_present_on_404_route(self, client):
         response = client.get("/test-404-nonexistent-route")
         assert response.status_code == 404
         assert response.headers.get("X-Frame-Options") == "DENY"
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
-        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: ScrobbleScope lacked baseline HTTP security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), leaving users exposed to clickjacking, MIME-sniffing, and referrer data leakage across all application routes. 
🎯 **Impact**: Malicious actors could embed the application in an invisible iframe to trick users into performing unintended actions (clickjacking). Browsers could be tricked into executing non-executable MIME types (MIME-sniffing). External sites linked from the app could inadvertently receive sensitive URL path info in the Referer header. 
🔧 **Fix**: Implemented an explicit `@application.after_request` middleware hook inside the `create_app` factory in `app.py`. This globally applies the `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` headers to all outbound responses. 
✅ **Verification**: 
1. Added `TestSecurityHeaders` class to `tests/test_app_factory.py` to assert the presence of these headers on both standard page loads and `404 Not Found` error pages. 
2. Executed full pytest suite locally (`python3 -m pytest`); all 352 tests passing. 
3. Note: Acknowledged memory and documentation explicitly avoiding CSP (Content-Security-Policy) headers for this application, so they were safely omitted from this patch.

---
*PR created automatically by Jules for task [8423857927979227279](https://jules.google.com/task/8423857927979227279) started by @pterw*