### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,14 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add standard HTTP security headers globally."""
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,22 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_global_security_headers(self):
+        import os
+
+        from app import create_app
+
+        os.environ["SECRET_KEY"] = "test-only-secret-key-min-16chars!!"
+        app = create_app()
+        app.config["TESTING"] = True
+        with app.test_client() as client:
+            response = client.get("/test-404-nonexistent-route")
+            assert response.headers.get("X-Content-Type-Options") == "nosniff"
+            assert response.headers.get("X-Frame-Options") == "DENY"
+            assert (
+                response.headers.get("Referrer-Policy")
+                == "strict-origin-when-cross-origin"
+            )


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in responses, such as `X-Content-Type-Options`, `X-Frame-Options`, and `Referrer-Policy`. This makes the application more susceptible to MIME sniffing, clickjacking, and referrer leakage.
🎯 Impact: Attackers could potentially exploit MIME sniffing to execute malicious scripts, clickjacking to deceive users into performing unintended actions, and referrer leakage to access sensitive information.
🔧 Fix: Added an `@application.after_request` hook in `app.py` to globally set `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, and `Referrer-Policy: strict-origin-when-cross-origin` on all responses.
✅ Verification: Ensure the test suite passes (`pytest`) and verify the `TestSecurityHeaders` class correctly checks for the presence of these headers.

---
*PR created automatically by Jules for task [12693504594549144400](https://jules.google.com/task/12693504594549144400) started by @pterw*