### PR TITLE
docs(playbook): mark Batch 20 WP-5 complete and advance next action t…

### DIFF
--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -19,7 +19,7 @@ Last updated: 2026-07-23
 | Batch 17 status | **Complete**. All 4 WPs done (WP-5 dropped). Definition: `docs/history/definitions/BATCH17_DEFINITION.md`. |
 | Batch 18 status | **Complete**. All 5 WPs done. Definition: `docs/history/definitions/BATCH18_DEFINITION.md`. |
 | Batch 19 status | **Complete**. All 5 WPs done plus owner-review follow-up. Definition: `docs/history/definitions/BATCH19_DEFINITION.md`. PR #152 merged to `main`. |
-| Batch 20 status | **Active.** File-hygiene + docs methodology refresh. WP-0 through WP-4 done. Definition: `BATCH20_DEFINITION.md`. |
+| Batch 20 status | **Active.** File-hygiene + docs methodology refresh. WP-0 through WP-5 done. Definition: `BATCH20_DEFINITION.md`. |
 | Batch 21 status | **Placeholder (renumbered from Batch 20).** Scope TBD: global UI overhaul. Definition stub: `BATCH21_DEFINITION.md`. No WP work until owner finalizes scope from audit PDF. |
 | Known open risk | `RotatingFileHandler` throws `PermissionError: [WinError 32]` on Windows when multiple Flask processes hold the log file open (Werkzeug debug reloader). Cosmetic -- Flask continues to serve. Linux/Fly.io unaffected. |
 
@@ -45,11 +45,11 @@ Last updated: 2026-07-23
 <!-- DOCSYNC:STATUS-START -->
 - Source of truth: `PLAYBOOK.md` (Section 3 and Section 4).
 - Current batch: Batch 20.
-- Current-batch entries in active log block: 5.
-- Completed work packages in current-batch entries: WP-0, WP-1, WP-2, WP-3, WP-4.
-- Next expected work package: WP-5.
+- Current-batch entries in active log block: 6.
+- Completed work packages in current-batch entries: WP-0, WP-1, WP-2, WP-3, WP-4, WP-5.
+- Next expected work package: WP-6.
 - Latest validated test count: **390 passed**.
-- Newest current-batch entry: 2026-07-24 - DEVELOPMENT.md path/timeline/prose cleanup (Batch 20 WP-4).
+- Newest current-batch entry: 2026-07-24 - DEVELOPMENT.md skills subsection (Batch 20 WP-5).
 <!-- DOCSYNC:STATUS-END -->
 
 ---

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -75,8 +75,8 @@ Completed batch definitions are archived individually under `docs/history/`.
   (font stack, palette integration, index card rework, Bootstrap CDN
   consolidation) driven by an owner audit PDF. No WP work begins until
   scope lands.
-- **Next action:** Batch 20 WP-5 (DEVELOPMENT.md: skills subsection).
-- Batch 20 WP status: WP-0 through WP-4 done. WP-5 through WP-8 not yet started.
+- **Next action:** Batch 20 WP-6 (FINDINGS.md: cleanup and archive).
+- Batch 20 WP status: WP-0 through WP-5 done. WP-6 through WP-8 not yet started.
 - **Perf note (measured 2026-05-16):** Heatmap fetch for `flounder14`
   (103 pages) took 10.9s. `lastfm.py` already uses `limit=200` and concurrent
   `as_completed` fetching. 10.9s is the rate-limit floor (103 pages /
@@ -196,6 +196,18 @@ non-current operational logs. Older dated entries live in
   all hooks pass.
 - Forward guidance: WP-5 adds the Claude Code skills subsection in
   `DEVELOPMENT.md`.
+
+### 2026-07-24 - DEVELOPMENT.md skills subsection (Batch 20 WP-5)
+
+- Scope: completed Batch 20 WP-5 in `DEVELOPMENT.md`.
+- Plan vs implementation:
+  - Added the "Claude Code Skills (tightly scoped tooling)" subsection
+    (lines 219-243) documenting `scrobblescope-bootstrap` and
+    `gemini-pr-triage` skills with their deliberately single-agent scope.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files` --
+  all hooks pass.
+- Forward guidance: WP-6 handles FINDINGS.md cleanup and archive.
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 


### PR DESCRIPTION
…o WP-6

## Summary

<!-- What changed and why -->

## Checklist

- [ ] `pytest -q` passes (update SESSION_CONTEXT Section 1 if test count changed)
- [ ] `pre-commit run --all-files` passes (all hooks)
- [ ] `python scripts/doc_state_sync.py --check` exits 0
- [ ] PLAYBOOK Section 3 reflects current WP/task state
- [ ] PLAYBOOK Section 4 has a dated log entry:
      - Batch WP: inside `DOCSYNC:CURRENT-BATCH-START/END` markers
      - Side task: after `DOCSYNC:CURRENT-BATCH-END` marker
- [ ] Changes are within scope of the active batch definition
      (or deviation is logged in the Section 4 entry)
