### PR TITLE
🛡️ Sentinel: [MEDIUM] Add standard HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-11 - Global Security Headers Added via App Factory
+**Vulnerability:** Missing standard HTTP security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy).
+**Learning:** The application was missing basic defense-in-depth protections against clickjacking and MIME-sniffing, primarily because these headers weren't set globally on the Flask app factory.
+**Prevention:** Ensured an `@application.after_request` hook is registered in `create_app` in `app.py` to automatically inject these headers into all outgoing HTTP responses.

--- a/app.py
+++ b/app.py
@@ -114,6 +114,17 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def add_security_headers(response):
+        """Apply global security headers to all HTTP responses."""
+        # Prevent clickjacking by denying framing
+        response.headers["X-Frame-Options"] = "DENY"
+        # Prevent MIME type sniffing
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        # Control referrer information leakage
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,15 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_global_security_headers_are_applied(self, client):
+        response = client.get("/test-404-nonexistent-route")
+
+        # Test headers are applied to the 404 response
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application lacked basic defense-in-depth protections like `X-Frame-Options` and `X-Content-Type-Options`, leaving it potentially susceptible to clickjacking or MIME-sniffing.
🎯 **Impact:** Browsers might allow the site to be framed by malicious sites or incorrectly sniff MIME types of user-supplied data.
🔧 **Fix:** Added an `@application.after_request` hook to globally set these headers on all responses in `app.py`. Added corresponding unit tests.
✅ **Verification:** Tests passed. Verified via `curl -I` equivalent in test client that the headers exist on the response.

---
*PR created automatically by Jules for task [10803597616631349051](https://jules.google.com/task/10803597616631349051) started by @pterw*