### PR TITLE
🛡️ Sentinel: Add standard HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,14 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def set_security_headers(response):
+        """Apply global security headers to all responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -41,4 +41,6 @@ class TestSecurityHeaders:
 
         assert response.headers.get("X-Frame-Options") == "DENY"
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
-        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,12 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_global_security_headers_present(self, client):
+        response = client.get("/test-404-nonexistent-route")
+
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
As the Sentinel security agent, I noticed the application was missing standard HTTP security headers that provide defense-in-depth against attacks like clickjacking and MIME-type sniffing.

This PR adds an `@application.after_request` hook to `app.py` to globally set the following headers:
- `X-Frame-Options: DENY` (prevents clickjacking by forbidding framing)
- `X-Content-Type-Options: nosniff` (prevents browsers from guessing the MIME type, mitigating some XSS attacks)
- `Referrer-Policy: strict-origin-when-cross-origin` (protects referrer data from leaking cross-origin when downgrading from HTTPS to HTTP)

It also includes a corresponding test in `tests/test_app_factory.py` that verifies these headers are correctly applied.

---
*PR created automatically by Jules for task [6330846637278622934](https://jules.google.com/task/6330846637278622934) started by @pterw*