### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,18 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add standard HTTP security headers to all responses."""
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        if not debug_mode:
+            response.headers["Strict-Transport-Security"] = (
+                "max-age=31536000; includeSubDomains"
+            )
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,18 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+class TestSecurityHeaders:
+    def test_security_headers_present(self, client):
+        response = client.get("/test-404-nonexistent-route")
+
+        assert response.headers.get("X-Frame-Options") == "DENY"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert (
+            response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        )
+
+        # In test mode debug_mode is usually inherited, so we test existence or check test configuration
+        # Since the test client might run with debug_mode inherited from app.py globals
+        # We just verify the basic headers are always there


### PR DESCRIPTION
## 🛡️ Sentinel: Security Improvement

### 🎯 What
Added standard HTTP security headers globally to all responses via an `@application.after_request` hook in `app.py`. The headers implemented are:
* `X-Frame-Options: DENY`
* `X-Content-Type-Options: nosniff`
* `Referrer-Policy: strict-origin-when-cross-origin`
* `Strict-Transport-Security: max-age=31536000; includeSubDomains` (only enforced when not in debug mode to allow local testing)

### 💡 Why
These headers provide essential defense-in-depth protections:
* Prevent clickjacking attacks (X-Frame-Options)
* Prevent MIME-sniffing vulnerabilities (X-Content-Type-Options)
* Protect sensitive information in the Referer header (Referrer-Policy)
* Enforce HTTPS connections (Strict-Transport-Security)

### ✅ Verification
* Ran the complete test suite (351 tests passed)
* Added a specific test `TestSecurityHeaders` in `tests/test_app_factory.py` to verify header presence on a 404 endpoint.
* Ran `pre-commit run --all-files` successfully.

---
*PR created automatically by Jules for task [10871813831700493585](https://jules.google.com/task/10871813831700493585) started by @pterw*