### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP Security Headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,14 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add global HTTP security headers to every response."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,12 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+def test_security_headers_are_present(client):
+    """Verify that global security headers are applied to all responses."""
+    response = client.get("/test-404-nonexistent-route")
+
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add HTTP Security Headers

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Missing standard HTTP security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
🎯 **Impact:** Exposes the application to potential clickjacking and MIME-sniffing vulnerabilities.
🔧 **Fix:** Added a global Flask `after_request` hook to inject standard security headers. (Note: Content-Security-Policy/Flask-Talisman intentionally omitted as per memory constraint).
✅ **Verification:** Added comprehensive test case `test_security_headers_are_present` to verify headers apply to responses. Tested with full pytest suite.

---
*PR created automatically by Jules for task [14795256786999880311](https://jules.google.com/task/14795256786999880311) started by @pterw*