### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add basic security headers to all responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,19 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_x_frame_options_is_deny(self, client):
+        response = client.get("/test-404-nonexistent-route")
+        assert response.headers.get("X-Frame-Options") == "DENY"
+
+    def test_x_content_type_options_is_nosniff(self, client):
+        response = client.get("/test-404-nonexistent-route")
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+
+    def test_referrer_policy_is_strict_origin(self, client):
+        response = client.get("/test-404-nonexistent-route")
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
As Sentinel, I've implemented a security enhancement by adding standard HTTP security response headers (`X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin`) to all Flask routes via an `@application.after_request` hook. I also included unit tests to verify the headers are applied correctly to responses.

---
*PR created automatically by Jules for task [17472994060631506325](https://jules.google.com/task/17472994060631506325) started by @pterw*