### PR TITLE
🛡️ Sentinel: [MEDIUM] Add global security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,6 +114,17 @@ def create_app():
 
     csrf.init_app(application)
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add global HTTP security headers to all responses.
+
+        Note: CSP is intentionally omitted per YAGNI (Batch 17 WP-5).
+        """
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     @application.errorhandler(CSRFError)
     def handle_csrf_error(e):
         """Return a user-friendly error page on CSRF token validation failure."""

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,15 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_security_headers_present(self, client):
+        """Verify that global security headers are correctly applied to responses."""
+        response = client.get("/test-404-nonexistent-route")
+
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing security headers. The application did not emit standard security headers.
🎯 Impact: Without X-Frame-Options, the application is vulnerable to clickjacking. Without X-Content-Type-Options, browsers might sniff the content type, leading to MIME-type confusion attacks. Without Referrer-Policy, the application might leak sensitive data in the Referer header when navigating to cross-origin sites.
🔧 Fix: Added an `@application.after_request` hook in the `create_app` factory in `app.py` to add `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` to all responses.
✅ Verification: Ensure tests pass locally (`python3 -m pytest tests/test_app_factory.py`). Observe network tab responses to verify the headers are set.

---
*PR created automatically by Jules for task [12969100467075196957](https://jules.google.com/task/12969100467075196957) started by @pterw*