### PR TITLE
🛡️ Sentinel: [security improvement] Add standard HTTP security headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -128,6 +128,14 @@ def create_app():
             400,
         )
 
+    @application.after_request
+    def add_security_headers(response):
+        """Add basic security headers to all responses."""
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
     from scrobblescope.routes import bp
 
     application.register_blueprint(bp)

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -33,3 +33,11 @@ class TestValidateSecretKey:
 
     def test_succeeds_with_strong_key_in_production(self):
         _validate_secret_key(_STRONG_KEY, is_dev_mode=False)
+
+
+def test_security_headers(client):
+    """Test that all responses include basic security headers."""
+    response = client.get("/")
+    assert response.headers.get("X-Content-Type-Options") == "nosniff"
+    assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"
+    assert response.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"


### PR DESCRIPTION
🛡️ **Sentinel: [security improvement] Add standard HTTP security headers**

**What**
Injected an `@application.after_request` hook in the Flask app factory (`app.py`) to append essential HTTP security headers to all responses. The added headers are:
- `X-Content-Type-Options: nosniff` (Mitigates MIME-sniffing vulnerabilities)
- `X-Frame-Options: SAMEORIGIN` (Mitigates clickjacking attacks)
- `Referrer-Policy: strict-origin-when-cross-origin` (Prevents referrer leakage)

**Why**
Adding these headers provides defense-in-depth and aligns the application with universally recommended web security best practices, protecting users against common attack vectors like clickjacking and unexpected script execution.

**Verification**
- Added `test_security_headers` to `tests/test_app_factory.py`.
- Ran the full test suite (`python3 -m pytest`); all 351 tests pass.

---
*PR created automatically by Jules for task [10284111347118733471](https://jules.google.com/task/10284111347118733471) started by @pterw*