### PR TITLE
🛡️ Sentinel: [security improvement] Add basic HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,20 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Inject basic HTTP security headers into all responses.
+
+        Addresses missing security headers:
+        - X-Frame-Options: prevents clickjacking by refusing to render in a frame.
+        - X-Content-Type-Options: prevents MIME-sniffing by forcing adherence to Content-Type.
+        - Referrer-Policy: limits referrer information sent to cross-origin destinations.
+        """
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,21 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+def test_security_header_x_frame_options(client):
+    """Test that X-Frame-Options is set to DENY to prevent clickjacking."""
+    response = client.get("/test-404-nonexistent-route")
+    assert response.headers.get("X-Frame-Options") == "DENY"
+
+
+def test_security_header_x_content_type_options(client):
+    """Test that X-Content-Type-Options is set to nosniff to prevent MIME sniffing."""
+    response = client.get("/test-404-nonexistent-route")
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+
+
+def test_security_header_referrer_policy(client):
+    """Test that Referrer-Policy is set to strict-origin-when-cross-origin."""
+    response = client.get("/test-404-nonexistent-route")
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Add basic security headers

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application was not setting basic HTTP security headers.
🎯 **Impact:** Browsers could potentially be tricked into MIME-sniffing files, framing the application (clickjacking), or leaking sensitive URLs to external domains.
🔧 **Fix:** Added an `after_request` hook in `app.py` to set `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: strict-origin-when-cross-origin`.
✅ **Verification:** Verified that tests pass via `pytest` and that the headers are included in 404 responses to confirm global application.

---
*PR created automatically by Jules for task [8538493618273027804](https://jules.google.com/task/8538493618273027804) started by @pterw*