### PR TITLE
🛡️ Sentinel: [security improvement] Add standard security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,14 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add standard security headers to prevent framing, MIME-sniffing, and cross-origin referrer leakage."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,14 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_global_security_headers_applied(self, client):
+        response = client.get("/test-404-nonexistent-route")
+
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers exposes the application to common web vulnerabilities like clickjacking, MIME-type sniffing, and cross-origin information leakage.
🎯 Impact: Attackers could potentially embed the application in malicious iframes, sniff content types, or leak sensitive referrer information across origins.
🔧 Fix: Implemented an `@application.after_request` hook in the `create_app` factory in `app.py` to inject `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin` on all HTTP responses.
✅ Verification: Added a test `test_global_security_headers_applied` in `tests/test_app_factory.py` that hits a non-existent route and verifies that the headers are properly attached. Tests and linting pass successfully.

---
*PR created automatically by Jules for task [8023369772559646484](https://jules.google.com/task/8023369772559646484) started by @pterw*