### PR TITLE
docs: complete Batch 20 -- audit gap fixes, FINDINGS standard, close-out

### DIFF
--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -8,7 +8,7 @@ Last updated: 2026-07-24
 
 | Item | Value |
 |------|-------|
-| Branch | `file-hygeine` |
+| Branch | `wip/batch-20` |
 | Tests | **390 passing** across 22 test modules |
 | Coverage | ~72% (2026-02-20 audit run) |
 | Pre-commit | All hooks pass |

--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -45,11 +45,11 @@ Last updated: 2026-07-24
 <!-- DOCSYNC:STATUS-START -->
 - Source of truth: `PLAYBOOK.md` (Section 3 and Section 4).
 - Current batch: Batch 20.
-- Current-batch entries in active log block: 6.
-- Completed work packages in current-batch entries: WP-0, WP-1, WP-2, WP-3, WP-4, WP-5.
-- Next expected work package: WP-6.
+- Current-batch entries in active log block: 7.
+- Completed work packages in current-batch entries: WP-0, WP-1, WP-2, WP-3, WP-4, WP-5, WP-6.
+- Next expected work package: WP-7.
 - Latest validated test count: **390 passed**.
-- Newest current-batch entry: 2026-07-24 - DEVELOPMENT.md skills subsection (Batch 20 WP-5).
+- Newest current-batch entry: 2026-07-24 - FINDINGS.md cleanup and archive (Batch 20 WP-6).
 <!-- DOCSYNC:STATUS-END -->
 
 ---

--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -19,8 +19,8 @@ Last updated: 2026-07-24
 | Batch 17 status | **Complete**. All 4 WPs done (WP-5 dropped). Definition: `docs/history/definitions/BATCH17_DEFINITION.md`. |
 | Batch 18 status | **Complete**. All 5 WPs done. Definition: `docs/history/definitions/BATCH18_DEFINITION.md`. |
 | Batch 19 status | **Complete**. All 5 WPs done plus owner-review follow-up. Definition: `docs/history/definitions/BATCH19_DEFINITION.md`. PR #152 merged to `main`. |
-| Batch 20 status | **Active.** File-hygiene + docs methodology refresh. WP-0 through WP-5 done. Definition: `BATCH20_DEFINITION.md`. |
-| Batch 21 status | **Placeholder (renumbered from Batch 20).** Scope TBD: global UI overhaul. Definition stub: `BATCH21_DEFINITION.md`. No WP work until owner finalizes scope from audit PDF. |
+| Batch 20 status | **Complete**. All 9 WPs done. Definition: `docs/history/definitions/BATCH20_DEFINITION.md`. |
+| Batch 21 status | **Next batch.** Scope TBD: global UI overhaul. Definition stub: `BATCH21_DEFINITION.md`. Owner is drafting the UI proposal; no WP work until scope lands. |
 | Known open risk | `RotatingFileHandler` throws `PermissionError: [WinError 32]` on Windows when multiple Flask processes hold the log file open (Werkzeug debug reloader). Cosmetic -- Flask continues to serve. Linux/Fly.io unaffected. |
 
 **Key runtime facts:**
@@ -44,12 +44,12 @@ Last updated: 2026-07-24
 
 <!-- DOCSYNC:STATUS-START -->
 - Source of truth: `PLAYBOOK.md` (Section 3 and Section 4).
-- Current batch: Batch 20.
-- Current-batch entries in active log block: 8.
-- Completed work packages in current-batch entries: WP-0, WP-1, WP-2, WP-3, WP-4, WP-5, WP-6, WP-7.
-- Next expected work package: WP-8.
+- Current batch: Batch 21.
+- Current-batch entries in active log block: 1.
+- Completed work packages in current-batch entries: none.
+- Next expected work package: unknown.
 - Latest validated test count: **390 passed**.
-- Newest current-batch entry: 2026-07-24 - FINDINGS on-demand rule + finding-writing standard (Batch 20 WP-7).
+- Newest current-batch entry: 2026-07-24 - Batch 20 complete; definition archived, log purged (Batch 20 close-out).
 <!-- DOCSYNC:STATUS-END -->
 
 ---

--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -45,11 +45,11 @@ Last updated: 2026-07-24
 <!-- DOCSYNC:STATUS-START -->
 - Source of truth: `PLAYBOOK.md` (Section 3 and Section 4).
 - Current batch: Batch 20.
-- Current-batch entries in active log block: 7.
-- Completed work packages in current-batch entries: WP-0, WP-1, WP-2, WP-3, WP-4, WP-5, WP-6.
-- Next expected work package: WP-7.
+- Current-batch entries in active log block: 8.
+- Completed work packages in current-batch entries: WP-0, WP-1, WP-2, WP-3, WP-4, WP-5, WP-6, WP-7.
+- Next expected work package: WP-8.
 - Latest validated test count: **390 passed**.
-- Newest current-batch entry: 2026-07-24 - FINDINGS.md cleanup and archive (Batch 20 WP-6).
+- Newest current-batch entry: 2026-07-24 - FINDINGS on-demand rule + finding-writing standard (Batch 20 WP-7).
 <!-- DOCSYNC:STATUS-END -->
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,8 +401,11 @@ grep history.
 2. **Required fields:** the F-ID heading, a one-sentence problem statement,
    a `Status:` line, and a `Source:` line when the finding came from a
    named audit or session.
-3. **Rotation:** resolved and no-action items move to the archive with
-   their original F-ID and a `-- RESOLVED` / `-- NO ACTION` suffix.
+3. **Rotation:** resolved and closed no-action items move to the archive
+   with their original F-ID and a `-- RESOLVED` / `-- NO ACTION` suffix.
+   Standing design-decision Info items (documentation of deliberate,
+   still-current choices) keep their F-IDs in the active file and rotate
+   only when superseded.
 4. **Cross-references:** promoted or absorbed findings keep a one-line
    pointer in the "Deferred / future-batch candidates" block (for
    example, `F-B18-1 -- promoted to F-B20-2`) so old IDs stay resolvable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,15 @@ only the minimum bootstrap/context files needed to answer that thread. Open
 batch definitions or archive/history docs only when the linked comment
 explicitly depends on batch-acceptance or historical context.
 
-1. `.claude/SESSION_CONTEXT.md` -- current batch, test count, architecture, risks.
-2. `PLAYBOOK.md` Section 3 (next action) + Section 4 (current-batch log).
-3. Relevant `docs/history/` doc if the log references one.
+1. `PLAYBOOK.md` Section 3 (next action) + Section 4 (current-batch log).
+2. The batch definition file named in Section 3 (repo root while active;
+   under `docs/history/definitions/` once the batch is closed).
+3. `.claude/SESSION_CONTEXT.md` -- current batch, test count, architecture, risks.
 4. `AGENT_NOTES.md` -- owner preferences, local dev setup, constraints.
+5. Relevant `docs/history/` doc only if the log references one.
+6. `FINDINGS.md` -- read on demand only: when PLAYBOOK Section 4 or your
+   task explicitly references an F-* finding ID or an open P0/P1 item.
+   Not part of the mandatory bootstrap set.
 
 If SESSION_CONTEXT Section 1 and PLAYBOOK Section 3 agree on the current batch
 and next WP, you have enough context to start.
@@ -370,6 +375,37 @@ Agents must check their work against this list before committing.
    owner's terminal. Never start a server via the Bash tool. The owner runs
    the app in their own terminal. To probe a running server use
    `python -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1:5000/').status)"`.
+6. **Naive-tz vacuous datetime tests (PR #152, F-B19-6):** A datetime test
+   that builds its inputs with the same tz-awareness pattern (naive vs
+   aware) as the code under test compares the code against itself, not
+   against an invariant -- it passes even if the code silently regresses
+   to a naive-tz day-shift bug. Build test inputs with explicit `tzinfo=`
+   and assert on a date that would shift under a naive interpretation.
+   Canonical example: `tests/test_heatmap.py::TestAggregateDailyCounts::`
+   `test_utc_decode_invariant_against_local_tz_drift`.
+
+---
+
+## Finding-Writing Rules
+
+Findings live in `FINDINGS.md` (active) and rotate to
+`docs/history/findings/FINDINGS_ARCHIVE.md` at batch close-out or during a
+dedicated findings-cleanup WP. Nothing is deleted -- the archive preserves
+grep history.
+
+1. **F-ID format:** every item heading is `F-<context>-<N>: <title>`.
+   Context is a batch tag (`B18`, `B19`, `B20`, ...) or a source tag
+   (`MAS` for MULTI_AGENT_SWEEP, `DOCSYNC`, `AUDIT`, `LOAD` for the
+   load-testing session); `FEATURE` covers feature-prep notes. No
+   bare-numbered items in FINDINGS.md.
+2. **Required fields:** the F-ID heading, a one-sentence problem statement,
+   a `Status:` line, and a `Source:` line when the finding came from a
+   named audit or session.
+3. **Rotation:** resolved and no-action items move to the archive with
+   their original F-ID and a `-- RESOLVED` / `-- NO ACTION` suffix.
+4. **Cross-references:** promoted or absorbed findings keep a one-line
+   pointer in the "Deferred / future-batch candidates" block (for
+   example, `F-B18-1 -- promoted to F-B20-2`) so old IDs stay resolvable.
 
 ---
 

--- a/AGENT_NOTES.md
+++ b/AGENT_NOTES.md
@@ -129,10 +129,11 @@ only in the current process environment and is gone when the shell exits.
 - **Core feature definition:** `docs/history/definitions/BATCH18_DEFINITION.md`.
 - **Batch 19 polish definition (archived):** `docs/history/definitions/BATCH19_DEFINITION.md`.
   Closed out 2026-05-19; PR #152 (`feat/heatmap` -> `main`) merged.
-- **Batch 21 placeholder definition:** `BATCH21_DEFINITION.md` at repo root
-  (renumbered from Batch 20). Scope is TBD (global UI overhaul, owner audit
-  PDF). No WP work until owner finalizes scope. Batch 20 is now active for
-  file-hygiene + docs methodology refresh; see `BATCH20_DEFINITION.md`.
+- **Batch 21 definition stub (next batch):** `BATCH21_DEFINITION.md` at repo
+  root (renumbered from Batch 20). Scope is TBD (global UI overhaul, owner
+  audit PDF; owner drafting the proposal). No WP work until scope lands.
+  Batch 20 (file-hygiene + docs methodology refresh) is complete; its
+  definition is archived at `docs/history/definitions/BATCH20_DEFINITION.md`.
 - **Batch 19 scope:** frame/headline/KPIs result redesign, "Top Albums" pill
   rename, pinwheel/loading polish, mobile heatmap layout, and stale
   documentation cleanup. Full app palette/font rebrand remains deferred.

--- a/BATCH20_DEFINITION.md
+++ b/BATCH20_DEFINITION.md
@@ -1,8 +1,8 @@
 # BATCH20: File-hygiene + docs methodology refresh
 
-**Status:** Definition awaiting owner audit.
-**Branch:** `file-hygeine` (off `main` after committing `.gitignore` exclusion of `CLAUDE.md` and pushing).
-**Baseline:** 389 tests passing (post PR #152 merge to main; no code changes in this batch should move the count).
+**Status:** Active. WP-0 through WP-5 merged to `main` via PR #159; WP-6 through WP-8 remain.
+**Branch:** `wip/batch-20` (worktree off `main`; earlier WPs landed via `file-hygeine`).
+**Baseline:** 390 tests passing (389 at batch open; +1 regression test from the WP-5 docsync scan-order deviation).
 
 ---
 

--- a/BATCH21_DEFINITION.md
+++ b/BATCH21_DEFINITION.md
@@ -2,7 +2,7 @@
 
 **Status:** Placeholder. Scope to be defined when owner finalizes the audit-PDF-driven plan. Renumbered from Batch 20 on 2026-05-22 so Batch 20 (file-hygiene + docs methodology refresh) could be slotted ahead of the UI work.
 **Branch:** to be decided when scope is finalized.
-**Baseline:** 389 tests passing (Batch 19 close-out + PR #152 fixes; same number as Batch 20 baseline).
+**Baseline:** 390 tests passing (Batch 20 close-out; 389 at Batch 20 open, +1 regression test from the WP-5 docsync deviation).
 
 ---
 

--- a/BATCH21_DEFINITION.md
+++ b/BATCH21_DEFINITION.md
@@ -42,7 +42,9 @@ cleanly. Owner ideas captured during Batch 19 review:
 - **Dark-mode toggle placement on mobile.** F-B18/F-B19 noted the
   fixed-position toggle may overlap content on small screens.
 
-Documented in FINDINGS.md F-B19-4 and F-B19-5.
+Documented in FINDINGS.md F-B19-4 (deferred block); F-B19-5
+(visual-verification tooling) is archived at
+`docs/history/findings/FINDINGS_ARCHIVE.md`.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -225,10 +225,12 @@ locally and are not tracked in this repository (`.gitignore` excludes `.claude/`
 except `SESSION_CONTEXT.md`); this section documents their purpose for context.
 
 **`scrobblescope-bootstrap`** runs the canonical session bootstrap in a fixed
-read order: `.claude/SESSION_CONTEXT.md` Sections 1-2, then `PLAYBOOK.md`
-Sections 3-4, stopping early if those two sources agree on the current batch
-and next work package. `AGENT_NOTES.md` is read only when early-stop does not
-trigger and owner constraints are needed. Invoke it at the start of any
+read order: `AGENTS.md`, then `PLAYBOOK.md` Sections 3-4, the active batch
+definition named there, `.claude/SESSION_CONTEXT.md` Sections 1-2, and
+`AGENT_NOTES.md`, finishing with a git-state and test-baseline check against
+what those files claim. If PLAYBOOK Section 3 and SESSION_CONTEXT Section 1
+agree on the current batch and next work package, the agent has enough
+context to start. Invoke it at the start of any
 substantive session -- new feature work, refactors, or multi-WP batch work.
 Skip it when the change is too small to require batch context; the skill
 illustrates this with the anti-example "tweak the heatmap pill padding," a

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -57,13 +57,6 @@ Global font stack, palette integration, index card rework, and the
 remaining F-B19-4 audit notes; Batch 21 main scope, possible Batch 22
 contingency. Status: open; scope lands via `BATCH21_DEFINITION.md`.
 
-### F-B19-6: register naive-tz vacuous-test anti-pattern in AGENTS.md
-
-Code fix archived; open portion: record in the AGENTS.md anti-pattern
-registry that datetime tests building inputs with the SUT's tz-awareness
-pattern are vacuous against tz bugs -- use explicit `tzinfo=` and assert
-on a date that shifts under naive decoding. Status: open (WP-7 candidate).
-
 ### F-B18-11: heatmap Last.fm page fetch is rate-limit bound
 
 Fetch time is bound by page count and the shared 10 req/s throttle

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,8 +1,8 @@
 # ScrobbleScope Findings & Open Issues
 
 Last updated: 2026-07-24
-Status: Batch 20 active (file-hygiene + docs methodology refresh).
-390 tests across 22 test modules.
+Status: Batch 20 complete; Batch 21 (UI overhaul) is next, scope pending
+the owner's proposal. 390 tests across 22 test modules.
 
 **Rotation policy:** resolved and no-action findings rotate to
 `docs/history/findings/FINDINGS_ARCHIVE.md` at batch close-out (or during
@@ -56,6 +56,7 @@ Status: open. Source: F-B19-4 owner review; README roadmap companion.
 Global font stack, palette integration, index card rework, and the
 remaining F-B19-4 audit notes; Batch 21 main scope, possible Batch 22
 contingency. Status: open; scope lands via `BATCH21_DEFINITION.md`.
+Source: owner audit PDF + F-B19-4 owner review.
 
 ### F-B18-11: heatmap Last.fm page fetch is rate-limit bound
 
@@ -64,6 +65,7 @@ Fetch time is bound by page count and the shared 10 req/s throttle
 concurrent at `limit=200`). Options: heatmap-specific caching,
 progressive rendering, or a higher rate limit (not recommended).
 Status: open; no further fetch-speed work scheduled.
+Source: Batch 18 audit + perf measurement session 2026-05-16.
 
 ### F-LOAD-1: concurrent-user UX when job slots are full
 
@@ -116,18 +118,22 @@ logging per exception class. Status: open. Source: MULTI_AGENT_SWEEP.
 
 Process-local dict breaks polling under multiple workers/machines;
 migration path is Redis or a Postgres-backed job table.
+Status: open (P2). Source: MULTI_AGENT_SWEEP.
 
 ### F-MAS-6: Celery/Redis RQ for task queue
 
 **Owner decision:** out of scope until features complete.
+Status: open (P2, owner-gated). Source: MULTI_AGENT_SWEEP.
 
 ### F-MAS-7: process-local Spotify token cache
 
 Redundant refreshes under multiple workers; acceptable at current scale.
+Status: open (P2). Source: MULTI_AGENT_SWEEP.
 
 ### F-MAS-8: REQUEST_CACHE growth with always-on machines
 
 Cleanup is opportunistic (at job start); TTL mitigates, does not cap.
+Status: open (P2). Source: MULTI_AGENT_SWEEP.
 
 ---
 
@@ -136,22 +142,24 @@ Cleanup is opportunistic (at job start); TTL mitigates, does not cap.
 ### F-LOAD-3: in-memory REQUEST_CACHE is intentional
 
 Avoids re-fetching Last.fm on re-searches; clears on machine sleep.
+Status: standing design decision. Source: load testing 2026-03-04.
 
 ### F-LOAD-4: Spotify cache TTL is ToS-compliant
 
 Hits do NOT refresh `updated_at`; 30-day expiry from last API call.
+Status: standing design decision. Source: cache verification 2026-03-04.
 
 ### F-LOAD-5: pre-slicing reduces Spotify API load
 
 Playcount filter + 500-album playtime cap applied before cache lookup.
+Status: standing design decision. Source: load testing 2026-03-04.
 
 ---
 
 ## Deferred / future-batch candidates (Batch 18/19 audits)
 
 One-line cross-references; full text lives in `docs/history/` audits and
-archived batch definitions. Load-test measurements (2026-03-04) formerly
-here are in the archive and `load-test-findings.md`.
+archived definitions; 2026-03-04 load-test data now lives in the archive.
 
 - F-B18-1: orchestrator monolith -- promoted to F-B20-2 above.
 - F-B18-2: JOBS dict lacks TypedDict/dataclass annotations.
@@ -174,11 +182,10 @@ here are in the archive and `load-test-findings.md`.
 ### F-FEATURE-1: top songs feature
 
 Rank most-played tracks for a year (separate task type + loading/results
-flow). Deferred; on the README roadmap.
+flow). Status: deferred; on the README roadmap. Source: owner roadmap.
 
-### F-FEATURE-2: listening heatmap feature -- SHIPPED
-
-Batches 18/19 delivered and polished it. Perf follow-ups: F-B18-11.
+(F-FEATURE-2, the listening heatmap, shipped in Batches 18/19 and is
+archived; perf follow-ups continue as F-B18-11.)
 
 ---
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -113,6 +113,16 @@ class. Status: open. Source: MULTI_AGENT_SWEEP.
 
 ## P2 -- Scaling roadmap
 
+### F-DOCSYNC-2: STATUS block misreports current batch between batches
+
+When a close-out entry (untagged `(Batch N close-out)` suffix) still sits
+inside the CURRENT-BATCH markers, `renderer.py:85-86` falls back to
+`last_completed + 1` even though the Section 3 parse correctly returns
+the between-batches state. Transient: rotation self-corrects it when the
+next batch's WP-0 entry lands. Fix candidates: prefer the between-batches
+branch whenever the parse returns none, or make close-out tags parseable.
+Status: open (P2). Source: PR #162 review round 4.
+
 ### F-MAS-5: in-memory JOBS dict limits horizontal scaling
 
 Process-local dict breaks polling under multiple workers/machines;

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -5,12 +5,11 @@ Status: Batch 20 complete; Batch 21 (UI overhaul) is next, scope pending
 the owner's proposal. 390 tests across 22 test modules.
 
 **Rotation policy:** resolved and no-action findings rotate to
-`docs/history/findings/FINDINGS_ARCHIVE.md` at batch close-out (or during
-dedicated findings-cleanup WPs); nothing is deleted. Every remaining item
-uses an `F-<context>-<N>:` heading (contexts: B18/B19/B20 batches; LOAD,
-MAS, DOCSYNC, AUDIT source audits; FEATURE prep notes). Read this file on
-demand -- when a task or PLAYBOOK entry references an F-* ID or a P0/P1
-item -- not as part of the standard bootstrap order.
+`docs/history/findings/FINDINGS_ARCHIVE.md` at batch close-out or during
+findings-cleanup WPs; nothing is deleted. Every item uses an
+`F-<context>-<N>:` heading (format: AGENTS.md "Finding-Writing Rules").
+Read this file on demand -- when a task or PLAYBOOK entry references an
+F-* ID or a P0/P1 item -- not as part of the standard bootstrap order.
 
 ---
 
@@ -40,9 +39,8 @@ batch processing, error mapping, progress tracking, and result assembly.
 Now that `heatmap.py` provides a second pipeline, extract the shared
 patterns (event loop setup including the win32 Proactor guard, progress
 mapping, error guards) into a common module and split the orchestrator
-into pipeline / processing / result-shaping modules. Same item is on the
-README roadmap; absorbs F-B18-7 (duplicated win32 event-loop guard).
-Status: open. Source: Batch 18 audit, promoted in Batch 20.
+into pipeline / processing / result-shaping modules. Also on the README
+roadmap; absorbs F-B18-7. Status: open. Source: Batch 18 audit.
 
 ### F-B20-3: Bootstrap CDN source consolidation
 
@@ -63,9 +61,9 @@ Source: owner audit PDF + F-B19-4 owner review.
 Fetch time is bound by page count and the shared 10 req/s throttle
 (2026-05-16: 103 pages, 10.9s vs a 10.3s floor; fetching is already
 concurrent at `limit=200`). Options: heatmap-specific caching,
-progressive rendering, or a higher rate limit (not recommended).
-Status: open; no further fetch-speed work scheduled.
-Source: Batch 18 audit + perf measurement session 2026-05-16.
+progressive rendering, or a higher rate limit (not recommended). Status:
+open; no fetch-speed work scheduled. Source: Batch 18 audit + perf
+session 2026-05-16.
 
 ### F-LOAD-1: concurrent-user UX when job slots are full
 
@@ -107,8 +105,9 @@ Status: open. Source: MULTI_AGENT_SWEEP.
 
 ### F-MAS-4: broad `except Exception` catches
 
-14 instances across `scrobblescope/*.py`; narrow or add structured
-logging per exception class. Status: open. Source: MULTI_AGENT_SWEEP.
+17 instances across `scrobblescope/*.py` (recounted 2026-07-24; 14 at
+the original sweep); narrow or add structured logging per exception
+class. Status: open. Source: MULTI_AGENT_SWEEP.
 
 ---
 
@@ -158,8 +157,9 @@ Status: standing design decision. Source: load testing 2026-03-04.
 
 ## Deferred / future-batch candidates (Batch 18/19 audits)
 
-One-line cross-references; full text lives in `docs/history/` audits and
-archived definitions; 2026-03-04 load-test data now lives in the archive.
+One-line cross-references; detailed bodies live in pre-Batch-20
+`FINDINGS.md` (git history before `494f2c7`) or the `docs/history/`
+audits; 2026-03-04 load-test data is in the findings archive.
 
 - F-B18-1: orchestrator monolith -- promoted to F-B20-2 above.
 - F-B18-2: JOBS dict lacks TypedDict/dataclass annotations.
@@ -184,8 +184,8 @@ archived definitions; 2026-03-04 load-test data now lives in the archive.
 Rank most-played tracks for a year (separate task type + loading/results
 flow). Status: deferred; on the README roadmap. Source: owner roadmap.
 
-(F-FEATURE-2, the listening heatmap, shipped in Batches 18/19 and is
-archived; perf follow-ups continue as F-B18-11.)
+F-FEATURE-2 (listening heatmap) shipped in Batches 18/19 and is now
+archived; perf follow-ups continue as F-B18-11.
 
 ---
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,11 +1,16 @@
 # ScrobbleScope Findings & Open Issues
 
-Last updated: 2026-05-19
-Status: Batch 19 closed out; `feat/heatmap` PR #152 open against `main` with
-two Gemini-Code-Review-driven fixes applied (UTC timestamps, nested
-daily_counts isolation, streak boundary). 389 tests, 24 test files.
-Includes findings from load testing + cache verification session (2026-03-04)
-and Batch 18 full source-code audit (2026-03-07).
+Last updated: 2026-07-24
+Status: Batch 20 active (file-hygiene + docs methodology refresh).
+390 tests across 22 test modules.
+
+**Rotation policy:** resolved and no-action findings rotate to
+`docs/history/findings/FINDINGS_ARCHIVE.md` at batch close-out (or during
+dedicated findings-cleanup WPs); nothing is deleted. Every remaining item
+uses an `F-<context>-<N>:` heading (contexts: B18/B19/B20 batches; LOAD,
+MAS, DOCSYNC, AUDIT source audits; FEATURE prep notes). Read this file on
+demand -- when a task or PLAYBOOK entry references an F-* ID or a P0/P1
+item -- not as part of the standard bootstrap order.
 
 ---
 
@@ -20,261 +25,6 @@ and Batch 18 full source-code audit (2026-03-07).
 
 ---
 
-## Resolved since last update (2026-03-02)
-
-Items from prior audits that have been addressed:
-
-- ~~MEMORY.md stale~~ -- Deleted. Replaced by `AGENT_NOTES.md` (tracked) in Batch 17 WP-4.
-- ~~README.md screenshot placeholders~~ -- Owner replaced with "coming soon".
-- ~~CI Python version drift~~ -- Aligned to 3.13 in Batch 15.
-- ~~docsync cli.py unconditional rewrite~~ -- Gated on changed set (Batch 14).
-- ~~Test-count regex defined 3 times~~ -- Consolidated to single `TEST_COUNT_RE`
-  in `parser.py`; renderer and logic import it (Batch 14).
-- ~~Dedup-sort pattern copy-pasted~~ -- Extracted `_dedup_sorted()` helper in
-  `logic.py` (Batch 14).
-- ~~Gunicorn HTTP serialization~~ -- Added `--threads 4` to Dockerfile CMD.
-  Merged to `main` as `f8a579f` (#57). Deployed and verified.
-- ~~Dark mode ignores browser preference~~ -- `theme.js` falls back to
-  `matchMedia('prefers-color-scheme: dark')`. Commit `463282e`.
-- ~~Log rotation loses data under load~~ -- Increased to 2MB cap, 10 backups.
-  Commit `21a3b4c` on `main`.
-- ~~F-B18-8 nested daily_counts shared by reference~~ -- `get_job_context`
-  now explicitly copies `results["daily_counts"]` in addition to the outer
-  dict. Closed during PR #152 review (Gemini Code Review catch).
-
----
-
-## Batch 18 audit findings (2026-03-07)
-
-Peripheral findings from the full source-code audit that do not directly
-affect Batch 18 WPs but should be tracked for future batches. Corrections
-that DO affect WPs are documented in BATCH18_DEFINITION.md audit section.
-
-### F-B18-1: orchestrator.py monolith (920 lines)
-
-Album search orchestration, Spotify batch processing, error mapping, progress
-tracking, and result assembly in one file. Adding heatmap.py keeps SoC for
-iteration 1 but a future batch should extract shared patterns (event loop
-setup, progress mapping, error guards) into a common module. Explicitly
-deferred.
-
-### F-B18-2: JOBS dict has no type annotations
-
-`repositories.py` JOBS stores heterogeneous result types (list for albums,
-dict for heatmap). No TypedDict or dataclass definitions. Future batch
-candidate.
-
-### F-B18-3: loading.js hardcoded album messaging
-
-`loading.js` (409 lines) has album-specific rotating messages and scrobble
-count cycling. Irrelevant to heatmap (separate heatmap.js). If 3+ features
-emerge, polling/progress patterns should be extracted into shared utility.
-
-### F-B18-4: _check_user_exists creates throwaway event loops
-
-`routes.py` wraps an async call via `run_async_in_thread()`. Creates a
-throwaway event loop per call. Not a problem at current scale.
-
-### F-B18-5: inline SVG payload growth
-
-Main logo via `{% include 'inline/scrobble_scope_inline.svg' %}` plus new
-pinwheel SVG increases initial HTML payload. Both small enough for iteration 1.
-If more inline SVGs are added, consider lazy loading or sprite sheets.
-
-### F-B18-6: dark mode uses body.dark-mode class, not data attributes
-
-CSS uses `.dark-mode` class toggled by `theme.js`. Original Batch 18
-definition referenced `[data-theme="dark"]` which does not exist. Corrected
-in audited definition.
-
-### F-B18-7: Windows SelectorEventLoop guard duplication
-
-Both `orchestrator.py background_task()` and new `heatmap_task()` need
-identical `sys.platform == "win32"` guard for `WindowsSelectorEventLoopPolicy`.
-Shared utility candidate for future refactor.
-
-### F-B18-8: get_job_context shallow-copies results but not nested dicts -- RESOLVED
-
-**Status:** resolved during PR #152 review (Gemini Code Review catch).
-`get_job_context()` now explicitly does `results["daily_counts"] =
-dict(results["daily_counts"])` after the outer dict copy, restoring the
-function's stated contract for heatmap result shape. Variant chosen over
-`copy.deepcopy` because the polling hot path runs every ~1s per active
-job and the nested structure is well known. New regression test:
-`tests/test_repositories.py::test_get_job_context_nested_daily_counts_is_isolated`.
-
-Historical context: `repositories.py` `get_job_context()` originally
-copied list results via `list(results)` but did not copy dict results at
-all (returned the original reference). A Boy Scout fix added an
-`elif isinstance(results, dict): results = dict(results)` branch, but
-that was still a shallow copy, leaving the nested `daily_counts` shared
-by reference. PR #152 review surfaced this; the fix above closes it.
-
-### F-B18-9: username not sanitized for JS/SVG injection
-
-Routes validate that a username exists on Last.fm but do no input
-sanitization beyond that. Usernames are echoed back in JSON and rendered
-by heatmap.js into SVG text elements and tooltip HTML. Flask's Jinja2
-auto-escapes template output, but JS-side rendering into `innerHTML` or
-SVG `textContent` must escape manually. `textContent` is safe;
-`innerHTML` is not. heatmap.js must use `textContent` for any
-user-supplied strings. Note for WP-4 code review.
-
-### F-B18-10: heatmap + album jobs share global throttle
-
-The `_GlobalThrottle` in `utils.py` serializes ALL API calls at 10 req/s
-across all job threads. A concurrent album search + heatmap fetch will
-compete for the same 10 req/s budget. This is correct behavior (prevents
-upstream 429s) but means heatmap fetch slows if album searches are running,
-and vice versa. No action needed -- documenting for load-test awareness.
-
-### F-B18-11: heatmap Last.fm page fetch is rate-limit bound (P1)
-
-Heatmap fetch time is dominated by Last.fm page count and the shared
-10 req/s global throttle. `lastfm.py` already uses `limit=200`, concurrent
-`as_completed` fetching, and `MAX_CONCURRENT_LASTFM=10`; the old sequential
-diagnosis was from the pre-implementation design and is no longer accurate.
-
-**Measured data (2026-05-16, local, concurrent):**
-- `flounder14`: 103 pages, 10.9s wall-clock.
-- Rate-limit floor at current config: 103 pages / 10 req/s = 10.3s minimum.
-
-**Root cause:** `_GlobalThrottle` serializes aggregate Last.fm traffic across
-all job threads at `LASTFM_REQUESTS_PER_SECOND` (default 10). This protects
-against upstream 429s and is shared by album and heatmap jobs.
-
-**Optimization options after Batch 19:**
-1. **Heatmap-specific caching** for same-user repeat requests inside a short
-   TTL. This avoids refetching but must account for the rolling 365-day window.
-2. **Progressive rendering** so users see partial activity while pages arrive.
-   This adds route/JS complexity and should be scoped separately.
-3. **Higher Last.fm rate limit** only if the owner accepts 429 risk. Official
-   Last.fm guidance is lower than the current 10 req/s setting, so raising it
-   is not recommended without load testing.
-
-Priority: P1 -- directly impacts user experience, but no further fetch-speed
-work is in Batch 19.
-
-### F-B18-12: pill tabs mismatched in width
-
-The "Album Filtering" pill is wider than "Heatmap" due to different text
-lengths and no `min-width` constraint. Owner flagged this after testing.
-CSS fix: add `min-width` to `.mode-pill` in `heatmap.css` so both pills
-are the same width. To be fixed in a Phase 2 WP.
-
----
-
-## Batch 19 owner-review findings (2026-05-19)
-
-### F-B19-1: loading state still read as a card
-
-Owner review showed the pinwheel centered inside a large Bootstrap card-like
-box. That made the loading state feel broken even after the earlier clipping
-fix. The follow-up removes the card wrapper and uses an unframed loading panel
-with a larger SVG-bounded pinwheel.
-
-Status: fixed in Batch 19 owner-review follow-up. The final SVG keeps the
-original breathing/expanding blade animation; the simplified rotating
-replacement was rejected during owner review.
-
-### F-B19-2: heatmap sizing needed separate desktop and mobile treatment
-
-Desktop screenshots at 1440p and 1080p showed the heatmap grid taking too
-little visual space because the result container was still constrained by the
-Bootstrap `col-md-8` width. Mobile review showed the opposite failure after
-the prior reduction pass: cells were no longer heavy, but calendar-constrained
-mobile layouts either left excessive side space or made cells too small.
-
-Follow-up direction: widen only `#heatmap-result` on desktop, keep the rest of
-the page unchanged, and replace calendar-constrained mobile layouts with a
-sequential activity strip that fills the heatmap frame width with larger cells.
-The headline also needs mobile fitting so common usernames avoid a forced line
-break.
-
-Status: fixed in Batch 19 owner-review follow-up; owner visual approval still
-required.
-
-### F-B19-3: last.timer is not a drop-in heatmap speedup
-
-The referenced `last.timer` project fetches Last.fm aggregate endpoints:
-`user.gettopartists` and `user.gettoptracks`, with `limit=1000`, page fan-out,
-and `Promise.all` for remaining pages. That is appropriate for top-track
-period summaries, but it does not provide per-scrobble timestamps needed for an
-exact day-by-day heatmap.
-
-Potential future experiments:
-1. Test whether `user.getrecenttracks` reliably accepts `limit=1000`; current
-   ScrobbleScope uses the documented conservative `limit=200`.
-2. Add heatmap-specific cached daily aggregates for repeat same-user requests.
-3. Add progressive rendering if partial heatmap feedback is worth the extra
-   route and client complexity.
-
-Status: documented for a future performance batch; no Batch 19 API change.
-
-### F-B19-4: broader front-end UI audit should be a separate batch
-
-Low-risk local heatmap changes are fine in Batch 19, but a global UI overhaul
-should not be folded into owner-review fixes. Open audit notes:
-
-- Bootstrap is split across CDNs: `base.html` uses cdnjs for CSS, while
-  `index.html` uses jsdelivr for the Bootstrap JS bundle and other pages use
-  cdnjs. A future batch should standardize the source before considering a
-  Bootstrap upgrade.
-- Bootstrap 5.3 color modes could reduce `.dark-mode .table`,
-  `.dark-mode .modal-content`, and `.dark-mode .form-control` overrides, but
-  upgrading from 5.1.3 risks component regressions and should be tested as its
-  own WP.
-- Global Geist font, Bootstrap variable overrides, warm surfaces, and inky
-  purple palette should be handled in `global.css`/`base.html` as a dedicated
-  UI batch, not piecemeal in heatmap follow-up work.
-- Index popovers/tooltips are visually large relative to form labels and
-  should be reviewed with form density, label sizing, and mobile tap targets in
-  the same UI batch.
-- Dark-mode table/export CSS remains scattered across `results.css`,
-  `unmatched.css`, and `results.js`; Bootstrap 5.3 or shared CSS tokens may
-  reduce that duplication.
-
-### F-B19-5: visual-verification tooling
-
-The Browser plugin/skill is the right Codex-side tool when its browser MCP
-tools are exposed. In this session, deferred tool discovery did not expose a
-callable browser screenshot tool, and shell-launched headless Chrome did not
-emit screenshots in the sandbox. For future UI-heavy batches, enable a
-Browser/Playwright MCP path if available. No new Python or Node package is
-recommended for Batch 19 solely for visual QA.
-
-### F-B19-6: naive-tz vacuous-test anti-pattern
-
-PR #152 review (Gemini) surfaced that `scrobblescope/heatmap.py` decoded
-Last.fm UTS values with naive `datetime.fromtimestamp` and built the fetch
-window with naive `datetime.now()`. On Fly.io (UTC container) this was
-silently fine; on local Windows dev or any non-UTC host it shifted day
-attribution by hours.
-
-The deeper finding -- worth recording so it does not repeat -- is that the
-**test pyramid did not catch it**. `tests/test_heatmap.py` constructed UTS
-values using the same naive `datetime.combine(...).timestamp()` pattern that
-the SUT decoded. Boundary tests like `test_midnight_boundary_attribution`
-passed only because the SUT and tests shared the same naive-tz interpretation:
-the test was effectively comparing the SUT against itself, not against an
-invariant. This is the **vacuous-test pattern** AGENTS.md forbids ("Every
-test must fail if the function under test is deleted") in a subtler form --
-the test fails if the function is deleted, but does *not* fail if the function
-silently regresses to a naive-tz bug.
-
-**Anti-pattern to register in AGENTS.md (future):** any datetime test that
-builds inputs with the same tz-awareness pattern (naive vs aware) as the SUT
-is at risk of being vacuous against tz bugs. Build inputs with explicit
-`tzinfo=` and assert on a date that would shift under a naive interpretation.
-
-The PR #152 fix added `tests/test_heatmap.py::TestAggregateDailyCounts::
-test_utc_decode_invariant_against_local_tz_drift` as the canonical example.
-
-Status: code fixed in PR #152 (commit `ccb000f`). AGENTS.md addition is
-deferred to the next bootstrap/docs batch -- noted here as a forward TODO.
-
----
-
 ## P0 -- Fix before next deploy
 
 _No open P0 items._
@@ -283,129 +33,159 @@ _No open P0 items._
 
 ## P1 -- Next batch candidates
 
-### Concurrency & deployment
+### F-B20-2: orchestrator.py second-pass decomposition (promoted from F-B18-1)
 
-2. **Concurrent user UX when slots are full.** When all 10 `MAX_ACTIVE_JOBS`
-   slots are occupied, the user sees "Too many requests in progress. Please
-   try again in a moment." on the home page. No indication of how many slots
-   are in use. Estimating wait time is not feasible (job durations vary
-   21s cached to 5+ min uncached). Showing "N/10 slots in use" or a clearer
-   busy state would help.
+`scrobblescope/orchestrator.py` (916 lines) mixes album workflow, Spotify
+batch processing, error mapping, progress tracking, and result assembly.
+Now that `heatmap.py` provides a second pipeline, extract the shared
+patterns (event loop setup including the win32 Proactor guard, progress
+mapping, error guards) into a common module and split the orchestrator
+into pipeline / processing / result-shaping modules. Same item is on the
+README roadmap; absorbs F-B18-7 (duplicated win32 event-loop guard).
+Status: open. Source: Batch 18 audit, promoted in Batch 20.
 
-3. **Dark mode CSS on mobile.** Toggle is fixed-position in footer; may
-   overlap content on small screens. Minor CSS polish.
-   Source: AUDIT_2026-02-11.
+### F-B20-3: Bootstrap CDN source consolidation
 
-### Test suite gaps
+`base.html` loads Bootstrap CSS from cdnjs while `index.html` loads the
+JS bundle from jsdelivr; other pages use cdnjs. Consolidate to a single
+provider before any Bootstrap 5.1 -> 5.3 upgrade.
+Status: open. Source: F-B19-4 owner review; README roadmap companion.
 
-4. **No integration tests in CI.** All 350 tests use mocked dependencies.
-   No test makes a real API call, connects to a real DB, or exercises the
-   full request-response cycle. The manual scripts (`concurrent_users_test.py`,
-   `smoke_cache_check.py`) require a running Flask instance and are not part
-   of CI.
+### F-B20-4: UI overhaul (driven by owner audit PDF)
 
-5. **Mocks may drift from API reality.** No contract tests or recorded API
-   response fixtures. If Last.fm/Spotify change response formats, mocked
-   tests pass while production breaks.
+Global font stack, palette integration, index card rework, and the
+remaining F-B19-4 audit notes; Batch 21 main scope, possible Batch 22
+contingency. Status: open; scope lands via `BATCH21_DEFINITION.md`.
 
-6. **No automated JS tests.** Client-side behavior (theme toggle, screenshot
-   rendering, progress polling) has no automated test coverage.
+### F-B19-6: register naive-tz vacuous-test anti-pattern in AGENTS.md
 
-### Code quality (verified still open)
+Code fix archived; open portion: record in the AGENTS.md anti-pattern
+registry that datetime tests building inputs with the SUT's tz-awareness
+pattern are vacuous against tz bugs -- use explicit `tzinfo=` and assert
+on a date that shifts under naive decoding. Status: open (WP-7 candidate).
 
-7. **`ENTRY_BATCH_RE` too loose.** `parser.py:37` regex can misroute entries
-   whose title contains "Batch N" substrings. Tightening requires careful
-   backward-compat testing. Source: DOCSYNC_AUDIT Finding 6.
+### F-B18-11: heatmap Last.fm page fetch is rate-limit bound
 
-8. **`test_docsync_logic.py` is 852 lines.** Covers sync integration,
-   cross-validation, split/merge, and count extraction in one file.
-   Suggested split: integration / cross-validate / archive-routing.
-   Source: MULTI_AGENT_SWEEP.
+Fetch time is bound by page count and the shared 10 req/s throttle
+(2026-05-16: 103 pages, 10.9s vs a 10.3s floor; fetching is already
+concurrent at `limit=200`). Options: heatmap-specific caching,
+progressive rendering, or a higher rate limit (not recommended).
+Status: open; no further fetch-speed work scheduled.
 
-9. **Broad `except Exception` catches.** 14 instances across
-   `scrobblescope/*.py`. Protects UX but masks root causes. Consider
-   narrowing or adding structured logging for exception classes.
-   Source: MULTI_AGENT_SWEEP.
+### F-LOAD-1: concurrent-user UX when job slots are full
+
+With all 10 `MAX_ACTIVE_JOBS` slots busy, users get "Too many requests in
+progress" with no occupancy hint; "N/10 slots in use" would help.
+Status: open. Source: load testing 2026-03-04.
+
+### F-AUDIT-1: dark-mode toggle placement on mobile
+
+Fixed-position footer toggle may overlap content on small screens; minor
+CSS polish, also a Batch 21 note. Status: open. Source: AUDIT_2026-02-11.
+
+### F-LOAD-2: no integration tests in CI
+
+All tests mock dependencies; an in-process `/results_loading ->
+/progress -> /results_complete` test is on the README roadmap.
+Status: open. Source: load testing 2026-03-04.
+
+### F-MAS-1: mocks may drift from API reality
+
+No contract tests or recorded API fixtures; upstream format changes would
+pass mocked tests. Status: open. Source: MULTI_AGENT_SWEEP.
+
+### F-MAS-2: no automated JS tests
+
+Theme toggle, export, polling, and heatmap rendering have no automated
+coverage. Status: open. Source: MULTI_AGENT_SWEEP.
+
+### F-DOCSYNC-1: ENTRY_BATCH_RE too loose
+
+`parser.py` batch-tag regex can misroute entries whose titles contain
+"Batch N" substrings; tightening needs backward-compat testing. On the
+README roadmap. Status: open. Source: DOCSYNC_AUDIT Finding 6.
+
+### F-MAS-3: test_docsync_logic.py is 852 lines
+
+Suggested split: integration / cross-validate / archive-routing.
+Status: open. Source: MULTI_AGENT_SWEEP.
+
+### F-MAS-4: broad `except Exception` catches
+
+14 instances across `scrobblescope/*.py`; narrow or add structured
+logging per exception class. Status: open. Source: MULTI_AGENT_SWEEP.
 
 ---
 
 ## P2 -- Scaling roadmap
 
-10. **In-memory `JOBS` dict limits horizontal scaling.** `repositories.py`
-    stores job state in a process-local dict. Multiple gunicorn workers or
-    Fly.io machines break progress polling. Migration path: Redis or
-    Postgres-backed job table.
+### F-MAS-5: in-memory JOBS dict limits horizontal scaling
 
-11. **Celery/Redis RQ for task queue.** Current daemon-thread model works
-    for single-worker single-machine. Horizontal scaling requires a real
-    task queue. **Owner decision:** out of scope until features complete.
+Process-local dict breaks polling under multiple workers/machines;
+migration path is Redis or a Postgres-backed job table.
 
-12. **Process-local Spotify token cache.** `config.py` `spotify_token_cache`
-    is per-process; multiple workers cause redundant refreshes. Acceptable
-    at current scale.
+### F-MAS-6: Celery/Redis RQ for task queue
 
-13. **REQUEST_CACHE growth with always-on machines.** If Fly.io machines
-    stay on permanently, cleanup is opportunistic (runs at job start, not
-    on a timer). TTL mitigates but doesn't cap memory.
+**Owner decision:** out of scope until features complete.
+
+### F-MAS-7: process-local Spotify token cache
+
+Redundant refreshes under multiple workers; acceptable at current scale.
+
+### F-MAS-8: REQUEST_CACHE growth with always-on machines
+
+Cleanup is opportunistic (at job start); TTL mitigates, does not cap.
 
 ---
 
 ## Info -- Design decisions (no action needed)
 
-14. **In-memory `REQUEST_CACHE` is intentional.** Avoids re-fetching Last.fm
-    pages when a user re-searches the same year with different filters.
-    Clears on machine sleep. By design.
+### F-LOAD-3: in-memory REQUEST_CACHE is intentional
 
-15. **Spotify cache TTL is ToS-compliant.** Verified 2026-03-04. Cache hits
-    do NOT refresh `updated_at`. Albums expire 30 days from last Spotify
-    API call regardless of access frequency.
+Avoids re-fetching Last.fm on re-searches; clears on machine sleep.
 
-16. **Pre-slicing reduces Spotify API load.** Playcount filter + 500-album
-    playtime cap applied before cache lookup.
+### F-LOAD-4: Spotify cache TTL is ToS-compliant
 
-17. **Orchestrator splitting deferred to post-Batch 18.** `orchestrator.py`
-    (920 lines) mixes workflow, business rules, result shaping, and error
-    classification. Now that Batch 18 adds a second pipeline (`heatmap.py`),
-    shared patterns (event loop setup, progress mapping, error guards) are
-    prime candidates for extraction. See F-B18-1 above. Revisit after both
-    pipelines exist and work end-to-end.
+Hits do NOT refresh `updated_at`; 30-day expiry from last API call.
+
+### F-LOAD-5: pre-slicing reduces Spotify API load
+
+Playcount filter + 500-album playtime cap applied before cache lookup.
 
 ---
 
-## Load test data (2026-03-04, local)
+## Deferred / future-batch candidates (Batch 18/19 audits)
 
-Test environment: Flask dev server (Werkzeug, threaded), local `ss-postgres`
-Docker container, all caches cleared between runs.
+One-line cross-references; full text lives in `docs/history/` audits and
+archived batch definitions. Load-test measurements (2026-03-04) formerly
+here are in the archive and `load-test-findings.md`.
 
-| Concurrent Users | Per-user elapsed | Wall time | Upstream 429s | Outcome |
-|------------------|------------------|-----------|---------------|---------|
-| 1 (cached)       | 21s              | 21s       | 0             | OK      |
-| 2 (uncached)     | 88-106s          | 107s      | 0             | All OK  |
-| 3 (uncached)     | 125-201s         | 202s      | 0             | All OK  |
-| 5 (uncached)     | 115-268s         | 269s      | 0             | All OK  |
-| 10 (partial)     | 216-353s         | ~6min     | unknown       | 6/10 OK |
-
-**Caveat:** Local tests use Werkzeug (threaded HTTP). Production was single
-sync gunicorn worker (no threads) at time of testing.
-
-**Global throttle:** `_GlobalThrottle` serializes all API calls at 10 req/s
-across all job threads. Jobs slow linearly: N jobs sharing 10 req/s =
-~10/N req/s per job.
-
-**Last.fm rate config:** App configures 10 req/s; official limit is 5 req/s
-averaged over 5 minutes. No 429s observed in testing, but aggressive.
+- F-B18-1: orchestrator monolith -- promoted to F-B20-2 above.
+- F-B18-2: JOBS dict lacks TypedDict/dataclass annotations.
+- F-B18-3: `loading.js` album messaging; extract shared polling utility
+  if a third feature emerges.
+- F-B18-4: `_check_user_exists` creates a throwaway event loop per call.
+- F-B18-5: inline SVG payload growth; lazy-load or sprite if more added.
+- F-B18-7: duplicated win32 event-loop guard -- absorbed into F-B20-2.
+- F-B18-10: heatmap + album jobs share the 10 req/s throttle (by design).
+- F-B18-12: mode pills differ in width (no `min-width` on `.mode-pill`);
+  Batch 21 UI candidate.
+- F-B19-3: last.timer aggregate endpoints are not a drop-in heatmap
+  speedup; future perf experiments listed in the archive.
+- F-B19-4: front-end UI audit notes -- basis of `BATCH21_DEFINITION.md`.
 
 ---
 
 ## Feature preparation notes
 
-18. **Top songs feature.** Rank most-played tracks for a year. Needs Last.fm +
-    possibly Spotify enrichment. Deferred; heatmap (Batch 18) takes priority.
+### F-FEATURE-1: top songs feature
 
-19. **Listening heatmap feature.** Last.fm-only scrobble density calendar for
-    365 days. No Spotify calls. Batch 18 completed the working end-to-end
-    feature; Batch 19 is polishing the result frame, KPIs, pill labels,
-    pinwheel animation, and mobile layout on `feat/heatmap`.
+Rank most-played tracks for a year (separate task type + loading/results
+flow). Deferred; on the README roadmap.
+
+### F-FEATURE-2: listening heatmap feature -- SHIPPED
+
+Batches 18/19 delivered and polished it. Perf follow-ups: F-B18-11.
 
 ---
 
@@ -415,4 +195,5 @@ averaged over 5 minutes. No 429s observed in testing, but aggressive.
 - `docs/history/AUDIT_2026-02-27_MULTI_AGENT_SWEEP.md` -- Full architecture sweep
 - `docs/history/AUDIT_2026-02-11_IMPLEMENTATION_REPORT.md` -- Earlier audit
 - `docs/history/AUDIT_2026-01-10.md` -- Rate limit regression audit
+- `docs/history/findings/FINDINGS_ARCHIVE.md` -- Rotated resolved/no-action items
 - Agent memory: `load-test-findings.md` -- Raw load test data and analysis

--- a/HANDOFF_PROMPT.md
+++ b/HANDOFF_PROMPT.md
@@ -41,8 +41,11 @@ without explicit owner instruction.
 5. `AGENT_NOTES.md` (repo root) -- owner preferences, local dev setup,
    architectural constraints, and known issues. Tracked in the repo;
    readable by all agents.
+6. `FINDINGS.md` -- on demand only: read when PLAYBOOK Section 4 or your
+   task references an F-* finding ID or an open P0/P1 item. Not part of
+   the mandatory set. Finding-writing rules live in `AGENTS.md`.
 
-After reading all five files, run:
+After reading the five core files, run:
 
 ```bash
 git status

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -48,7 +48,7 @@ Completed batch definitions are archived individually under `docs/history/`.
 | 17 | Agent bootstrap hardening, CI/CD improvements, and dep pinning | `docs/history/definitions/BATCH17_DEFINITION.md` |
 | 18 | Scrobble heatmap -- iteration 1 | `docs/history/definitions/BATCH18_DEFINITION.md` |
 | 19 | Heatmap polish -- frame, KPIs, mobile layout | `docs/history/definitions/BATCH19_DEFINITION.md` |
-| 20 | File-hygiene + docs methodology refresh | `BATCH20_DEFINITION.md` |
+| 20 | File-hygiene + docs methodology refresh | `docs/history/definitions/BATCH20_DEFINITION.md` |
 | 21 | UI overhaul -- TBD | `BATCH21_DEFINITION.md` |
 
 ### Open decisions (owner confirmation needed)
@@ -66,19 +66,17 @@ Completed batch definitions are archived individually under `docs/history/`.
 - **Batch 19 is complete.** All 5 WPs done plus owner-review follow-up.
   Definition archived: `docs/history/definitions/BATCH19_DEFINITION.md`.
   PR #152 (Batches 18 + 19) merged to `main`.
-- **Batch 20 is active.** Definition: `BATCH20_DEFINITION.md` (repo root).
-  Scope: file-hygiene + docs methodology refresh (README, DEVELOPMENT.md,
-  FINDINGS.md rotation, AGENTS.md finding-writing rules, bootstrap skill
-  update). No production-code changes. Branch: `wip/batch-20`
-  (WP-0 through WP-5 landed via `file-hygeine`, merged in PR #159).
-- **Batch 21 (placeholder, renumbered from Batch 20).** Definition:
-  `BATCH21_DEFINITION.md` (repo root). Scope TBD -- global UI overhaul
-  (font stack, palette integration, index card rework, Bootstrap CDN
-  consolidation) driven by an owner audit PDF. No WP work begins until
-  scope lands.
-- **Next action:** Batch 20 WP-8 (close-out: archive definition, purge
-  log, mark batch complete).
-- Batch 20 WP status: WP-0 through WP-7 done. WP-8 not yet started.
+- **Batch 20 is complete.** All 9 WPs done (WP-0 through WP-5 via PR #159
+  on `file-hygeine`; audit gap-fix follow-up, WP-6, WP-7, and WP-8 on
+  `wip/batch-20`, unpushed pending owner instruction). Definition
+  archived: `docs/history/definitions/BATCH20_DEFINITION.md`.
+- **Batch 21 is next.** Definition stub: `BATCH21_DEFINITION.md` (repo
+  root). Scope TBD -- global UI overhaul (font stack, palette
+  integration, index card rework, Bootstrap CDN consolidation) driven by
+  the owner's audit PDF; owner is drafting the UI proposal now. No WP
+  work begins until scope lands.
+- **Next action:** await Batch 21 scope from the owner's UI proposal,
+  then expand `BATCH21_DEFINITION.md` into WPs.
 - **Perf note (measured 2026-05-16):** Heatmap fetch for `flounder14`
   (103 pages) took 10.9s. `lastfm.py` already uses `limit=200` and concurrent
   `as_completed` fetching. 10.9s is the rate-limit floor (103 pages /
@@ -113,286 +111,30 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-START -->
 
-### 2026-05-22 - Batch scaffolding (Batch 20 WP-0)
+### 2026-07-24 - Batch 20 complete; definition archived, log purged (Batch 20 close-out)
 
-- Scope: opened Batch 20 (file-hygiene + docs methodology refresh) and
-  renumbered the UI-overhaul placeholder to Batch 21, since that
-  placeholder had no started WPs.
+- Scope: Batch 20 WP-8 close-out per the AGENTS.md procedure.
 - Plan vs implementation:
-  - `git mv BATCH20_DEFINITION.md BATCH21_DEFINITION.md`, header updated
-    to `# BATCH21: UI overhaul -- TBD`, status note records the rename
-    reason and date.
-  - Wrote new `BATCH20_DEFINITION.md` -- 9 WPs (WP-0 through WP-8) covering README, DEVELOPMENT.md,
-    FINDINGS.md rotation + archive, AGENTS.md finding-writing rules,
-    HANDOFF_PROMPT.md pointer, and the `scrobblescope-bootstrap` skill
-    update. No production-code changes; baseline is 389 tests throughout.
-  - PLAYBOOK Section 2: added Batch 20 and Batch 21 rows. Section 3:
-    Batch 20 marked active, Batch 21 marked placeholder pending owner's
-    audit PDF, next action set to Batch 20 WP-1.
-- Deviations: none -- this session found the rename staged/edited but
-  uncommitted from a prior session (owner confirmed via `HANDOFF_PROMPT.md`
-  handoff) and completed the WP-0 commit per the definition file's own
-  instructions.
-- Validation: `pytest -q` -- **389 passed**, 3 existing aiohttp/Python 3.13
-  warnings (no code touched). `pre-commit run --all-files` -- all 10 hooks
-  pass. `doc_state_sync.py --check` -- exit 0, two expected root-BATCH-file
-  warnings (Batch 20 active + Batch 21 placeholder, both intentional).
-- Forward guidance: WP-1 starts the README pass (test-file count, project
-  structure, mermaid diagram refresh).
-
-### 2026-07-24 - README counts/structure/mermaid refresh (Batch 20 WP-1)
-
-- Scope: completed Batch 20 WP-1 in `README.md` (test-count wording, project
-  structure refresh, and Mermaid flow update).
-- Plan vs implementation:
-  - Updated test-count references to 22 test modules.
-  - Refreshed the root project-structure block with the requested
-    orchestration/documentation files.
-  - Replaced the older architecture mermaid with the current two-pipeline
-    diagram and removed the doc-state-sync bullet from key highlights.
-- Deviations: none.
-- Validation: `pytest -q` -- **389 passed**. `pre-commit run --all-files` --
-  all hooks pass.
-- Forward guidance: continue with WP-2 roadmap trimming.
-
-### 2026-07-24 - README roadmap trim (Batch 20 WP-2)
-
-- Scope: completed Batch 20 WP-2 roadmap cleanup in `README.md`.
-- Plan vs implementation:
-  - Removed completed/scaffolding roadmap items and duplicate heatmap entries.
-  - Preserved required unchecked roadmap items and converted the quality-track
-    checklist into a concise reminder paragraph.
-  - Added concrete forward items for orchestrator decomposition, integration
-    testing, CDN consolidation, and regex hardening.
-- Deviations: none.
-- Validation: `pytest -q` -- **389 passed**. `pre-commit run --all-files` --
-  all hooks pass.
-- Forward guidance: continue with WP-3 Getting Started compression.
-
-### 2026-07-24 - README getting-started compression (Batch 20 WP-3)
-
-- Scope: completed Batch 20 WP-3 Getting Started tightening in `README.md`.
-- Plan vs implementation:
-  - Compressed the venv/setup instructions while retaining Linux + Windows
-    coverage.
-  - Reduced `.env` optional-tuning examples and pointed readers to
-    `scrobblescope/config.py` for the full option set.
-  - Tightened local DB-cache development prose while preserving prerequisites,
-    one-command startup, and smoke/concurrency checks.
-- Deviations: initial commit left the full 8-var optional-tuning list and the
-  `load_dotenv()` trivia line in place; both corrections were applied in
-  follow-up commits after reviewer feedback (`BATCH20_DEFINITION.md:107-108`).
-- Validation: `pytest -q` -- **389 passed**. `pre-commit run --all-files` --
-  all hooks pass.
-- Forward guidance: continue with WP-4 DEVELOPMENT.md cleanup.
-
-### 2026-07-24 - DEVELOPMENT.md path/timeline/prose cleanup (Batch 20 WP-4)
-
-- Scope: completed Batch 20 WP-4 in `DEVELOPMENT.md`.
-- Plan vs implementation:
-  - Corrected the archive-definition path references to
-    `docs/history/definitions/...`.
-  - Updated the development-timeline framing to reflect concentrated
-    Feb-March work plus lighter later follow-up.
-  - Trimmed identified AI-prose padding while preserving technical intent.
-- Deviations: none.
-- Validation: `pytest -q` -- **389 passed**. `pre-commit run --all-files` --
-  all hooks pass.
-- Forward guidance: WP-5 adds the Claude Code skills subsection in
-  `DEVELOPMENT.md`.
-
-### 2026-07-24 - DEVELOPMENT.md skills subsection (Batch 20 WP-5)
-
-- Scope: completed Batch 20 WP-5 -- added the "Claude Code Skills (tightly
-  scoped tooling)" subsection to `DEVELOPMENT.md`.
-- Plan vs implementation:
-  - Added subsection documenting `scrobblescope-bootstrap` and
-    `gemini-pr-triage` skills with their single-agent scope.
-  - Placed between the doc-sync tooling section and the batch-structure section
-    as specified by the definition.
-- Deviations: small functional docsync fix bundled with this commit (flagged
-  at PR #159 discussion_r3645236188). `scripts/docsync/logic.py` and
-  `scripts/docsync/renderer.py`: corrected entry scan order from forward
-  (oldest-first) to reverse so `_latest_test_count_from_entries` and
-  `_build_status_block` both read the most recent entry's test count instead
-  of the oldest's. Updated existing tests to reflect correct behavior. Under
-  20 lines of production code; treated as an in-WP deviation per AGENTS.md
-  scope-discipline rules. Raises pytest baseline from 389 to 390 (one new
-  renderer regression test added).
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files` --
-  all hooks pass.
-- Forward guidance: WP-6 cleans up and archives `FINDINGS.md`.
-
-### 2026-07-24 - FINDINGS.md cleanup and archive (Batch 20 WP-6)
-
-- Scope: completed Batch 20 WP-6 -- one-time FINDINGS.md cleanup, created
-  `docs/history/findings/FINDINGS_ARCHIVE.md`, standardized all remaining
-  items to `F-<context>-<N>:` headings, added the rotation-policy header.
-- Plan vs implementation:
-  - Archived: "Resolved since last update (2026-03-02)" block, F-B18-8,
-    F-B19-1, F-B19-2, F-B19-5, the F-B19-6 code-fix portion, and F-B20-1
-    (written directly to the archive per the definition).
-  - `BATCH21_DEFINITION.md`: F-B19-5 source reference now points to the
-    archive.
-  - Consolidated deferred Batch 18/19 findings into a one-line
-    "Deferred / future-batch candidates" block; promoted F-B18-1 to the
-    fully scoped P1 item F-B20-2; added F-B20-3 and F-B20-4.
-  - Bare-number to F-ID mapping: 2 -> F-LOAD-1, 3 -> F-AUDIT-1,
-    4 -> F-LOAD-2, 5 -> F-MAS-1, 6 -> F-MAS-2, 7 -> F-DOCSYNC-1,
-    8 -> F-MAS-3, 9 -> F-MAS-4, 10-13 -> F-MAS-5 through F-MAS-8,
-    14-16 -> F-LOAD-3 through F-LOAD-5, 18/19 -> F-FEATURE-1/2.
-- Deviations (all to meet the under-200-line target while keeping
-  PLAYBOOK cross-references to F-B18-11 and F-B19-3 valid):
-  - Also archived F-B18-6 and F-B18-9 (both resolved; F-B18-9 verified
-    against `heatmap.js`, which renders user strings via `textContent`
-    and cites the finding in its header comment) though neither was on
-    the definition's archive list.
-  - Added F-B18-2, F-B18-12 (verified still open: no `min-width` on
-    `.mode-pill`), F-B19-3, and F-B19-4 to the deferred one-liner block
-    beyond the six listed in the definition.
-  - Moved the 2026-03-04 load-test data table to the archive with a
-    pointer left in FINDINGS.md.
-  - Folded Info item 17 (orchestrator split deferral) into F-B20-2
-    rather than assigning it an ID, since it duplicated F-B18-1.
+  - `doc_state_sync.py --fix --keep-non-current 0` purged the 4 rotated
+    non-current side-task entries into the monolith archive.
+  - `git mv BATCH20_DEFINITION.md docs/history/definitions/` and marked
+    the archived definition header Complete.
+  - PLAYBOOK Section 2: Batch 20 row now links to the archived
+    definition. Section 3: Batch 20 marked complete; Batch 21 (UI
+    overhaul) flagged as next, awaiting the owner's in-progress UI
+    proposal.
+  - `.claude/SESSION_CONTEXT.md` Section 1: Batch 20 row set to
+    Complete (all 9 WPs); Batch 21 row set to next-batch status. The
+    "22 test modules" wording was already correct from earlier WPs.
+- Deviations: none. Batch ran WP-0..WP-5 via Copilot PRs (#153/#155/
+  #156/#159), then a post-merge audit follow-up commit plus WP-6, WP-7,
+  and this close-out on `wip/batch-20` in a worktree.
 - Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-  `FINDINGS.md` is 199 physical lines (down from 418) -- meets the
-  under-200 acceptance criterion; the 150-180 stretch target was not
-  reachable without cutting content the definition says to keep.
-- Forward guidance: WP-7 adds the FINDINGS read-on-demand pointer and
-  finding-writing rules to AGENTS.md + HANDOFF_PROMPT.md + the bootstrap
-  skill; F-B19-6 (naive-tz anti-pattern registration) is a natural WP-7
-  companion since it also edits the AGENTS.md anti-pattern registry.
-
-### 2026-07-24 - FINDINGS on-demand rule + finding-writing standard (Batch 20 WP-7)
-
-- Scope: completed Batch 20 WP-7 across `AGENTS.md`, `HANDOFF_PROMPT.md`,
-  and the local `scrobblescope-bootstrap` Claude Code skill.
-- Plan vs implementation:
-  - `AGENTS.md` Session Bootstrap: added `FINDINGS.md` as an explicit
-    read-on-demand step (only when Section 4 or the task references an
-    F-* ID or an open P0/P1 item).
-  - `AGENTS.md`: new "Finding-Writing Rules" section after the
-    Anti-Pattern Registry (F-ID format, required fields, no bare numbers,
-    rotation to `docs/history/findings/FINDINGS_ARCHIVE.md`,
-    cross-reference pointers for promoted/absorbed findings).
-  - `HANDOFF_PROMPT.md` Section 1: symmetric on-demand FINDINGS pointer
-    as new item 6; "read all five files" wording adjusted to "five core
-    files" so the on-demand item is not read as mandatory.
-  - Skill: finding-related cues added to the frontmatter description
-    (which drives invocation) and the "When to invoke" list, plus an
-    on-demand FINDINGS note in the read order. The skill file lives
-    outside the repo (`~/.claude/skills/`), so it is not part of this
-    commit; recorded here for traceability.
-- Deviations:
-  - Folded in F-B19-6 as owner-approved: registered the naive-tz
-    vacuous-datetime-test anti-pattern as Anti-Pattern Registry item 6,
-    citing the canonical regression test from PR #152. Since that closes
-    the finding, F-B19-6 was removed from FINDINGS.md P1 and rotated to
-    the archive in the same commit (avoids the silent-doc-staleness
-    anti-pattern rather than waiting for WP-8).
-  - Aligned the `AGENTS.md` Session Bootstrap numbered list with the
-    canonical HANDOFF_PROMPT.md order (PLAYBOOK -> batch definition ->
-    SESSION_CONTEXT -> AGENT_NOTES). The two files previously disagreed
-    (SESSION_CONTEXT-first vs PLAYBOOK-first, missing definition step),
-    a divergence flagged during this session's bootstrap; HANDOFF_PROMPT
-    owns the session-start procedure per the SoC contract, so AGENTS.md
-    now matches it.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: WP-8 close-out remains -- archive the definition via
-  `git mv`, update PLAYBOOK Sections 2/3, purge non-current log entries
-  with `--keep-non-current 0`, and refresh SESSION_CONTEXT.
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0 with only the
+  expected `BATCH21_DEFINITION.md` root warning remaining.
+- Forward guidance: next batch is Batch 21 (UI overhaul); expand
+  `BATCH21_DEFINITION.md` into WPs once the owner's proposal lands.
+  `wip/batch-20` holds four unpushed commits awaiting owner review and
+  push/PR instruction.
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
-
-### 2026-07-24 - Post-merge audit gap fixes (Batch 20 audit follow-up)
-
-- Scope: close gaps found by the owner-requested audit of PR #159 (WP-1
-  through WP-5 were executed via Copilot + PR reviews; audit compared the
-  merged result against `BATCH20_DEFINITION.md` acceptance criteria).
-  Work continues in a `wip/batch-20` worktree off `main` for isolation.
-- Plan vs implementation:
-  - `README.md`: deleted the "Doc-State Sync Tooling" bullet from Key
-    Implementation Highlights (WP-1 acceptance item; the WP-1 log entry
-    claimed removal but no commit ever removed it). Fixed the Project
-    Structure tree so the agent-docs cluster is a comment row instead of
-    a fake directory nesting five root-level files, and moved `AGENTS.md`
-    and `PLAYBOOK.md` into that cluster. Added the missing prose note that
-    `BATCHN_DEFINITION.md` sits at the root only while a batch is active.
-  - `DEVELOPMENT.md`: corrected the `scrobblescope-bootstrap` description
-    to the skill's actual read order (AGENTS.md -> PLAYBOOK 3-4 -> active
-    batch definition -> SESSION_CONTEXT 1-2 -> AGENT_NOTES, then git/test
-    verification) replacing the inaccurate SESSION_CONTEXT-first
-    early-stop description.
-  - `BATCH20_DEFINITION.md` header: refreshed stale status ("awaiting
-    owner audit"), branch, and 389 baseline (390 since the WP-5 deviation).
-  - `PLAYBOOK.md` Section 3 + `.claude/SESSION_CONTEXT.md` Section 1:
-    branch updated from merged `file-hygeine` to `wip/batch-20`.
-- Deviations: Getting Started length (WP-3 target ~95-100 lines, actual
-  155 after review iterations added a full `docker run` block and 3-OS
-  schema-init instructions) left as-is pending owner decision:
-  re-compress vs accept the expanded setup detail.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: WP-6 (FINDINGS.md cleanup and archive) is next.
-
-### 2026-07-24 - README CSRF and UX cleanup (side-task)
-
-- Scope: PR-review-comment-driven fixes to `README.md` and `AGENTS.md`.
-- Plan vs implementation:
-  - `README.md`: updated CSRF description to document three distinct injection
-    mechanisms -- form-submit body token (`/results_loading`, `/results_complete`,
-    `/unmatched_view`), header-only fetch (`/reset_progress`), and both body and
-    header (`/heatmap_loading`). Added `/unmatched_view` to the form-submit route
-    list after reviewer confirmed the hidden `csrf_token` input at
-    `templates/results.html:177-178`.
-  - `README.md`: removed three duplicate UX entries from the Styling & UX details
-    block (rotating messages, personalized stats, onboarding) that were already
-    covered in the Features section above.
-  - `AGENTS.md`: removed a non-ASCII section symbol (replaced with plain text
-    "Section") to comply with the ASCII-only markdown authoring rule.
-- Deviations: none -- all changes are documentation-only PR review responses
-  outside Batch 20 WPs; Batch 20 WP status and next action are unchanged.
-- Validation: `python scripts/doc_state_sync.py --check` -- exit 0.
-- Forward guidance: Batch 20 WP-6 (FINDINGS.md cleanup) is still the next
-  work package.
-
-### 2026-07-24 - DEVELOPMENT.md file-count follow-up
-
-- Scope: side-task follow-up to close the missed Batch 20 WP-5 documentation
-  requirement in `DEVELOPMENT.md` by acknowledging `FINDINGS.md` as the sixth
-  advisory, read-on-demand file in the external-memory description.
-- Plan vs implementation:
-  - Reworded the file-count paragraph to distinguish the five core tracked
-    files from advisory `FINDINGS.md`, while keeping the archive-directory
-    count unchanged.
-  - Kept the wording explicit so IDE-based agents (for example Claude Code
-    and Codex in VS Code) do not misread `FINDINGS.md` as part of the
-    mandatory bootstrap set.
-- Deviations: none -- this closes a missed WP-5 acceptance item flagged in PR
-  review and leaves Batch 20 WP-6 as the next unstarted work package.
-- Validation: `.venv/bin/pytest -q` -- **390 passed**. `.venv/bin/pre-commit
-  run --all-files` -- all hooks pass. `.venv/bin/python scripts/doc_state_sync.py
-  --check` -- exit 0 with the two expected root-BATCH warnings.
-- Forward guidance: WP-6 still cleans up and archives `FINDINGS.md`.
-
-### 2026-07-24 - Restore out-of-scope README edits (side-task)
-
-- Scope: revert the Features-section rewrite and the Acknowledgements removal
-  made in PR #159 outside Batch 20 WP-1 through WP-3; keep Screenshots removal
-  as intentional.
-- Plan vs implementation:
-  - `README.md`: restored the original flat-list Features section (removed the
-    "As mentioned above" intro and the `<details>` wrapper added out-of-scope).
-  - `README.md`: restored the Acknowledgements section before Author & Contact.
-  - `README.md`: updated Table of Contents to re-include only the
-    Acknowledgements link.
-- Deviations: none -- pure restoration of pre-PR content flagged by code review
-  at PR #159 discussion_r3644787390.
-- Validation: `pre-commit run --all-files` -- pass. `pytest -q` -- not
-  applicable (documentation-only change). `python scripts/doc_state_sync.py
-  --check` -- pass.
-- Forward guidance: Features and Acknowledgements now match the intended PR
-  state, with Screenshots intentionally removed; any future changes to those
-  sections require an explicit batch WP or deviation log entry.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -70,11 +70,11 @@ Completed batch definitions are archived individually under `docs/history/`.
   on `file-hygeine`; audit gap-fix follow-up, WP-6, WP-7, and WP-8 on
   `wip/batch-20`, submitted as PR #162). Definition archived:
   `docs/history/definitions/BATCH20_DEFINITION.md`.
-- **Batch 21 is next.** Definition stub: `BATCH21_DEFINITION.md` (repo
-  root). Scope TBD -- global UI overhaul (font stack, palette
+- **Batch 21 is not yet defined.** Definition stub: `BATCH21_DEFINITION.md`
+  (repo root). Scope TBD -- global UI overhaul (font stack, palette
   integration, index card rework, Bootstrap CDN consolidation) driven by
   the owner's audit PDF; owner is drafting the UI proposal now. No WP
-  work begins until scope lands.
+  work begins until the definition is approved and committed.
 - **Next action:** await Batch 21 scope from the owner's UI proposal,
   then expand `BATCH21_DEFINITION.md` into WPs.
 - **Perf note (measured 2026-05-16):** Heatmap fetch for `flounder14`
@@ -213,3 +213,28 @@ non-current operational logs. Older dated entries live in
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: review rounds are now in pure-style territory;
   recommend merging PR #162.
+
+### 2026-07-24 - PR #162 review response, round 4 (side-task)
+
+- Scope: Copilot round 4 -- one comment on PLAYBOOK Section 3 batch-state
+  wording. Acted on, with a corrected mechanism note.
+- Plan vs implementation:
+  - Section 3 now uses the parser-recognized marker "Batch 21 is not yet
+    defined"; the Section 3 parse verifiably returns the between-batches
+    state with that wording in place.
+  - Verified the comment's mechanism was doubly off: `BATCH_NEXT_RE`
+    does not match "Batch 21 is next" (the attribution came from the
+    `last_completed + 1` fallback at `parser.py:198-199`), and the
+    wording fix alone cannot change the rendered STATUS -- with the
+    close-out entry still inside the CURRENT-BATCH markers,
+    `renderer.py:85-86` applies its own `last_completed + 1` fallback.
+    Batch 19 precedent shows this is transient: its identically-tagged
+    close-out entry rotated out automatically when Batch 20 WP-0 landed,
+    and the same will happen at Batch 21 WP-0.
+  - Logged the renderer gap as F-DOCSYNC-2 (open P2) rather than
+    hand-moving machine-managed marker content or patching docsync code
+    inside a docs-only PR.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: owner is merging PR #162; Batch 21 opens next.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -68,8 +68,8 @@ Completed batch definitions are archived individually under `docs/history/`.
   PR #152 (Batches 18 + 19) merged to `main`.
 - **Batch 20 is complete.** All 9 WPs done (WP-0 through WP-5 via PR #159
   on `file-hygeine`; audit gap-fix follow-up, WP-6, WP-7, and WP-8 on
-  `wip/batch-20`, unpushed pending owner instruction). Definition
-  archived: `docs/history/definitions/BATCH20_DEFINITION.md`.
+  `wip/batch-20`, submitted as PR #162). Definition archived:
+  `docs/history/definitions/BATCH20_DEFINITION.md`.
 - **Batch 21 is next.** Definition stub: `BATCH21_DEFINITION.md` (repo
   root). Scope TBD -- global UI overhaul (font stack, palette
   integration, index card rework, Bootstrap CDN consolidation) driven by
@@ -138,3 +138,33 @@ non-current operational logs. Older dated entries live in
   push/PR instruction.
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
+
+### 2026-07-24 - PR #162 review response (side-task)
+
+- Scope: address the Copilot review on PR #162 (Batch 20 completion).
+  All six comments (four inline + two suppressed low-confidence) were
+  valid doc-consistency catches; five acted on fully, one partially.
+- Plan vs implementation:
+  - `FINDINGS.md`: header status updated to Batch 20 complete / Batch 21
+    next; `Source:` added to F-B20-4 and F-B18-11; `Status:` lines added
+    to all P2, Info, and feature items; shipped F-FEATURE-2 rotated to
+    the archive with a cross-reference note.
+  - `AGENTS.md` Finding-Writing Rules: rotation rule clarified --
+    standing design-decision Info items (F-LOAD-3..5) keep their F-IDs
+    in the active file and rotate only when superseded. This is the
+    partial decline: archiving them would contradict the Batch 20
+    definition's WP-6 intent.
+  - `docs/history/findings/FINDINGS_ARCHIVE.md`: header claim narrowed
+    to ID/history preservation (bodies may be condensed at rotation).
+  - `PLAYBOOK.md` Section 3: "unpushed pending owner instruction"
+    replaced with "submitted as PR #162" (the Section 4 close-out entry
+    keeps the original wording as a point-in-time record).
+  - `AGENT_NOTES.md`: stale "Batch 20 is now active" block updated to
+    complete/archived status with Batch 21 next.
+  - `BATCH21_DEFINITION.md`: baseline refreshed 389 -> 390.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: batched reply posted on PR #162; awaiting merge.
+  Batch 21 scope expansion remains next once the owner's UI proposal
+  lands.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -69,7 +69,8 @@ Completed batch definitions are archived individually under `docs/history/`.
 - **Batch 20 is active.** Definition: `BATCH20_DEFINITION.md` (repo root).
   Scope: file-hygiene + docs methodology refresh (README, DEVELOPMENT.md,
   FINDINGS.md rotation, AGENTS.md finding-writing rules, bootstrap skill
-  update). No production-code changes. Branch: `file-hygeine`.
+  update). No production-code changes. Branch: `wip/batch-20`
+  (WP-0 through WP-5 landed via `file-hygeine`, merged in PR #159).
 - **Batch 21 (placeholder, renumbered from Batch 20).** Definition:
   `BATCH21_DEFINITION.md` (repo root). Scope TBD -- global UI overhaul
   (font stack, palette integration, index card rework, Bootstrap CDN
@@ -223,6 +224,37 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-24 - Post-merge audit gap fixes (Batch 20 audit follow-up)
+
+- Scope: close gaps found by the owner-requested audit of PR #159 (WP-1
+  through WP-5 were executed via Copilot + PR reviews; audit compared the
+  merged result against `BATCH20_DEFINITION.md` acceptance criteria).
+  Work continues in a `wip/batch-20` worktree off `main` for isolation.
+- Plan vs implementation:
+  - `README.md`: deleted the "Doc-State Sync Tooling" bullet from Key
+    Implementation Highlights (WP-1 acceptance item; the WP-1 log entry
+    claimed removal but no commit ever removed it). Fixed the Project
+    Structure tree so the agent-docs cluster is a comment row instead of
+    a fake directory nesting five root-level files, and moved `AGENTS.md`
+    and `PLAYBOOK.md` into that cluster. Added the missing prose note that
+    `BATCHN_DEFINITION.md` sits at the root only while a batch is active.
+  - `DEVELOPMENT.md`: corrected the `scrobblescope-bootstrap` description
+    to the skill's actual read order (AGENTS.md -> PLAYBOOK 3-4 -> active
+    batch definition -> SESSION_CONTEXT 1-2 -> AGENT_NOTES, then git/test
+    verification) replacing the inaccurate SESSION_CONTEXT-first
+    early-stop description.
+  - `BATCH20_DEFINITION.md` header: refreshed stale status ("awaiting
+    owner audit"), branch, and 389 baseline (390 since the WP-5 deviation).
+  - `PLAYBOOK.md` Section 3 + `.claude/SESSION_CONTEXT.md` Section 1:
+    branch updated from merged `file-hygeine` to `wip/batch-20`.
+- Deviations: Getting Started length (WP-3 target ~95-100 lines, actual
+  155 after review iterations added a full `docker run` block and 3-OS
+  schema-init instructions) left as-is pending owner decision:
+  re-compress vs accept the expanded setup detail.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: WP-6 (FINDINGS.md cleanup and archive) is next.
+
 ### 2026-07-24 - README CSRF and UX cleanup (side-task)
 
 - Scope: PR-review-comment-driven fixes to `README.md` and `AGENTS.md`.
@@ -282,26 +314,3 @@ non-current operational logs. Older dated entries live in
 - Forward guidance: Features and Acknowledgements now match the intended PR
   state, with Screenshots intentionally removed; any future changes to those
   sections require an explicit batch WP or deviation log entry.
-
-### 2026-07-24 - Copilot comment-job bootstrap trim (side-task)
-
-- Scope: reduce unnecessary bootstrap for Copilot PR comment/review-comment
-  jobs after the `copilot` Actions run failed in request processing with a
-  monthly-quota error before reaching the linked review thread.
-- Plan vs implementation:
-  - `AGENTS.md`: added a targeted review-comment fast-path for prompts that
-    link to a single `discussion_r...` thread, limiting reads to the linked
-    file/lines plus only the bootstrap context that thread actually needs.
-  - `HANDOFF_PROMPT.md`: removed the unconditional "read all bootstrap
-    files" mandate for comment jobs and aligned the startup procedure with
-    the lighter fast-path in `AGENTS.md`.
-- Deviations: none -- this is a side-task CI reliability fix outside Batch 20;
-  Batch 20 WP status and next action are unchanged.
-- Validation: `python scripts/doc_state_sync.py --fix` -- no changes.
-  `python scripts/doc_state_sync.py --check` -- pass, with the two expected
-  active-root-BATCH warnings. `pytest -q` and `pre-commit run --all-files`
-  could not run in this sandbox because the repo-local `.venv` and those
-  executables are not present here.
-- Forward guidance: if future comment jobs still hit quota, inspect whether
-  the prompt is fetching full PR comment lists when a direct review-comment
-  URL is already supplied.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -76,9 +76,9 @@ Completed batch definitions are archived individually under `docs/history/`.
   (font stack, palette integration, index card rework, Bootstrap CDN
   consolidation) driven by an owner audit PDF. No WP work begins until
   scope lands.
-- **Next action:** Batch 20 WP-7 (AGENTS.md + HANDOFF_PROMPT.md + skill:
-  FINDINGS on-demand pointer + finding-writing standard).
-- Batch 20 WP status: WP-0 through WP-6 done. WP-7 and WP-8 not yet started.
+- **Next action:** Batch 20 WP-8 (close-out: archive definition, purge
+  log, mark batch complete).
+- Batch 20 WP status: WP-0 through WP-7 done. WP-8 not yet started.
 - **Perf note (measured 2026-05-16):** Heatmap fetch for `flounder14`
   (103 pages) took 10.9s. `lastfm.py` already uses `limit=200` and concurrent
   `as_completed` fetching. 10.9s is the rate-limit floor (103 pages /
@@ -263,6 +263,46 @@ non-current operational logs. Older dated entries live in
   finding-writing rules to AGENTS.md + HANDOFF_PROMPT.md + the bootstrap
   skill; F-B19-6 (naive-tz anti-pattern registration) is a natural WP-7
   companion since it also edits the AGENTS.md anti-pattern registry.
+
+### 2026-07-24 - FINDINGS on-demand rule + finding-writing standard (Batch 20 WP-7)
+
+- Scope: completed Batch 20 WP-7 across `AGENTS.md`, `HANDOFF_PROMPT.md`,
+  and the local `scrobblescope-bootstrap` Claude Code skill.
+- Plan vs implementation:
+  - `AGENTS.md` Session Bootstrap: added `FINDINGS.md` as an explicit
+    read-on-demand step (only when Section 4 or the task references an
+    F-* ID or an open P0/P1 item).
+  - `AGENTS.md`: new "Finding-Writing Rules" section after the
+    Anti-Pattern Registry (F-ID format, required fields, no bare numbers,
+    rotation to `docs/history/findings/FINDINGS_ARCHIVE.md`,
+    cross-reference pointers for promoted/absorbed findings).
+  - `HANDOFF_PROMPT.md` Section 1: symmetric on-demand FINDINGS pointer
+    as new item 6; "read all five files" wording adjusted to "five core
+    files" so the on-demand item is not read as mandatory.
+  - Skill: finding-related cues added to the frontmatter description
+    (which drives invocation) and the "When to invoke" list, plus an
+    on-demand FINDINGS note in the read order. The skill file lives
+    outside the repo (`~/.claude/skills/`), so it is not part of this
+    commit; recorded here for traceability.
+- Deviations:
+  - Folded in F-B19-6 as owner-approved: registered the naive-tz
+    vacuous-datetime-test anti-pattern as Anti-Pattern Registry item 6,
+    citing the canonical regression test from PR #152. Since that closes
+    the finding, F-B19-6 was removed from FINDINGS.md P1 and rotated to
+    the archive in the same commit (avoids the silent-doc-staleness
+    anti-pattern rather than waiting for WP-8).
+  - Aligned the `AGENTS.md` Session Bootstrap numbered list with the
+    canonical HANDOFF_PROMPT.md order (PLAYBOOK -> batch definition ->
+    SESSION_CONTEXT -> AGENT_NOTES). The two files previously disagreed
+    (SESSION_CONTEXT-first vs PLAYBOOK-first, missing definition step),
+    a divergence flagged during this session's bootstrap; HANDOFF_PROMPT
+    owns the session-start procedure per the SoC contract, so AGENTS.md
+    now matches it.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: WP-8 close-out remains -- archive the definition via
+  `git mv`, update PLAYBOOK Sections 2/3, purge non-current log entries
+  with `--keep-non-current 0`, and refresh SESSION_CONTEXT.
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -193,3 +193,23 @@ non-current operational logs. Older dated entries live in
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: PR #162 ready for merge; Batch 21 definition draft
   sits uncommitted in the worktree awaiting owner approval.
+
+### 2026-07-24 - PR #162 review response, round 3 (side-task)
+
+- Scope: Copilot round 3 (two comments + one suppressed duplicate).
+  One acted on, one declined.
+- Plan vs implementation:
+  - Acted: both F-B19-6 archive headings moved their portion qualifier
+    after the colon to match the `F-<context>-<N>: <title>` format the
+    batch itself established (AGENTS.md Finding-Writing Rules).
+  - Declined: updating the `BATCH20_DEFINITION.md:107-108` citation
+    inside the archived `docs/history/logs/BATCH20_LOG.md` WP-3 entry.
+    Rotated log entries are point-in-time records (same principle as
+    the round-1 "unpushed" decline, which the reviewer accepted), they
+    are machine-rotated content the docsync tooling owns, and the
+    filename remains uniquely greppable at its archived location.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: review rounds are now in pure-style territory;
+  recommend merging PR #162.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -76,8 +76,9 @@ Completed batch definitions are archived individually under `docs/history/`.
   (font stack, palette integration, index card rework, Bootstrap CDN
   consolidation) driven by an owner audit PDF. No WP work begins until
   scope lands.
-- **Next action:** Batch 20 WP-6 (FINDINGS.md: cleanup and archive).
-- Batch 20 WP status: WP-0 through WP-5 done. WP-6 through WP-8 not yet started.
+- **Next action:** Batch 20 WP-7 (AGENTS.md + HANDOFF_PROMPT.md + skill:
+  FINDINGS on-demand pointer + finding-writing standard).
+- Batch 20 WP status: WP-0 through WP-6 done. WP-7 and WP-8 not yet started.
 - **Perf note (measured 2026-05-16):** Heatmap fetch for `flounder14`
   (103 pages) took 10.9s. `lastfm.py` already uses `limit=200` and concurrent
   `as_completed` fetching. 10.9s is the rate-limit floor (103 pages /
@@ -221,6 +222,47 @@ non-current operational logs. Older dated entries live in
 - Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files` --
   all hooks pass.
 - Forward guidance: WP-6 cleans up and archives `FINDINGS.md`.
+
+### 2026-07-24 - FINDINGS.md cleanup and archive (Batch 20 WP-6)
+
+- Scope: completed Batch 20 WP-6 -- one-time FINDINGS.md cleanup, created
+  `docs/history/findings/FINDINGS_ARCHIVE.md`, standardized all remaining
+  items to `F-<context>-<N>:` headings, added the rotation-policy header.
+- Plan vs implementation:
+  - Archived: "Resolved since last update (2026-03-02)" block, F-B18-8,
+    F-B19-1, F-B19-2, F-B19-5, the F-B19-6 code-fix portion, and F-B20-1
+    (written directly to the archive per the definition).
+  - `BATCH21_DEFINITION.md`: F-B19-5 source reference now points to the
+    archive.
+  - Consolidated deferred Batch 18/19 findings into a one-line
+    "Deferred / future-batch candidates" block; promoted F-B18-1 to the
+    fully scoped P1 item F-B20-2; added F-B20-3 and F-B20-4.
+  - Bare-number to F-ID mapping: 2 -> F-LOAD-1, 3 -> F-AUDIT-1,
+    4 -> F-LOAD-2, 5 -> F-MAS-1, 6 -> F-MAS-2, 7 -> F-DOCSYNC-1,
+    8 -> F-MAS-3, 9 -> F-MAS-4, 10-13 -> F-MAS-5 through F-MAS-8,
+    14-16 -> F-LOAD-3 through F-LOAD-5, 18/19 -> F-FEATURE-1/2.
+- Deviations (all to meet the under-200-line target while keeping
+  PLAYBOOK cross-references to F-B18-11 and F-B19-3 valid):
+  - Also archived F-B18-6 and F-B18-9 (both resolved; F-B18-9 verified
+    against `heatmap.js`, which renders user strings via `textContent`
+    and cites the finding in its header comment) though neither was on
+    the definition's archive list.
+  - Added F-B18-2, F-B18-12 (verified still open: no `min-width` on
+    `.mode-pill`), F-B19-3, and F-B19-4 to the deferred one-liner block
+    beyond the six listed in the definition.
+  - Moved the 2026-03-04 load-test data table to the archive with a
+    pointer left in FINDINGS.md.
+  - Folded Info item 17 (orchestrator split deferral) into F-B20-2
+    rather than assigning it an ID, since it duplicated F-B18-1.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+  `FINDINGS.md` is 199 physical lines (down from 418) -- meets the
+  under-200 acceptance criterion; the 150-180 stretch target was not
+  reachable without cutting content the definition says to keep.
+- Forward guidance: WP-7 adds the FINDINGS read-on-demand pointer and
+  finding-writing rules to AGENTS.md + HANDOFF_PROMPT.md + the bootstrap
+  skill; F-B19-6 (naive-tz anti-pattern registration) is a natural WP-7
+  companion since it also edits the AGENTS.md anti-pattern registry.
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -168,3 +168,28 @@ non-current operational logs. Older dated entries live in
 - Forward guidance: batched reply posted on PR #162; awaiting merge.
   Batch 21 scope expansion remains next once the owner's UI proposal
   lands.
+
+### 2026-07-24 - PR #162 review response, round 2 (side-task)
+
+- Scope: address Copilot's second review round on PR #162 (four inline
+  comments + one suppressed). All five verified valid; all acted on.
+- Plan vs implementation:
+  - `FINDINGS.md` F-MAS-4: `except Exception` count updated 14 -> 17
+    (verified by grep; Copilot's per-file breakdown was exact) with the
+    recount date noted.
+  - `FINDINGS.md` deferred-block pointer corrected: detailed bodies live
+    in pre-Batch-20 FINDINGS.md via git history (before `494f2c7`), not
+    under `docs/history/` as previously claimed.
+  - `FINDINGS.md` F-FEATURE-2 cross-reference recast as a direct
+    sentence (grammar).
+  - `docs/history/findings/FINDINGS_ARCHIVE.md`: F-FEATURE-2 heading
+    suffix normalized to `-- RESOLVED (shipped in Batches 18/19)` per
+    the AGENTS.md suffix rule.
+  - Archived `BATCH20_DEFINITION.md` header relabeled `Baseline:` ->
+    `Final count:` so it no longer conflicts with the definition's
+    unchanged 389-baseline plan text.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: PR #162 ready for merge; Batch 21 definition draft
+  sits uncommitted in the worktree awaiting owner approval.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ Heatmap
     * Persistent Postgres metadata cache (`spotify_cache`) for Spotify album metadata across deploys/restarts, with configurable TTL via `METADATA_CACHE_TTL_DAYS` (default 30 days).
 * **Security:** Template variables are injected into JavaScript via Jinja2's `|tojson` filter to prevent XSS. Dynamic content in the unmatched album modal is escaped with `escapeHtml()` before rendering.
 * **CSRF Protection:** All mutating POST routes (`/results_loading`, `/heatmap_loading`, `/results_complete`, `/unmatched_view`, `/reset_progress`) are protected via Flask-WTF `CSRFProtect`. Two complementary mechanisms are used: form-submit routes (`/results_loading`, `/results_complete`, `/unmatched_view`) include a hidden `csrf_token` body input; fetch-based routes read a `<meta name="csrf-token">` tag -- `/reset_progress` sends the token in the `X-CSRFToken` header only, while `/heatmap_loading` sends it in both the body and the header.
-* **Doc-State Sync Tooling:** A modular Python package (`scripts/docsync/`) keeps orchestration docs (PLAYBOOK, SESSION_CONTEXT, archive) consistent across agent handoffs. Deterministic rotation, SHA-256 dedup, and cross-validation replace manual copy-paste that drifted in earlier sessions. See [DEVELOPMENT.md](DEVELOPMENT.md) for rationale.
 * **Startup Secret Guard:** `create_app()` refuses to start in production when `SECRET_KEY` is absent, shorter than 16 characters, or set to a known-weak placeholder. `DEBUG_MODE=1` downgrades the failure to a logged warning for local development.
 * **Route Helpers (SoC):** Business logic and data transforms are extracted from Flask route handlers into named module-level helpers (`_check_user_exists`, `_extract_job_params`, `_filter_results_for_display`, `_group_unmatched_by_reason`) so route handlers stay thin and helpers can be unit-tested independently.
 <details>
@@ -339,14 +338,14 @@ pre-commit run --all-files
 |-- requirements.txt               # Runtime dependencies
 |-- requirements-dev.txt           # Dev/test/tooling (includes requirements.txt)
 |-- pyproject.toml                 # Tool config (isort, pytest, pyright)
+|                                  # -- agent orchestration / docs --
 |-- AGENTS.md                      # AI agent bootstrap and contribution rules
-|-- PLAYBOOK.md                    # Active handoff playbook (agent orchestration)
-|-- # Agent orchestration / docs
-|   |-- HANDOFF_PROMPT.md          # Session bootstrap procedure for AI agents
-|   |-- AGENT_NOTES.md             # Owner context and local development setup
-|   |-- FINDINGS.md                # Active findings and notes for current work
-|   |-- DEVELOPMENT.md             # Development methodology and doc-state process
-|   `-- DEPLOY.md                  # Deployment workflow and production checklist
+|-- PLAYBOOK.md                    # Active handoff playbook (work order + log)
+|-- HANDOFF_PROMPT.md              # Session bootstrap procedure for AI agents
+|-- AGENT_NOTES.md                 # Owner context and local development setup
+|-- FINDINGS.md                    # Active findings and notes for current work
+|-- DEVELOPMENT.md                 # Development methodology and doc-state process
+|-- DEPLOY.md                      # Deployment workflow and production checklist
 |-- scrobblescope/
 |   |-- __init__.py
 |   |-- config.py                  # Env var reads, API keys, concurrency constants
@@ -442,6 +441,8 @@ pre-commit run --all-files
 |-- LICENSE
 `-- README.md
 ```
+
+While a batch of work is active, its definition file (`BATCHN_DEFINITION.md`) sits at the repository root and is moved to `docs/history/definitions/` at close-out, so the tree above intentionally omits it.
 
 ## Deployment
 

--- a/docs/history/definitions/BATCH20_DEFINITION.md
+++ b/docs/history/definitions/BATCH20_DEFINITION.md
@@ -1,6 +1,6 @@
 # BATCH20: File-hygiene + docs methodology refresh
 
-**Status:** Active. WP-0 through WP-5 merged to `main` via PR #159; WP-6 through WP-8 remain.
+**Status:** Complete (2026-07-24). All 9 WPs done; definition archived at close-out.
 **Branch:** `wip/batch-20` (worktree off `main`; earlier WPs landed via `file-hygeine`).
 **Baseline:** 390 tests passing (389 at batch open; +1 regression test from the WP-5 docsync scan-order deviation).
 

--- a/docs/history/definitions/BATCH20_DEFINITION.md
+++ b/docs/history/definitions/BATCH20_DEFINITION.md
@@ -2,7 +2,7 @@
 
 **Status:** Complete (2026-07-24). All 9 WPs done; definition archived at close-out.
 **Branch:** `wip/batch-20` (worktree off `main`; earlier WPs landed via `file-hygeine`).
-**Baseline:** 390 tests passing (389 at batch open; +1 regression test from the WP-5 docsync scan-order deviation).
+**Final count:** 390 tests passing (the 389 baseline below held until the WP-5 docsync scan-order deviation added one regression test; see the Batch 20 log).
 
 ---
 

--- a/docs/history/findings/FINDINGS_ARCHIVE.md
+++ b/docs/history/findings/FINDINGS_ARCHIVE.md
@@ -7,6 +7,17 @@ F-IDs and text; nothing here is deleted. Newest rotation first.
 
 ---
 
+## Rotated 2026-07-24 (Batch 20 WP-7)
+
+### F-B19-6 (follow-up portion): register naive-tz anti-pattern in AGENTS.md -- RESOLVED
+
+The remaining open portion of F-B19-6 (the code fix was archived in WP-6
+below) was closed in Batch 20 WP-7: the naive-tz vacuous-datetime-test
+anti-pattern is now item 6 in the AGENTS.md Anti-Pattern Registry, citing
+`tests/test_heatmap.py::TestAggregateDailyCounts::
+test_utc_decode_invariant_against_local_tz_drift` as the canonical
+regression example.
+
 ## Rotated 2026-07-24 (Batch 20 WP-6)
 
 ### F-B20-1: README/SESSION_CONTEXT test-file count drift -- RESOLVED
@@ -128,5 +139,6 @@ silently fine; on local Windows dev or any non-UTC host it shifted day
 attribution by hours. Code fixed in PR #152 (commit `ccb000f`) with
 `tests/test_heatmap.py::TestAggregateDailyCounts::
 test_utc_decode_invariant_against_local_tz_drift` as the canonical
-regression test. The open follow-up (register the naive-tz vacuous-test
-anti-pattern in AGENTS.md) remains in `FINDINGS.md` as F-B19-6.
+regression test. The follow-up (register the naive-tz vacuous-test
+anti-pattern in AGENTS.md) was closed in Batch 20 WP-7; see the WP-7
+rotation block above.

--- a/docs/history/findings/FINDINGS_ARCHIVE.md
+++ b/docs/history/findings/FINDINGS_ARCHIVE.md
@@ -11,7 +11,7 @@ Newest rotation first.
 
 ## Rotated 2026-07-24 (PR #162 review follow-up)
 
-### F-FEATURE-2: listening heatmap feature -- SHIPPED
+### F-FEATURE-2: listening heatmap feature -- RESOLVED (shipped in Batches 18/19)
 
 Last.fm-only scrobble density calendar for the last 365 days, no Spotify
 calls. Batch 18 delivered the end-to-end feature; Batch 19 polished the

--- a/docs/history/findings/FINDINGS_ARCHIVE.md
+++ b/docs/history/findings/FINDINGS_ARCHIVE.md
@@ -1,0 +1,132 @@
+# FINDINGS Archive
+
+Resolved and no-action findings rotate here from `FINDINGS.md` at batch
+close-out (or during dedicated findings-cleanup WPs) so the active file
+stays short while grep history is preserved. Entries keep their original
+F-IDs and text; nothing here is deleted. Newest rotation first.
+
+---
+
+## Rotated 2026-07-24 (Batch 20 WP-6)
+
+### F-B20-1: README/SESSION_CONTEXT test-file count drift -- RESOLVED
+
+`README.md` and `.claude/SESSION_CONTEXT.md` claimed "24 test files" while
+the tree held 22 pytest modules. Corrected in Batch 20 WP-1 (README) and
+via the machine-managed SESSION_CONTEXT refresh; the stale "389 tests,
+24 test files" line in the FINDINGS header was the last occurrence, fixed
+in WP-6. Recorded for audit completeness and archived immediately.
+
+### Resolved since last update (2026-03-02)
+
+Items from prior audits that have been addressed:
+
+- ~~MEMORY.md stale~~ -- Deleted. Replaced by `AGENT_NOTES.md` (tracked) in Batch 17 WP-4.
+- ~~README.md screenshot placeholders~~ -- Owner replaced with "coming soon".
+- ~~CI Python version drift~~ -- Aligned to 3.13 in Batch 15.
+- ~~docsync cli.py unconditional rewrite~~ -- Gated on changed set (Batch 14).
+- ~~Test-count regex defined 3 times~~ -- Consolidated to single `TEST_COUNT_RE`
+  in `parser.py`; renderer and logic import it (Batch 14).
+- ~~Dedup-sort pattern copy-pasted~~ -- Extracted `_dedup_sorted()` helper in
+  `logic.py` (Batch 14).
+- ~~Gunicorn HTTP serialization~~ -- Added `--threads 4` to Dockerfile CMD.
+  Merged to `main` as `f8a579f` (#57). Deployed and verified.
+- ~~Dark mode ignores browser preference~~ -- `theme.js` falls back to
+  `matchMedia('prefers-color-scheme: dark')`. Commit `463282e`.
+- ~~Log rotation loses data under load~~ -- Increased to 2MB cap, 10 backups.
+  Commit `21a3b4c` on `main`.
+
+### F-B18-6: dark mode uses body.dark-mode class, not data attributes -- RESOLVED
+
+CSS uses `.dark-mode` class toggled by `theme.js`. Original Batch 18
+definition referenced `[data-theme="dark"]` which does not exist. Corrected
+in the audited definition; informational only since then.
+
+### F-B18-8: get_job_context shallow-copies results but not nested dicts -- RESOLVED
+
+**Status:** resolved during PR #152 review (Gemini Code Review catch).
+`get_job_context()` now explicitly does `results["daily_counts"] =
+dict(results["daily_counts"])` after the outer dict copy, restoring the
+function's stated contract for heatmap result shape. Variant chosen over
+`copy.deepcopy` because the polling hot path runs every ~1s per active
+job and the nested structure is well known. New regression test:
+`tests/test_repositories.py::test_get_job_context_nested_daily_counts_is_isolated`.
+
+Historical context: `repositories.py` `get_job_context()` originally
+copied list results via `list(results)` but did not copy dict results at
+all (returned the original reference). A Boy Scout fix added an
+`elif isinstance(results, dict): results = dict(results)` branch, but
+that was still a shallow copy, leaving the nested `daily_counts` shared
+by reference. PR #152 review surfaced this; the fix above closes it.
+
+### F-B18-9: username not sanitized for JS/SVG injection -- RESOLVED
+
+Routes validate that a username exists on Last.fm but do no input
+sanitization beyond that; usernames are echoed back in JSON and rendered
+client-side. Addressed during Batch 18: `heatmap.js` renders all
+user-supplied strings via `textContent` (never `innerHTML`), with the
+criterion cited at the top of the file ("No innerHTML with user data
+(XSS criterion F-B18-9)"). Verified still true 2026-07-24.
+
+### F-B19-1: loading state still read as a card -- RESOLVED
+
+Owner review showed the pinwheel centered inside a large Bootstrap card-like
+box. That made the loading state feel broken even after the earlier clipping
+fix. The follow-up removed the card wrapper and uses an unframed loading panel
+with a larger SVG-bounded pinwheel. The final SVG keeps the original
+breathing/expanding blade animation; the simplified rotating replacement was
+rejected during owner review. Fixed in Batch 19 owner-review follow-up.
+
+### F-B19-2: heatmap sizing needed separate desktop and mobile treatment -- RESOLVED
+
+Desktop screenshots at 1440p and 1080p showed the heatmap grid taking too
+little visual space because the result container was still constrained by the
+Bootstrap `col-md-8` width. Mobile review showed calendar-constrained layouts
+either left excessive side space or made cells too small. The follow-up
+widened only `#heatmap-result` on desktop and replaced the mobile layout with
+a sequential activity strip that fills the frame width with larger cells,
+plus mobile headline fitting. Fixed in Batch 19 owner-review follow-up.
+
+### F-B19-5: visual-verification tooling -- NO ACTION
+
+The Browser plugin/skill is the right Codex-side tool when its browser MCP
+tools are exposed. In the Batch 19 session, deferred tool discovery did not
+expose a callable browser screenshot tool, and shell-launched headless Chrome
+did not emit screenshots in the sandbox. For future UI-heavy batches, enable
+a Browser/Playwright MCP path if available. No new Python or Node package is
+recommended solely for visual QA.
+
+### Load test data (2026-03-04, local) -- HISTORICAL RECORD
+
+Test environment: Flask dev server (Werkzeug, threaded), local `ss-postgres`
+Docker container, all caches cleared between runs.
+
+| Concurrent Users | Per-user elapsed | Wall time | Upstream 429s | Outcome |
+|------------------|------------------|-----------|---------------|---------|
+| 1 (cached)       | 21s              | 21s       | 0             | OK      |
+| 2 (uncached)     | 88-106s          | 107s      | 0             | All OK  |
+| 3 (uncached)     | 125-201s         | 202s      | 0             | All OK  |
+| 5 (uncached)     | 115-268s         | 269s      | 0             | All OK  |
+| 10 (partial)     | 216-353s         | ~6min     | unknown       | 6/10 OK |
+
+**Caveat:** Local tests use Werkzeug (threaded HTTP). Production was single
+sync gunicorn worker (no threads) at time of testing.
+
+**Global throttle:** `_GlobalThrottle` serializes all API calls at 10 req/s
+across all job threads. Jobs slow linearly: N jobs sharing 10 req/s =
+~10/N req/s per job.
+
+**Last.fm rate config:** App configures 10 req/s; official limit is 5 req/s
+averaged over 5 minutes. No 429s observed in testing, but aggressive.
+
+### F-B19-6 (code-fix portion): naive-tz day-attribution bug -- RESOLVED
+
+PR #152 review (Gemini) surfaced that `scrobblescope/heatmap.py` decoded
+Last.fm UTS values with naive `datetime.fromtimestamp` and built the fetch
+window with naive `datetime.now()`. On Fly.io (UTC container) this was
+silently fine; on local Windows dev or any non-UTC host it shifted day
+attribution by hours. Code fixed in PR #152 (commit `ccb000f`) with
+`tests/test_heatmap.py::TestAggregateDailyCounts::
+test_utc_decode_invariant_against_local_tz_drift` as the canonical
+regression test. The open follow-up (register the naive-tz vacuous-test
+anti-pattern in AGENTS.md) remains in `FINDINGS.md` as F-B19-6.

--- a/docs/history/findings/FINDINGS_ARCHIVE.md
+++ b/docs/history/findings/FINDINGS_ARCHIVE.md
@@ -21,7 +21,7 @@ performance follow-ups continue as F-B18-11 in the active file.
 
 ## Rotated 2026-07-24 (Batch 20 WP-7)
 
-### F-B19-6 (follow-up portion): register naive-tz anti-pattern in AGENTS.md -- RESOLVED
+### F-B19-6: register naive-tz anti-pattern in AGENTS.md (follow-up portion) -- RESOLVED
 
 The remaining open portion of F-B19-6 (the code fix was archived in WP-6
 below) was closed in Batch 20 WP-7: the naive-tz vacuous-datetime-test
@@ -142,7 +142,7 @@ across all job threads. Jobs slow linearly: N jobs sharing 10 req/s =
 **Last.fm rate config:** App configures 10 req/s; official limit is 5 req/s
 averaged over 5 minutes. No 429s observed in testing, but aggressive.
 
-### F-B19-6 (code-fix portion): naive-tz day-attribution bug -- RESOLVED
+### F-B19-6: naive-tz day-attribution bug (code-fix portion) -- RESOLVED
 
 PR #152 review (Gemini) surfaced that `scrobblescope/heatmap.py` decoded
 Last.fm UTS values with naive `datetime.fromtimestamp` and built the fetch

--- a/docs/history/findings/FINDINGS_ARCHIVE.md
+++ b/docs/history/findings/FINDINGS_ARCHIVE.md
@@ -3,9 +3,21 @@
 Resolved and no-action findings rotate here from `FINDINGS.md` at batch
 close-out (or during dedicated findings-cleanup WPs) so the active file
 stays short while grep history is preserved. Entries keep their original
-F-IDs and text; nothing here is deleted. Newest rotation first.
+F-IDs; bodies may be condensed at rotation (full original text remains in
+git history and the source audit documents). Nothing here is deleted.
+Newest rotation first.
 
 ---
+
+## Rotated 2026-07-24 (PR #162 review follow-up)
+
+### F-FEATURE-2: listening heatmap feature -- SHIPPED
+
+Last.fm-only scrobble density calendar for the last 365 days, no Spotify
+calls. Batch 18 delivered the end-to-end feature; Batch 19 polished the
+result frame, KPIs, pill labels, pinwheel animation, and mobile layout.
+Rotated per the finding-writing rules since the feature shipped;
+performance follow-ups continue as F-B18-11 in the active file.
 
 ## Rotated 2026-07-24 (Batch 20 WP-7)
 

--- a/docs/history/logs/BATCH20_LOG.md
+++ b/docs/history/logs/BATCH20_LOG.md
@@ -1,0 +1,194 @@
+# Batch 20 Execution Log
+
+Archived entries for Batch 20 work packages.
+
+### 2026-07-24 - README counts/structure/mermaid refresh (Batch 20 WP-1)
+
+- Scope: completed Batch 20 WP-1 in `README.md` (test-count wording, project
+  structure refresh, and Mermaid flow update).
+- Plan vs implementation:
+  - Updated test-count references to 22 test modules.
+  - Refreshed the root project-structure block with the requested
+    orchestration/documentation files.
+  - Replaced the older architecture mermaid with the current two-pipeline
+    diagram and removed the doc-state-sync bullet from key highlights.
+- Deviations: none.
+- Validation: `pytest -q` -- **389 passed**. `pre-commit run --all-files` --
+  all hooks pass.
+- Forward guidance: continue with WP-2 roadmap trimming.
+
+### 2026-07-24 - README roadmap trim (Batch 20 WP-2)
+
+- Scope: completed Batch 20 WP-2 roadmap cleanup in `README.md`.
+- Plan vs implementation:
+  - Removed completed/scaffolding roadmap items and duplicate heatmap entries.
+  - Preserved required unchecked roadmap items and converted the quality-track
+    checklist into a concise reminder paragraph.
+  - Added concrete forward items for orchestrator decomposition, integration
+    testing, CDN consolidation, and regex hardening.
+- Deviations: none.
+- Validation: `pytest -q` -- **389 passed**. `pre-commit run --all-files` --
+  all hooks pass.
+- Forward guidance: continue with WP-3 Getting Started compression.
+
+### 2026-07-24 - README getting-started compression (Batch 20 WP-3)
+
+- Scope: completed Batch 20 WP-3 Getting Started tightening in `README.md`.
+- Plan vs implementation:
+  - Compressed the venv/setup instructions while retaining Linux + Windows
+    coverage.
+  - Reduced `.env` optional-tuning examples and pointed readers to
+    `scrobblescope/config.py` for the full option set.
+  - Tightened local DB-cache development prose while preserving prerequisites,
+    one-command startup, and smoke/concurrency checks.
+- Deviations: initial commit left the full 8-var optional-tuning list and the
+  `load_dotenv()` trivia line in place; both corrections were applied in
+  follow-up commits after reviewer feedback (`BATCH20_DEFINITION.md:107-108`).
+- Validation: `pytest -q` -- **389 passed**. `pre-commit run --all-files` --
+  all hooks pass.
+- Forward guidance: continue with WP-4 DEVELOPMENT.md cleanup.
+
+### 2026-07-24 - DEVELOPMENT.md path/timeline/prose cleanup (Batch 20 WP-4)
+
+- Scope: completed Batch 20 WP-4 in `DEVELOPMENT.md`.
+- Plan vs implementation:
+  - Corrected the archive-definition path references to
+    `docs/history/definitions/...`.
+  - Updated the development-timeline framing to reflect concentrated
+    Feb-March work plus lighter later follow-up.
+  - Trimmed identified AI-prose padding while preserving technical intent.
+- Deviations: none.
+- Validation: `pytest -q` -- **389 passed**. `pre-commit run --all-files` --
+  all hooks pass.
+- Forward guidance: WP-5 adds the Claude Code skills subsection in
+  `DEVELOPMENT.md`.
+
+### 2026-07-24 - DEVELOPMENT.md skills subsection (Batch 20 WP-5)
+
+- Scope: completed Batch 20 WP-5 -- added the "Claude Code Skills (tightly
+  scoped tooling)" subsection to `DEVELOPMENT.md`.
+- Plan vs implementation:
+  - Added subsection documenting `scrobblescope-bootstrap` and
+    `gemini-pr-triage` skills with their single-agent scope.
+  - Placed between the doc-sync tooling section and the batch-structure section
+    as specified by the definition.
+- Deviations: small functional docsync fix bundled with this commit (flagged
+  at PR #159 discussion_r3645236188). `scripts/docsync/logic.py` and
+  `scripts/docsync/renderer.py`: corrected entry scan order from forward
+  (oldest-first) to reverse so `_latest_test_count_from_entries` and
+  `_build_status_block` both read the most recent entry's test count instead
+  of the oldest's. Updated existing tests to reflect correct behavior. Under
+  20 lines of production code; treated as an in-WP deviation per AGENTS.md
+  scope-discipline rules. Raises pytest baseline from 389 to 390 (one new
+  renderer regression test added).
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files` --
+  all hooks pass.
+- Forward guidance: WP-6 cleans up and archives `FINDINGS.md`.
+
+### 2026-07-24 - FINDINGS.md cleanup and archive (Batch 20 WP-6)
+
+- Scope: completed Batch 20 WP-6 -- one-time FINDINGS.md cleanup, created
+  `docs/history/findings/FINDINGS_ARCHIVE.md`, standardized all remaining
+  items to `F-<context>-<N>:` headings, added the rotation-policy header.
+- Plan vs implementation:
+  - Archived: "Resolved since last update (2026-03-02)" block, F-B18-8,
+    F-B19-1, F-B19-2, F-B19-5, the F-B19-6 code-fix portion, and F-B20-1
+    (written directly to the archive per the definition).
+  - `BATCH21_DEFINITION.md`: F-B19-5 source reference now points to the
+    archive.
+  - Consolidated deferred Batch 18/19 findings into a one-line
+    "Deferred / future-batch candidates" block; promoted F-B18-1 to the
+    fully scoped P1 item F-B20-2; added F-B20-3 and F-B20-4.
+  - Bare-number to F-ID mapping: 2 -> F-LOAD-1, 3 -> F-AUDIT-1,
+    4 -> F-LOAD-2, 5 -> F-MAS-1, 6 -> F-MAS-2, 7 -> F-DOCSYNC-1,
+    8 -> F-MAS-3, 9 -> F-MAS-4, 10-13 -> F-MAS-5 through F-MAS-8,
+    14-16 -> F-LOAD-3 through F-LOAD-5, 18/19 -> F-FEATURE-1/2.
+- Deviations (all to meet the under-200-line target while keeping
+  PLAYBOOK cross-references to F-B18-11 and F-B19-3 valid):
+  - Also archived F-B18-6 and F-B18-9 (both resolved; F-B18-9 verified
+    against `heatmap.js`, which renders user strings via `textContent`
+    and cites the finding in its header comment) though neither was on
+    the definition's archive list.
+  - Added F-B18-2, F-B18-12 (verified still open: no `min-width` on
+    `.mode-pill`), F-B19-3, and F-B19-4 to the deferred one-liner block
+    beyond the six listed in the definition.
+  - Moved the 2026-03-04 load-test data table to the archive with a
+    pointer left in FINDINGS.md.
+  - Folded Info item 17 (orchestrator split deferral) into F-B20-2
+    rather than assigning it an ID, since it duplicated F-B18-1.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+  `FINDINGS.md` is 199 physical lines (down from 418) -- meets the
+  under-200 acceptance criterion; the 150-180 stretch target was not
+  reachable without cutting content the definition says to keep.
+- Forward guidance: WP-7 adds the FINDINGS read-on-demand pointer and
+  finding-writing rules to AGENTS.md + HANDOFF_PROMPT.md + the bootstrap
+  skill; F-B19-6 (naive-tz anti-pattern registration) is a natural WP-7
+  companion since it also edits the AGENTS.md anti-pattern registry.
+
+### 2026-07-24 - FINDINGS on-demand rule + finding-writing standard (Batch 20 WP-7)
+
+- Scope: completed Batch 20 WP-7 across `AGENTS.md`, `HANDOFF_PROMPT.md`,
+  and the local `scrobblescope-bootstrap` Claude Code skill.
+- Plan vs implementation:
+  - `AGENTS.md` Session Bootstrap: added `FINDINGS.md` as an explicit
+    read-on-demand step (only when Section 4 or the task references an
+    F-* ID or an open P0/P1 item).
+  - `AGENTS.md`: new "Finding-Writing Rules" section after the
+    Anti-Pattern Registry (F-ID format, required fields, no bare numbers,
+    rotation to `docs/history/findings/FINDINGS_ARCHIVE.md`,
+    cross-reference pointers for promoted/absorbed findings).
+  - `HANDOFF_PROMPT.md` Section 1: symmetric on-demand FINDINGS pointer
+    as new item 6; "read all five files" wording adjusted to "five core
+    files" so the on-demand item is not read as mandatory.
+  - Skill: finding-related cues added to the frontmatter description
+    (which drives invocation) and the "When to invoke" list, plus an
+    on-demand FINDINGS note in the read order. The skill file lives
+    outside the repo (`~/.claude/skills/`), so it is not part of this
+    commit; recorded here for traceability.
+- Deviations:
+  - Folded in F-B19-6 as owner-approved: registered the naive-tz
+    vacuous-datetime-test anti-pattern as Anti-Pattern Registry item 6,
+    citing the canonical regression test from PR #152. Since that closes
+    the finding, F-B19-6 was removed from FINDINGS.md P1 and rotated to
+    the archive in the same commit (avoids the silent-doc-staleness
+    anti-pattern rather than waiting for WP-8).
+  - Aligned the `AGENTS.md` Session Bootstrap numbered list with the
+    canonical HANDOFF_PROMPT.md order (PLAYBOOK -> batch definition ->
+    SESSION_CONTEXT -> AGENT_NOTES). The two files previously disagreed
+    (SESSION_CONTEXT-first vs PLAYBOOK-first, missing definition step),
+    a divergence flagged during this session's bootstrap; HANDOFF_PROMPT
+    owns the session-start procedure per the SoC contract, so AGENTS.md
+    now matches it.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: WP-8 close-out remains -- archive the definition via
+  `git mv`, update PLAYBOOK Sections 2/3, purge non-current log entries
+  with `--keep-non-current 0`, and refresh SESSION_CONTEXT.
+
+### 2026-05-22 - Batch scaffolding (Batch 20 WP-0)
+
+- Scope: opened Batch 20 (file-hygiene + docs methodology refresh) and
+  renumbered the UI-overhaul placeholder to Batch 21, since that
+  placeholder had no started WPs.
+- Plan vs implementation:
+  - `git mv BATCH20_DEFINITION.md BATCH21_DEFINITION.md`, header updated
+    to `# BATCH21: UI overhaul -- TBD`, status note records the rename
+    reason and date.
+  - Wrote new `BATCH20_DEFINITION.md` -- 9 WPs (WP-0 through WP-8) covering README, DEVELOPMENT.md,
+    FINDINGS.md rotation + archive, AGENTS.md finding-writing rules,
+    HANDOFF_PROMPT.md pointer, and the `scrobblescope-bootstrap` skill
+    update. No production-code changes; baseline is 389 tests throughout.
+  - PLAYBOOK Section 2: added Batch 20 and Batch 21 rows. Section 3:
+    Batch 20 marked active, Batch 21 marked placeholder pending owner's
+    audit PDF, next action set to Batch 20 WP-1.
+- Deviations: none -- this session found the rename staged/edited but
+  uncommitted from a prior session (owner confirmed via `HANDOFF_PROMPT.md`
+  handoff) and completed the WP-0 commit per the definition file's own
+  instructions.
+- Validation: `pytest -q` -- **389 passed**, 3 existing aiohttp/Python 3.13
+  warnings (no code touched). `pre-commit run --all-files` -- all 10 hooks
+  pass. `doc_state_sync.py --check` -- exit 0, two expected root-BATCH-file
+  warnings (Batch 20 active + Batch 21 placeholder, both intentional).
+- Forward guidance: WP-1 starts the README pass (test-file count, project
+  structure, mermaid diagram refresh).

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,97 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-24 - Post-merge audit gap fixes (Batch 20 audit follow-up)
+
+- Scope: close gaps found by the owner-requested audit of PR #159 (WP-1
+  through WP-5 were executed via Copilot + PR reviews; audit compared the
+  merged result against `BATCH20_DEFINITION.md` acceptance criteria).
+  Work continues in a `wip/batch-20` worktree off `main` for isolation.
+- Plan vs implementation:
+  - `README.md`: deleted the "Doc-State Sync Tooling" bullet from Key
+    Implementation Highlights (WP-1 acceptance item; the WP-1 log entry
+    claimed removal but no commit ever removed it). Fixed the Project
+    Structure tree so the agent-docs cluster is a comment row instead of
+    a fake directory nesting five root-level files, and moved `AGENTS.md`
+    and `PLAYBOOK.md` into that cluster. Added the missing prose note that
+    `BATCHN_DEFINITION.md` sits at the root only while a batch is active.
+  - `DEVELOPMENT.md`: corrected the `scrobblescope-bootstrap` description
+    to the skill's actual read order (AGENTS.md -> PLAYBOOK 3-4 -> active
+    batch definition -> SESSION_CONTEXT 1-2 -> AGENT_NOTES, then git/test
+    verification) replacing the inaccurate SESSION_CONTEXT-first
+    early-stop description.
+  - `BATCH20_DEFINITION.md` header: refreshed stale status ("awaiting
+    owner audit"), branch, and 389 baseline (390 since the WP-5 deviation).
+  - `PLAYBOOK.md` Section 3 + `.claude/SESSION_CONTEXT.md` Section 1:
+    branch updated from merged `file-hygeine` to `wip/batch-20`.
+- Deviations: Getting Started length (WP-3 target ~95-100 lines, actual
+  155 after review iterations added a full `docker run` block and 3-OS
+  schema-init instructions) left as-is pending owner decision:
+  re-compress vs accept the expanded setup detail.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: WP-6 (FINDINGS.md cleanup and archive) is next.
+
+### 2026-07-24 - README CSRF and UX cleanup (side-task)
+
+- Scope: PR-review-comment-driven fixes to `README.md` and `AGENTS.md`.
+- Plan vs implementation:
+  - `README.md`: updated CSRF description to document three distinct injection
+    mechanisms -- form-submit body token (`/results_loading`, `/results_complete`,
+    `/unmatched_view`), header-only fetch (`/reset_progress`), and both body and
+    header (`/heatmap_loading`). Added `/unmatched_view` to the form-submit route
+    list after reviewer confirmed the hidden `csrf_token` input at
+    `templates/results.html:177-178`.
+  - `README.md`: removed three duplicate UX entries from the Styling & UX details
+    block (rotating messages, personalized stats, onboarding) that were already
+    covered in the Features section above.
+  - `AGENTS.md`: removed a non-ASCII section symbol (replaced with plain text
+    "Section") to comply with the ASCII-only markdown authoring rule.
+- Deviations: none -- all changes are documentation-only PR review responses
+  outside Batch 20 WPs; Batch 20 WP status and next action are unchanged.
+- Validation: `python scripts/doc_state_sync.py --check` -- exit 0.
+- Forward guidance: Batch 20 WP-6 (FINDINGS.md cleanup) is still the next
+  work package.
+
+### 2026-07-24 - DEVELOPMENT.md file-count follow-up
+
+- Scope: side-task follow-up to close the missed Batch 20 WP-5 documentation
+  requirement in `DEVELOPMENT.md` by acknowledging `FINDINGS.md` as the sixth
+  advisory, read-on-demand file in the external-memory description.
+- Plan vs implementation:
+  - Reworded the file-count paragraph to distinguish the five core tracked
+    files from advisory `FINDINGS.md`, while keeping the archive-directory
+    count unchanged.
+  - Kept the wording explicit so IDE-based agents (for example Claude Code
+    and Codex in VS Code) do not misread `FINDINGS.md` as part of the
+    mandatory bootstrap set.
+- Deviations: none -- this closes a missed WP-5 acceptance item flagged in PR
+  review and leaves Batch 20 WP-6 as the next unstarted work package.
+- Validation: `.venv/bin/pytest -q` -- **390 passed**. `.venv/bin/pre-commit
+  run --all-files` -- all hooks pass. `.venv/bin/python scripts/doc_state_sync.py
+  --check` -- exit 0 with the two expected root-BATCH warnings.
+- Forward guidance: WP-6 still cleans up and archives `FINDINGS.md`.
+
+### 2026-07-24 - Restore out-of-scope README edits (side-task)
+
+- Scope: revert the Features-section rewrite and the Acknowledgements removal
+  made in PR #159 outside Batch 20 WP-1 through WP-3; keep Screenshots removal
+  as intentional.
+- Plan vs implementation:
+  - `README.md`: restored the original flat-list Features section (removed the
+    "As mentioned above" intro and the `<details>` wrapper added out-of-scope).
+  - `README.md`: restored the Acknowledgements section before Author & Contact.
+  - `README.md`: updated Table of Contents to re-include only the
+    Acknowledgements link.
+- Deviations: none -- pure restoration of pre-PR content flagged by code review
+  at PR #159 discussion_r3644787390.
+- Validation: `pre-commit run --all-files` -- pass. `pytest -q` -- not
+  applicable (documentation-only change). `python scripts/doc_state_sync.py
+  --check` -- pass.
+- Forward guidance: Features and Acknowledgements now match the intended PR
+  state, with Screenshots intentionally removed; any future changes to those
+  sections require an explicit batch WP or deviation log entry.
+
 ### 2026-07-24 - Copilot comment-job bootstrap trim (side-task)
 
 - Scope: reduce unnecessary bootstrap for Copilot PR comment/review-comment

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,29 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-24 - Copilot comment-job bootstrap trim (side-task)
+
+- Scope: reduce unnecessary bootstrap for Copilot PR comment/review-comment
+  jobs after the `copilot` Actions run failed in request processing with a
+  monthly-quota error before reaching the linked review thread.
+- Plan vs implementation:
+  - `AGENTS.md`: added a targeted review-comment fast-path for prompts that
+    link to a single `discussion_r...` thread, limiting reads to the linked
+    file/lines plus only the bootstrap context that thread actually needs.
+  - `HANDOFF_PROMPT.md`: removed the unconditional "read all bootstrap
+    files" mandate for comment jobs and aligned the startup procedure with
+    the lighter fast-path in `AGENTS.md`.
+- Deviations: none -- this is a side-task CI reliability fix outside Batch 20;
+  Batch 20 WP status and next action are unchanged.
+- Validation: `python scripts/doc_state_sync.py --fix` -- no changes.
+  `python scripts/doc_state_sync.py --check` -- pass, with the two expected
+  active-root-BATCH warnings. `pytest -q` and `pre-commit run --all-files`
+  could not run in this sandbox because the repo-local `.venv` and those
+  executables are not present here.
+- Forward guidance: if future comment jobs still hit quota, inspect whether
+  the prompt is fetching full PR comment lists when a direct review-comment
+  URL is already supplied.
+
 ### 2026-07-22 - Link-preview image + Open Graph meta tags (side-task)
 
 - Scope: LinkedIn (and Slack/Discord/etc.) show no image when the app URL


### PR DESCRIPTION
Completes Batch 20 (file-hygiene + docs methodology refresh) following the
Copilot-driven WP-1..WP-5 work merged in #159. Four commits, all
documentation-only; no production code touched.

## Commits

1. **17294e8 -- Post-merge audit gap fixes.** An audit of #159 against
   BATCH20_DEFINITION.md acceptance criteria found: the "Doc-State Sync
   Tooling" bullet was never removed from README Key Implementation
   Highlights (despite the WP-1 log claiming it was), the Project
   Structure tree nested five root-level docs under a fake directory row,
   the transient-BATCHN-definition prose note was missing, and
   DEVELOPMENT.md described the bootstrap skill with the wrong read
   order. All fixed; stale branch/baseline references updated.
2. **494f2c7 -- WP-6: FINDINGS.md cleanup.** 418 -> 199 lines (192 after
   WP-7). Resolved/no-action items rotated to the new
   docs/history/findings/FINDINGS_ARCHIVE.md; every remaining item uses
   an F-context-N heading; rotation policy documented in the header;
   forward findings F-B20-2/3/4 added.
3. **3023d91 -- WP-7: FINDINGS on-demand rule + finding-writing
   standard.** AGENTS.md gains a Finding-Writing Rules section and a
   read-on-demand FINDINGS bootstrap step; HANDOFF_PROMPT.md gets the
   symmetric pointer; the naive-tz vacuous-datetime-test anti-pattern
   (F-B19-6) is registered as Anti-Pattern Registry item 6, closing that
   finding. Also aligns the AGENTS.md bootstrap order with
   HANDOFF_PROMPT.md, which owns the procedure per the SoC contract.
4. **4f0a31e -- WP-8: close-out.** Definition archived to
   docs/history/definitions/, Batch 20 log entries rotated to
   docs/history/logs/BATCH20_LOG.md, non-current side-task entries
   purged, PLAYBOOK/SESSION_CONTEXT flipped to Batch 21 (UI overhaul) as
   next.

## Validation (every commit)

- pytest -q: 390 passed
- pre-commit run --all-files: all 10 hooks pass
- doc_state_sync.py --check: exit 0 (only the expected
  BATCH21_DEFINITION.md root warning remains)

## Known deferred item

README Getting Started is 155 lines vs the WP-3 target of ~95-100
(review iterations on #159 expanded the Docker/DB setup blocks); left
as-is pending owner decision, logged as a deviation in the Batch 20 log.
