### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,17 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def set_security_headers(response):
+        """Add standard HTTP security headers globally.
+        Note: Content-Security-Policy (CSP) is intentionally omitted
+        due to inline style conflicts (dropped in Batch 17 WP-5).
+        """
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,21 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_security_headers_applied_globally(self, client):
+        """GIVEN the application is running
+        WHEN a request is made to a guaranteed non-existent endpoint
+        THEN the standard security headers should be present on the response
+        """
+        response = client.get("/test-404-nonexistent-route")
+
+        # We test a 404 response to prove headers are applied globally via after_request
+        # and aren't just limited to successful 200 route responses.
+        assert response.status_code == 404
+
+        headers = response.headers
+        assert headers.get("X-Frame-Options") == "DENY"
+        assert headers.get("X-Content-Type-Options") == "nosniff"
+        assert headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
Added standard HTTP security headers globally to improve the application's overall security posture.

- `X-Frame-Options: DENY`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`

These headers protect against common vulnerabilities such as clickjacking and MIME-type sniffing. Note that Content-Security-Policy (CSP) is intentionally omitted due to a known conflict with inline styles (as documented in `AGENT_NOTES.md`). Tests were added to verify the headers are applied correctly to all endpoints, including error pages.

---
*PR created automatically by Jules for task [2401725816424392761](https://jules.google.com/task/2401725816424392761) started by @pterw*