### PR TITLE
🛡️ Sentinel: Add security headers to responses

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,7 +128,6 @@ def create_app():
             400,
         )
 
-
     @application.after_request
     def add_security_headers(response):
         """Add standard HTTP security headers to all responses."""

--- a/app.py
+++ b/app.py
@@ -128,6 +128,15 @@ def create_app():
             400,
         )
 
+
+    @application.after_request
+    def add_security_headers(response):
+        """Add standard HTTP security headers to all responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,11 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+    def test_global_security_headers_are_applied(self, client):
+        """Verify that standard security headers are present on responses."""
+        # Request a guaranteed non-existent route so we only test the global hooks.
+        response = client.get("/test-404-nonexistent-route")
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -40,4 +40,6 @@ class TestValidateSecretKey:
         response = client.get("/test-404-nonexistent-route")
         assert response.headers.get("X-Frame-Options") == "DENY"
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
-        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
🛡️ Sentinel: Add security headers to responses

🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers. The application did not have standard security headers such as `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy`. This makes it vulnerable to attacks like clickjacking, MIME-sniffing, and referrer leakage.
🎯 Impact: Without these headers, an attacker could potentially embed the site in an iframe to trick users (clickjacking), cause browsers to misinterpret file types (MIME-sniffing leading to XSS), or leak sensitive URLs in the Referer header.
🔧 Fix: Added an `@application.after_request` hook in `app.py` to add standard security headers to all HTTP responses. Also added testing coverage to verify the headers are applied correctly to nonexistent routes (which forces evaluation of global hooks).
✅ Verification: Ran unit tests (tests/test_app_factory.py) which execute successfully. You can verify this by checking any response headers.

---
*PR created automatically by Jules for task [2008512406150971630](https://jules.google.com/task/2008512406150971630) started by @pterw*