### PR TITLE
🛡️ Sentinel: [security improvement] Add basic HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,14 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add basic security headers to all responses to prevent MIME-sniffing, clickjacking, and referrer leakage."""
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,11 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+def test_security_headers(client):
+    """Verify basic HTTP security headers are injected into responses."""
+    response = client.get("/test-404-nonexistent-route")
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
Adds standard HTTP security response headers (`X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, and `Referrer-Policy: strict-origin-when-cross-origin`) to all Flask responses using an `@after_request` hook in `app.py`. A corresponding test has been added to `test_app_factory.py` to ensure their presence. This provides defense in depth without adding external dependencies.

---
*PR created automatically by Jules for task [18238988586137675067](https://jules.google.com/task/18238988586137675067) started by @pterw*