### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix command subshell execution for console configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - Fix Command Injection Risk in Console Configuration
+**Vulnerability:** Command injection risk via `os.system("")` used to enable ANSI escape codes on Windows.
+**Learning:** `os.system()` executes the given command in a subshell. Even when passing an empty string (`""`), spawning a subshell can be risky and is considered a poor practice for simple system configurations. It bypasses the safety of standard APIs and could theoretically be hooked or exploited if `cmd.exe` or environment variables are tampered with.
+**Prevention:** Use direct, secure API calls like `ctypes.windll.kernel32.SetConsoleMode()` to configure the console instead of relying on side effects of subshell execution.

--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ if isinstance(sys.stderr, io.TextIOWrapper):
 # Enable ANSI escape codes on Windows cmd
 if os.name == "nt":
     import ctypes
+
     kernel32 = ctypes.windll.kernel32
     kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
 

--- a/app.py
+++ b/app.py
@@ -28,7 +28,10 @@ if isinstance(sys.stderr, io.TextIOWrapper):
     sys.stderr.reconfigure(encoding="utf-8")
 
 # Enable ANSI escape codes on Windows cmd
-os.system("")
+if os.name == "nt":
+    import ctypes
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
 
 # Ensure the logs directory exists
 os.makedirs("logs", exist_ok=True)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `app.py` used `os.system("")` as a hack to enable ANSI escape codes (colors) on Windows. This executed an unnecessary subshell.
🎯 Impact: While a hardcoded empty string isn't directly exploitable via user input, spawning a subshell bypasses standard APIs and presents a theoretical risk if `cmd.exe` or system environment variables are tampered with. It violates the principle of using direct APIs for system configurations.
🔧 Fix: Replaced `os.system("")` with `ctypes.windll.kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)` restricted to Windows (`os.name == "nt"`). This enables the same functionality directly through the Win32 API.
✅ Verification: `python3 -m pytest tests/test_app_factory.py` passes. A journal entry was created in `.jules/sentinel.md` documenting this learning.

---
*PR created automatically by Jules for task [17169391064097109712](https://jules.google.com/task/17169391064097109712) started by @pterw*