### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure os.system usage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - Insecure `os.system("")` Usage
+**Vulnerability:** Found `os.system("")` used to enable ANSI escape codes on Windows consoles in `app.py`.
+**Learning:** Using `os.system()` invokes a subshell and is considered bad practice when better APIs exist. It also unnecessarily runs a shell on non-Windows systems where it isn't needed.
+**Prevention:** Use direct Win32 APIs like `ctypes.windll.kernel32.SetConsoleMode` to enable ANSI escape sequences securely without shelling out, and wrap the call in an `os.name == "nt"` check.

--- a/app.py
+++ b/app.py
@@ -27,8 +27,15 @@ csrf = CSRFProtect()
 if isinstance(sys.stderr, io.TextIOWrapper):
     sys.stderr.reconfigure(encoding="utf-8")
 
-# Enable ANSI escape codes on Windows cmd
-os.system("")
+# Enable ANSI escape codes on Windows cmd safely without subshell
+if os.name == "nt":
+    import ctypes
+
+    # ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+    # STD_OUTPUT_HANDLE = -11
+    # See: https://docs.microsoft.com/en-us/windows/console/setconsolemode
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
 
 # Ensure the logs directory exists
 os.makedirs("logs", exist_ok=True)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `app.py` used `os.system("")` on startup to enable ANSI escape codes for Windows command prompts.
🎯 Impact: While passing an empty string avoids direct injection, using `os.system` in a web application factory invokes a subshell unnecessarily. This is flagged by security scanners as an unsafe pattern and creates needless overhead on non-Windows environments (where it executes an empty shell command).
🔧 Fix: Replaced `os.system("")` with a direct call to the Win32 API `ctypes.windll.kernel32.SetConsoleMode`. Wrapped the logic in an `if os.name == "nt":` block to ensure it only executes on Windows. Logged the learning in `.jules/sentinel.md`.
✅ Verification: Ran `pre-commit run --all-files` and `pytest tests/` locally to ensure no functionality is broken and syntax is valid.

---
*PR created automatically by Jules for task [16460121826016273962](https://jules.google.com/task/16460121826016273962) started by @pterw*