### PR TITLE
🛡️ Sentinel: [security improvement] Add standard HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,14 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add standard security headers to all responses."""
+        response.headers['X-Frame-Options'] = 'DENY'
+        response.headers['X-Content-Type-Options'] = 'nosniff'
+        response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/app.py
+++ b/app.py
@@ -131,9 +131,9 @@ def create_app():
     @application.after_request
     def add_security_headers(response):
         """Add standard security headers to all responses."""
-        response.headers['X-Frame-Options'] = 'DENY'
-        response.headers['X-Content-Type-Options'] = 'nosniff'
-        response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         return response
 
     from scrobblescope.routes import bp

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -38,4 +38,6 @@ class TestValidateSecretKey:
         response = client.get("/test-404-nonexistent-route")
         assert response.headers.get("X-Frame-Options") == "DENY"
         assert response.headers.get("X-Content-Type-Options") == "nosniff"
-        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,9 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+    def test_security_headers_applied(self, client):
+        response = client.get("/test-404-nonexistent-route")
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Missing standard HTTP security headers leaves the application more vulnerable to some common web attacks such as clickjacking and MIME-sniffing.
🎯 **Impact**: An attacker could potentially iframe the site for clickjacking, or execute unintended content due to MIME-type sniffing.
🔧 **Fix**: Added `@application.after_request` hook in `app.py` to globally set `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` on all responses.
✅ **Verification**: Added `test_security_headers_applied` to `tests/test_app_factory.py` to ensure these headers are applied on all requests, even 404s. The test suite passes locally.

---
*PR created automatically by Jules for task [10491535501439297189](https://jules.google.com/task/10491535501439297189) started by @pterw*