### PR TITLE
🛡️ Sentinel: [Medium] Add global HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-27 - Missing HTTP Security Headers
+**Vulnerability:** The application was missing standard HTTP security headers such as `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` across its responses.
+**Learning:** These headers were likely omitted during initial development or because they were assumed to be handled by a proxy. However, failing to set them at the application level leaves the app vulnerable to attacks like Clickjacking (`X-Frame-Options: DENY`), MIME-type sniffing (`X-Content-Type-Options: nosniff`), and inadvertently leaking sensitive URL information via referrers (`Referrer-Policy: strict-origin-when-cross-origin`).
+**Prevention:** Ensure that all applications define global response hooks (e.g., using `@app.after_request` in Flask) to apply these headers universally, and write unit tests against non-existent routes to guarantee they are applied to every HTTP response (including errors).

--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def add_security_headers(response):
+        """Globally apply standard HTTP security headers to all responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,13 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+def test_global_security_headers(client):
+    """Verify that global security headers are applied to responses."""
+    # Test against a non-existent route to ensure headers are applied globally
+    response = client.get("/test-404-nonexistent-route")
+
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was missing standard HTTP security headers such as `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` across its responses.
🎯 Impact: Failing to set these headers at the application level leaves the app vulnerable to attacks like Clickjacking (`X-Frame-Options: DENY`), MIME-type sniffing (`X-Content-Type-Options: nosniff`), and inadvertently leaking sensitive URL information via referrers (`Referrer-Policy: strict-origin-when-cross-origin`).
🔧 Fix: Implemented an `@application.after_request` hook inside `create_app` in `app.py` to globally add these standard HTTP security headers to all responses.
✅ Verification: An automated test was added in `tests/test_app_factory.py` to ensure these headers are applied correctly even when making requests to non-existent routes (404 responses), and the test suite has passed.

---
*PR created automatically by Jules for task [7761577706014154431](https://jules.google.com/task/7761577706014154431) started by @pterw*