### PR TITLE
🛡️ Sentinel: [HIGH] Add standard security headers

### DIFF
--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -9,7 +9,7 @@ Last updated: 2026-03-05
 | Item | Value |
 |------|-------|
 | Branch | `feat/heatmap` |
-| Tests | **350 passing** across 23 test files |
+| Tests | **351 passing** across 23 test files |
 | Coverage | ~72% (2026-02-20 audit run) |
 | Pre-commit | All hooks pass |
 | Batch 13 status | **Complete**. All 5 WPs done. Definition: `docs/history/definitions/BATCH13_DEFINITION.md`. |

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-05 - Missing Security Headers
+**Vulnerability:** The application was missing standard security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) on its HTTP responses, which could lead to attacks like clickjacking and MIME-type sniffing.
+**Learning:** This existed because Flask does not enforce these by default, and `Flask-Talisman` or a similar tool was omitted (CSP headers were dropped as YAGNI in Batch 17 WP-5 since they broke inline styles).
+**Prevention:** I added an `@application.after_request` hook inside the `create_app` factory in `app.py` to globally set the `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` headers. A test was also added to ensure these are applied globally to all routes (including 404 responses).

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -219,3 +219,10 @@ non-current operational logs. Older dated entries live in
   design -- they will auto-rotate to `BATCH17_LOG.md` when the next batch
   is declared active in Section 3.
 - **350 tests passing**, all hooks green.
+
+### 2026-03-05 - Added standard security headers (Sentinel)
+
+- Addressed a missing security headers vulnerability reported by the Sentinel agent.
+- Added `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` to all responses using an `@application.after_request` hook in `app.py`.
+- Added `test_global_security_headers` to `tests/test_app_factory.py` to verify the headers are globally applied to all responses, including 404s.
+- **351 tests passing**, all hooks green.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add standard security headers to all HTTP responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,11 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+def test_global_security_headers(client):
+    """Verify standard security headers are present on all responses."""
+    response = client.get("/test-404-nonexistent-route")
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix missing security headers

🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was missing standard security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) on its HTTP responses, which could lead to attacks like clickjacking and MIME-type sniffing.
🎯 **Impact:** An attacker could embed the site in an iframe to perform clickjacking or trick the browser into executing non-executable MIME types as scripts.
🔧 **Fix:** I added an `@application.after_request` hook inside the `create_app` factory in `app.py` to globally set the `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` headers. A unit test was added to verify these apply to all responses (even 404 routes).
✅ **Verification:** Verified by checking the HTTP headers on any valid or 404 response. The newly added test `test_global_security_headers` validates this automatically.

*Note: CSP headers were omitted as per project constraints (they break inline styles).*

---
*PR created automatically by Jules for task [9788253200343312494](https://jules.google.com/task/9788253200343312494) started by @pterw*