### PR TITLE
🛡️ Sentinel: Add standard HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,19 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add standard HTTP security headers to all responses.
+
+        Note: Content-Security-Policy (CSP) and Flask-Talisman are intentionally
+        omitted due to heavy reliance on inline styles in templates (e.g.,
+        SVG defs, progress bars). A strict CSP would break functionality.
+        """
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,14 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_global_security_headers(self, client):
+        """Verify that standard HTTP security headers are added to all responses."""
+        response = client.get("/test-404-nonexistent-route")
+
+        # Test headers that should be present
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -43,4 +43,6 @@ class TestSecurityHeaders:
         # Test headers that should be present
         assert response.headers.get("X-Frame-Options") == "DENY"
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
-        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
Added an `@application.after_request` hook in `app.py` to globally set standard security headers: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin`. CSP and Flask-Talisman were explicitly omitted due to the application's reliance on inline styles in the frontend templates, which would be broken by a strict CSP. Also added a `TestSecurityHeaders` class in `tests/test_app_factory.py` to verify the headers are applied correctly to all responses.

---
*PR created automatically by Jules for task [18274553137859197696](https://jules.google.com/task/18274553137859197696) started by @pterw*