### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+## 2025-02-28 - Missing Security Headers
+
+**Vulnerability:** The application was missing standard HTTP security headers: `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`.
+
+**Learning:** Although these don't protect against direct exploitation in most APIs, they are essential defense-in-depth protections for web applications to prevent clickjacking, MIME-type sniffing, and cross-origin referrer leakage.
+
+**Prevention:** These can be easily enforced via Flask's `@application.after_request` hook so that they are globally applied to every HTTP response without relying on per-route implementation.

--- a/app.py
+++ b/app.py
@@ -128,6 +128,17 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def set_security_headers(response):
+        """Add standard HTTP security headers to all responses.
+
+        Mitigates clickjacking, MIME-sniffing, and referrer leakage.
+        """
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,12 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+def test_security_headers(client):
+    """Test that standard security headers are applied to all responses."""
+    response = client.get("/test-404-nonexistent-route")
+
+    assert response.headers.get("X-Frame-Options") == "DENY"
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The web application was missing standard defense-in-depth HTTP headers, leaving it potentially exposed to clickjacking, MIME-type sniffing attacks, and cross-origin referrer leakage.
🎯 Impact: Without these headers, malicious sites could embed the application in an iframe to trick users (clickjacking), and browsers could misinterpret file types, potentially executing malicious scripts.
🔧 Fix: Implemented an `@application.after_request` hook in the Flask app factory to globally apply `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` to all HTTP responses.
✅ Verification: Added a test in `tests/test_app_factory.py` to ensure the headers are successfully applied to outgoing responses. Run `pytest` to confirm.

---
*PR created automatically by Jules for task [18080599985380115704](https://jules.google.com/task/18080599985380115704) started by @pterw*