### PR TITLE
🛡️ Sentinel: Add security headers to responses

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def add_security_headers(response):
+        """Apply standard HTTP security headers to all responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,15 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+def test_security_headers_applied(client):
+    """
+    GIVEN a Flask application configured for testing
+    WHEN a request is made to any endpoint (even a non-existent one)
+    THEN the response should include standard HTTP security headers.
+    """
+    response = client.get("/test-404-nonexistent-route")
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Missing standard HTTP security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
🎯 **Impact:** Without these headers, the application is more susceptible to clickjacking (MIME-type sniffing) and sensitive referrer leakage.
🔧 **Fix:** Added a global `@application.after_request` hook to inject the `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` headers. Also created a `test_security_headers_applied` unit test.
✅ **Verification:** Verified by running the test suite (`pytest`) and checking the headers on arbitrary requests, even 404s.

---
*PR created automatically by Jules for task [12201076688592532757](https://jules.google.com/task/12201076688592532757) started by @pterw*