### PR TITLE
🛡️ Sentinel: [security improvement] Add basic HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,19 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add basic HTTP security headers to all responses.
+
+        - X-Content-Type-Options: prevents MIME-sniffing
+        - X-Frame-Options: mitigates Clickjacking attacks
+        - Referrer-Policy: protects referrer information when crossing origins
+        """
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,15 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+def test_security_headers_present(client):
+    """Test that all basic security headers are set on an arbitrary response.
+
+    Using a 404 (non-existent route) ensures the @after_request hook
+    runs for everything globally.
+    """
+    response = client.get("/test-404-nonexistent-route")
+    assert response.status_code == 404
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -34,6 +34,7 @@ class TestValidateSecretKey:
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
 
+
 def test_security_headers_present(client):
     """Test that all basic security headers are set on an arbitrary response.
 


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Add basic HTTP security headers

**🎯 What:**
Added basic HTTP security response headers (`X-Content-Type-Options`, `X-Frame-Options`, and `Referrer-Policy`) globally across the Flask application using an `@after_request` hook. Included a unit test to verify their presence on responses (including 404s).

**💡 Why:**
The application previously lacked these fundamental security headers, leaving it potentially vulnerable to MIME-sniffing, clickjacking, and unintended referrer information leakage. This enhancement improves the defense-in-depth posture of the application using established, safe defaults.

**✅ Verification:**
Ran `pytest tests/test_app_factory.py` and the full test suite (`pytest`) to ensure the newly added test passes and no regressions were introduced.

**✨ Result:**
The application now securely serves responses with appropriate security headers, mitigating several common web vulnerabilities.

---
*PR created automatically by Jules for task [17053173297546628107](https://jules.google.com/task/17053173297546628107) started by @pterw*