### PR TITLE
🛡️ Sentinel: [MEDIUM] Replace insecure os.system call with ctypes for Windows console

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-28 - Removed `os.system("")` hack
+**Vulnerability:** Use of `os.system("")` to enable ANSI escape codes on Windows.
+**Learning:** This approach executes an empty string as a system command, which is an unnecessary attack vector and generally an anti-pattern (especially since it relies on system shell evaluation and can be hijacked if the environment path is manipulated or shell variables are overridden). The standard Win32 API provides `ctypes.windll.kernel32.SetConsoleMode` to enable terminal processing securely without spawning a subshell.
+**Prevention:** Avoid `os.system()` and use platform-specific APIs (like `ctypes` on Windows) for low-level console state changes, or rely on a vetted library like `colorama`.

--- a/app.py
+++ b/app.py
@@ -28,7 +28,16 @@ if isinstance(sys.stderr, io.TextIOWrapper):
     sys.stderr.reconfigure(encoding="utf-8")
 
 # Enable ANSI escape codes on Windows cmd
-os.system("")
+if os.name == "nt":
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32
+    # STD_OUTPUT_HANDLE = -11
+    handle = kernel32.GetStdHandle(-11)
+    mode = ctypes.c_ulong()
+    if kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+        # ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+        kernel32.SetConsoleMode(handle, mode.value | 0x0004)
 
 # Ensure the logs directory exists
 os.makedirs("logs", exist_ok=True)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Use of `os.system("")` to enable ANSI escape codes on Windows executes an empty string as a system command, risking unnecessary subshell spawning and potential hijacking.
🎯 Impact: While the risk of arbitrary command injection is low due to the empty string, relying on system shell evaluation for configuring console settings is generally considered a security anti-pattern and poor hygiene.
🔧 Fix: Replaced `os.system("")` with explicit Win32 API calls (`ctypes.windll.kernel32.SetConsoleMode`) on Windows to securely configure terminal properties.
✅ Verification: Ran `pytest` locally and ensured the application factory starts and sets up without error. Tested basic import of `ctypes` snippet. Pre-commit hooks passed.

---
*PR created automatically by Jules for task [15878903667304612661](https://jules.google.com/task/15878903667304612661) started by @pterw*