### PR TITLE
🛡️ Sentinel: [security improvement] Add standard HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,19 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add standard HTTP security headers to all responses.
+
+        Note: Content-Security-Policy (CSP) is intentionally omitted here
+        because a strict CSP broke inline styles and was deemed not currently
+        viable for this application.
+        """
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,19 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_security_header_x_frame_options(self, client):
+        response = client.get("/test-404-nonexistent-route")
+        assert response.headers.get("X-Frame-Options") == "DENY"
+
+    def test_security_header_x_content_type_options(self, client):
+        response = client.get("/test-404-nonexistent-route")
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+
+    def test_security_header_referrer_policy(self, client):
+        response = client.get("/test-404-nonexistent-route")
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

### 🚨 Severity: ENHANCEMENT
### 💡 Vulnerability: The application previously did not set standard HTTP security headers on its responses.
### 🎯 Impact: Setting `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` prevents clickjacking, MIME-type sniffing, and cross-origin referrer leakage respectively, providing a valuable defense-in-depth security layer.
### 🔧 Fix: Added an `@application.after_request` hook to `create_app()` in `app.py` to append these three headers to all HTTP responses. I intentionally did not add a `Content-Security-Policy` (CSP) header because previous explorations determined a strict CSP breaks inline styling (SVGs and Bootstrap progress bars).
### ✅ Verification: 
- `pytest -q` passes (353 passed).
- Unit tests added to `tests/test_app_factory.py` verify that `X-Frame-Options`, `X-Content-Type-Options`, and `Referrer-Policy` are returned.
- `pre-commit run --all-files` passes.

---
*PR created automatically by Jules for task [7917295325136660457](https://jules.google.com/task/7917295325136660457) started by @pterw*