### PR TITLE
🛡️ Sentinel: [Enhancement] Add standard HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,19 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add standard HTTP security headers to all responses.
+
+        Security concern: These headers defend against clickjacking (X-Frame-Options),
+        MIME-type sniffing (X-Content-Type-Options), and excessive referrer leakage
+        (Referrer-Policy).
+        """
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,15 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_security_headers_are_present(self, client):
+        """Verify standard security headers are present on all responses."""
+        response = client.get("/test-404-nonexistent-route")
+
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
## 🛡️ Sentinel: [Enhancement] Add standard HTTP security headers

### 🚨 Severity: ENHANCEMENT
### 💡 Vulnerability: Missing standard HTTP security headers.
### 🎯 Impact: The application was susceptible to clickjacking (missing X-Frame-Options), MIME-type sniffing (missing X-Content-Type-Options), and potentially leaking excessive referrer information across origins (missing Referrer-Policy).
### 🔧 Fix: Implemented an `@application.after_request` hook in the `create_app` factory in `app.py` to append these headers to all outgoing responses.
### ✅ Verification: Added a new test class `TestSecurityHeaders` in `tests/test_app_factory.py` to confirm the presence of these headers on all routes. Verified using `pytest` and passed all pre-commit hooks.

---
*PR created automatically by Jules for task [12779863844730962547](https://jules.google.com/task/12779863844730962547) started by @pterw*