### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix subshell execution in app.py

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - Subshell Execution for Console Configuration
+**Vulnerability:** Found `os.system("")` used as a hack to enable ANSI escape codes in Windows cmd. This unnecessarily executes a subshell and creates an opening for command injection or unintended OS interactions if not carefully isolated.
+**Learning:** Avoid using side-effects of system commands for configuration tasks that can be achieved via direct API calls. `os.system()` should only be used as a last resort when direct execution/API access is impossible, and never just for side effects like terminal initialization.
+**Prevention:** Use direct OS API bindings like `ctypes.windll.kernel32.SetConsoleMode` on Windows to configure console properties securely without spawning sub-processes.

--- a/app.py
+++ b/app.py
@@ -28,7 +28,11 @@ if isinstance(sys.stderr, io.TextIOWrapper):
     sys.stderr.reconfigure(encoding="utf-8")
 
 # Enable ANSI escape codes on Windows cmd
-os.system("")
+if sys.platform == "win32":
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
 
 # Ensure the logs directory exists
 os.makedirs("logs", exist_ok=True)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Found `os.system("")` used as a hack to enable ANSI escape codes in Windows cmd. This unnecessarily executes a subshell and creates an opening for command injection or unintended OS interactions if not carefully isolated.
🎯 **Impact:** Exposes the application to potential sub-process manipulation or unintended environmental side effects.
🔧 **Fix:** Replaced the `os.system("")` call with a direct `ctypes` binding to `kernel32.SetConsoleMode`, conditionally applied only on `sys.platform == "win32"`. This achieves the same goal securely without spawning a shell.
✅ **Verification:** Verified by running the full `pytest` suite and `pre-commit` checks. Added a journal entry to `.jules/sentinel.md` documenting the learning.

---
*PR created automatically by Jules for task [8160172834667015657](https://jules.google.com/task/8160172834667015657) started by @pterw*