### PR TITLE
🛡️ Sentinel: [MEDIUM] Add standard HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-23 - Add Missing Security Headers
+**Vulnerability:** Missing standard security HTTP headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+**Learning:** These headers are often forgotten when initial setup is done without an explicit security layer, leaving the app vulnerable to basic clickjacking and MIME-sniffing attacks.
+**Prevention:** Include a simple `@app.after_request` hook in the Flask application factory during initial scaffolding to apply fundamental security headers globally across all routes.

--- a/app.py
+++ b/app.py
@@ -130,6 +130,14 @@ def create_app():
 
     from scrobblescope.routes import bp
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add global security headers to all responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     application.register_blueprint(bp)
     return application
 

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,11 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+def test_global_security_headers(client):
+    """Test that standard HTTP security headers are applied to all responses."""
+    response = client.get("/test-404-nonexistent-route")
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard security HTTP headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`), leaving the application vulnerable to basic clickjacking and MIME-sniffing attacks.
🎯 Impact: Attackers could embed the application in malicious iframes to trick users (clickjacking) or cause the browser to interpret files incorrectly, potentially executing malicious scripts (MIME-sniffing).
🔧 Fix: Added a Flask `after_request` hook in the application factory (`app.py`) to globally apply these headers to all responses.
✅ Verification: Added tests to `tests/test_app_factory.py` to verify the headers are correctly applied. Also verified via `pre-commit run --all-files` and `pytest`.

---
*PR created automatically by Jules for task [10986842543499983874](https://jules.google.com/task/10986842543499983874) started by @pterw*