### PR TITLE
🛡️ Sentinel: [MEDIUM] Add global security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,6 +114,14 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def set_security_headers(response):
+        """Apply standard HTTP security headers globally."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,16 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_global_security_headers_applied(self, client):
+        # We test against a guaranteed non-existent route so we test the
+        # global hook behavior on 404 responses without hitting specific route logic.
+        response = client.get("/test-404-nonexistent-route")
+        assert response.status_code == 404
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add global security headers

**🚨 Severity:** MEDIUM
**💡 Vulnerability:** Missing standard HTTP response headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy) which leaves the application lacking baseline defense-in-depth protections against clickjacking, MIME sniffing, and unintended referrer leakage.
**🎯 Impact:** While not a direct exploit vector on its own, missing these headers makes it easier for other vulnerabilities (if present) to be exploited or chained, particularly in modern browser environments.
**🔧 Fix:** Implemented a global `@application.after_request` hook in `app.py` to ensure that all Flask responses (including error pages like 404s) have these three standard security headers appended. Explicitly excluded CSP per repository constraints. Added a unit test in `tests/test_app_factory.py`.
**✅ Verification:** The new tests specifically call a 404 route using the test client and assert that all three headers are correctly returned. Pre-commit formatters and the full test suite pass successfully.

---
*PR created automatically by Jules for task [5170793227260226998](https://jules.google.com/task/5170793227260226998) started by @pterw*