### PR TITLE
🛡️ Sentinel: Add global HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,14 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def apply_security_headers(response):
+        """Add standard security headers to all responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,17 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_global_security_headers_applied(self, client):
+        # To test global request hooks without being affected by specific route logic,
+        # request a guaranteed non-existent endpoint. The hooks apply to 404 responses too.
+        response = client.get("/test-404-nonexistent-route")
+
+        assert response.status_code == 404
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
This PR adds standard HTTP security headers to all responses to protect against common web vulnerabilities.
- `X-Frame-Options: DENY`: Prevents clickjacking by ensuring the site cannot be framed.
- `X-Content-Type-Options: nosniff`: Prevents browsers from incorrectly sniffing MIME types, mitigating XSS risks.
- `Referrer-Policy: strict-origin-when-cross-origin`: Minimizes referrer leakage to external sites.
A test class `TestSecurityHeaders` has been added to `tests/test_app_factory.py` to ensure these headers are applied correctly globally.

---
*PR created automatically by Jules for task [13343293321090745583](https://jules.google.com/task/13343293321090745583) started by @pterw*