### PR TITLE
🛡️ Sentinel: Add global security headers to HTTP responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-14 - Application HTTP Security Headers Enhancement
+**Vulnerability:** The application was missing basic defense-in-depth HTTP security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) globally across responses.
+**Learning:** Standard security headers should be enforced globally using application hooks (like Flask's `after_request`) instead of relying on specific route configuration.
+**Prevention:** In the future, ensure global security policies are centralized in the application factory configuration. Note that CSP was explicitly omitted per project policy (YAGNI / Batch 17 WP-5).

--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def set_security_headers(response):
+        """Set standard global HTTP security headers on all responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,16 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_global_security_headers_applied(self, client):
+        """Test that global security headers are applied to all responses, including 404s."""
+        response = client.get("/test-404-nonexistent-route")
+
+        assert response.status_code == 404
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
This PR implements defense-in-depth by adding standard HTTP security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) globally to all responses using Flask's `@application.after_request` hook.

🚨 Severity: MEDIUM (Defense-in-depth Enhancement)
💡 Vulnerability: The application previously lacked basic security headers, missing out on browser-level protections against common attacks.
🎯 Impact: Helps mitigate risks related to clickjacking, MIME-type sniffing, and unintended cross-origin information leakage.
🔧 Fix: Implemented an `after_request` hook in `app.py` to inject the headers on all requests (including 404s/500s). CSP is omitted per previous YAGNI project policy.
✅ Verification: Covered by a new automated test in `tests/test_app_factory.py` that verifies the headers on a mock 404 response. Tests and linters pass.

---
*PR created automatically by Jules for task [4315406372796636932](https://jules.google.com/task/4315406372796636932) started by @pterw*