### PR TITLE
🛡️ Sentinel: [security improvement] Add missing HTTP security response headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-15 - Missing Security Headers Added Manually
+**Vulnerability:** The application was missing basic HTTP security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`). Flask-Talisman was deemed YAGNI due to inline styles and strict CSP incompatibility, but the standard security headers were omitted as a result, leaving the app open to framing and MIME-sniffing vulnerabilities.
+**Learning:** Dropping a comprehensive security dependency (Flask-Talisman) often leads to dropping the foundational security controls it provides, rather than implementing the subset that is safe to use.
+**Prevention:** Implement standard, universally-safe security headers natively (e.g., via `@app.after_request`) when dropping an external security extension to ensure baseline protections are maintained.

--- a/app.py
+++ b/app.py
@@ -131,9 +131,9 @@ def create_app():
     @application.after_request
     def add_security_headers(response):
         """Add standard HTTP security headers to all responses."""
-        response.headers['X-Frame-Options'] = 'DENY'
-        response.headers['X-Content-Type-Options'] = 'nosniff'
-        response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         return response
 
     from scrobblescope.routes import bp

--- a/app.py
+++ b/app.py
@@ -128,6 +128,14 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add standard HTTP security headers to all responses."""
+        response.headers['X-Frame-Options'] = 'DENY'
+        response.headers['X-Content-Type-Options'] = 'nosniff'
+        response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -34,6 +34,7 @@ class TestValidateSecretKey:
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
 
+
 class TestSecurityHeaders:
     def test_security_header_x_frame_options(self, client):
         response = client.get("/test-404-nonexistent-route")
@@ -45,4 +46,6 @@ class TestSecurityHeaders:
 
     def test_security_header_referrer_policy(self, client):
         response = client.get("/test-404-nonexistent-route")
-        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,16 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+class TestSecurityHeaders:
+    def test_security_header_x_frame_options(self, client):
+        response = client.get("/test-404-nonexistent-route")
+        assert response.headers.get("X-Frame-Options") == "DENY"
+
+    def test_security_header_x_content_type_options(self, client):
+        response = client.get("/test-404-nonexistent-route")
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+
+    def test_security_header_referrer_policy(self, client):
+        response = client.get("/test-404-nonexistent-route")
+        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
Added standard HTTP security response headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`) globally via an `after_request` hook. This replaces the baseline controls that were inadvertently dropped when `Flask-Talisman` was discarded due to strict CSP incompatibility. Also included test coverage and documented the finding in the sentinel log.

---
*PR created automatically by Jules for task [1302684133089936386](https://jules.google.com/task/1302684133089936386) started by @pterw*