### PR TITLE
Phantom worktree

### DIFF
--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -31,10 +31,8 @@ Last updated: 2026-07-28
 - Cold-start validated 2026-02-19 (both app + DB auto-wake on demand).
 - DB cache validated working locally 2026-03-03: `verdict=PASS`, `db_cache_lookup_hits=44`,
   elapsed ~1.05s. Requires `ss-postgres` Docker container running and `DATABASE_URL` in `.env`.
-- **Heatmap perf (measured 2026-05-16):** 10.9s for 103 pages (`flounder14`).
-  `lastfm.py` already uses `limit=200` and concurrent `as_completed` fetching.
-  10.9s is the rate-limit floor (103 pages / 10 req/s). No further optimization
-  without heatmap-specific caching or rate-limit risk. See FINDINGS.md F-B18-11.
+- Heatmap fetch speed is rate-limit bound; measurement and rationale live in
+  FINDINGS.md F-B18-11 (single source).
 
 ---
 
@@ -57,7 +55,7 @@ Last updated: 2026-07-28
 ## 3. Project structure
 
 ```
-app.py                      # create_app() factory (~152 lines)
+app.py                      # create_app() factory (~150 lines)
 scrobblescope/
   config.py                 # env var reads, API keys, concurrency constants
   errors.py                 # SpotifyUnavailableError, ERROR_CODES
@@ -71,11 +69,11 @@ scrobblescope/
   orchestrator.py           # process_albums, _fetch_and_process, background_task, fetch_top_albums_async
   heatmap.py                # heatmap_task, _fetch_and_process_heatmap, _aggregate_daily_counts
   routes.py                 # Flask Blueprint, all route + error handlers
-templates/
-  inline/scrobblescope_pinwheel.svg  # animated pinwheel loading spinner
+templates/                  # base, index, loading, results, unmatched, error
+  inline/                   # scrobblescope_pinwheel.svg, scrobble_scope_inline.svg (wordmark)
 static/
-  css/heatmap.css            # heatmap pill tabs, form, loading, result styles
-  js/heatmap.js              # pill switching, AJAX, polling, SVG grid, tooltips
+  css/                      # global, index, loading, results, unmatched, error, heatmap (7 files)
+  js/                       # theme, index, loading, results, unmatched, error, heatmap (7 files)
 ```
 
 ---

--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -1,6 +1,6 @@
 # ScrobbleScope Session Context
 
-Last updated: 2026-07-28
+Last updated: 2026-07-31
 
 ---
 

--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -24,7 +24,8 @@ Last updated: 2026-07-28
 | Known open risk | `RotatingFileHandler` throws `PermissionError: [WinError 32]` on Windows when multiple Flask processes hold the log file open (Werkzeug debug reloader). Cosmetic -- Flask continues to serve. Linux/Fly.io unaffected. |
 
 **Key runtime facts:**
-- `MAX_ACTIVE_JOBS` (default 10) caps concurrent background jobs via `worker.py`.
+- `MAX_ACTIVE_JOBS` (default 5 since 2026-07-31; was 10) caps concurrent
+  background jobs via `worker.py`.
 - `_GlobalThrottle` in `utils.py` caps aggregate API throughput across all threads.
 - `_cache_lock` in `utils.py` guards `REQUEST_CACHE` thread safety.
 - `_PLAYTIME_ALBUM_CAP = 500` in `orchestrator.py` limits Spotify fetch for playtime sort.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,10 +201,10 @@ managed by the owner, not by individual agents.
 ## Side-Task Handling
 
 Not all work is batch work (e.g., a leap-year bugfix, a dark-mode polish commit).
-Non-batch changes follow the commit rules above unchanged -- including step
-4, which puts the dated Section 4 entry in the *same* commit as the change
-(Anti-Pattern Registry #9). Side-tasks differ only in where that entry goes
-and how it is tagged:
+Non-batch changes follow the commit rules above unchanged -- including the
+documentation step, which puts the dated Section 4 entry in the *same*
+commit as the change ("Missing log entries" in the Anti-Pattern Registry).
+Side-tasks differ only in where that entry goes and how it is tagged:
 
 1. Add the dated entry in PLAYBOOK Section 4 **after** the
    `<!-- DOCSYNC:CURRENT-BATCH-END -->` marker, using the same log format
@@ -365,7 +365,7 @@ When all WPs in the active batch are committed and validated:
 5. **Run `--fix` again** to refresh the STATUS block.
 6. **Verify clean:** `python scripts/doc_state_sync.py --check` must exit 0 with no
    "Broken archive link" warnings (the two expected root BATCH file warnings disappear
-   once the proposal is archived in step 2).
+   once the definition file has been archived by the step above).
 7. **Commit:** `chore(close-out): Batch N complete; archive definition and purge log`.
 
 ---
@@ -443,6 +443,21 @@ Agents must check their work against this list before committing.
     without re-measuring. The "~72%" coverage figure survived five months
     of doc passes while the real figure was 89%. Re-run the measuring
     command before repeating a number in any doc.
+11. **Fixing the instance instead of the class (PR #165 rounds 5-6):**
+    every finding in round 6 was created by round 5's own fixes --
+    a procedure was renumbered without updating the prose that cited
+    "step 4", and a claim was corrected in `config.py` while the
+    identical claim survived in `AGENT_NOTES.md`. Every edit requires a
+    blast-radius grep before the validation gates:
+    - after renumbering or renaming, run
+      `rg -n "step \d|Registry #\d|rule \d|criterion \d"` across the
+      docs and repoint each hit by **name**, not number -- a name
+      cannot go stale when the list reorders;
+    - after correcting a factual claim, grep its distinctive phrase
+      repo-wide and fix every copy in the same commit, or delete the
+      copies and link to the single owner (Anti-duplication rule).
+    A fix that leaves siblings behind is half a fix and costs another
+    review round.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,10 +182,12 @@ managed by the owner, not by individual agents.
 ## Side-Task Handling
 
 Not all work is batch work (e.g., a leap-year bugfix, a dark-mode polish commit).
-For non-batch changes:
+Non-batch changes follow the commit rules above unchanged -- including step
+4, which puts the dated Section 4 entry in the *same* commit as the change
+(Anti-Pattern Registry #9). Side-tasks differ only in where that entry goes
+and how it is tagged:
 
-1. Commit normally following the commit rules above.
-2. Add a dated entry in PLAYBOOK Section 4 **after** the
+1. Add the dated entry in PLAYBOOK Section 4 **after** the
    `<!-- DOCSYNC:CURRENT-BATCH-END -->` marker, using the same log format
    but **without** a `(Batch N WP-X)` suffix in the heading.
    Placing it outside the current-batch markers avoids the batch-aware
@@ -199,8 +201,8 @@ For non-batch changes:
    entry is treated as oldest and archived by the very next `--fix` run
    instead of staying in the active window (below capacity it is
    retained, but top placement is still correct).
-3. Run `doc_state_sync.py --fix`.
-4. Update SESSION_CONTEXT Section 1 if the change affects test count or project state.
+2. Run `doc_state_sync.py --fix`.
+3. Update SESSION_CONTEXT Section 1 if the change affects test count or project state.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,12 +469,15 @@ Agents must check their work against this list before committing.
     without re-measuring. The "~72%" coverage figure survived five months
     of doc passes while the real figure was 89%. Re-run the measuring
     command before repeating a number in any doc.
-11. **Fixing the instance instead of the class (PR #165 rounds 5-6):**
-    every finding in round 6 was created by round 5's own fixes --
-    a procedure was renumbered without updating the prose that cited
-    "step 4", and a claim was corrected in `config.py` while the
-    identical claim survived in `AGENT_NOTES.md`. Every edit requires a
-    blast-radius grep before the validation gates:
+11. **Fixing the instance instead of the class:** repairing the reported
+    symptom while its siblings survive untouched. Two forms recur:
+    renumbering or renaming something without updating the prose that
+    cites the old number or name, and correcting a factual claim in one
+    file while identical copies remain elsewhere. This is the single
+    largest source of repeat review rounds in this repository -- a
+    documentation PR needed several extra rounds because each round's
+    findings were produced by the previous round's own fixes. Every edit
+    requires a blast-radius grep before the validation gates:
     - after renumbering or renaming, run
       `rg -n "step \d|Registry #\d|rule \d|criterion \d"` across the
       docs and repoint each hit by **name**, not number -- a name
@@ -484,32 +487,37 @@ Agents must check their work against this list before committing.
       copies and link to the single owner (Anti-duplication rule).
     A fix that leaves siblings behind is half a fix and costs another
     review round.
-12. **Lossy or contradictory consolidation (PR #165 rounds 1-4, 7):**
-    collapsing a duplicated rule to a single owner, but (a) leaving the
-    copies in place while claiming they were removed, (b) dropping a
-    specific prohibition during the collapse -- the `git add -A` ban was
-    nearly lost this way -- or (c) writing canonical text that
-    contradicts another section of the same file, as when a "document
-    before committing" rule landed while Side-Task Handling still said
-    to commit first. When consolidating: re-read the **whole**
-    destination file, not the diff, and diff the old text against the
-    new pointer to confirm no requirement was silently dropped.
-13. **Assertions over sets, ranges, and citations (PR #163 rounds 2, 4;
-    PR #165 rounds 2, 5, 7):** stating a property of a group without
-    checking each member -- "read across all seven CSS files" when one
-    does not, "Open findings: F-DOCSYNC-1 through F-DOCSYNC-4" when the
-    fourth is resolved, citing anti-pattern #10 for a rule it does not
-    cover, or citing a gitignored file as a source. Ranges and "all X"
-    phrasings are the highest-risk constructions in this repo: expand
-    them and verify member by member, or write the claim so it does not
-    depend on the membership.
-14. **Happy-path-only procedures (PR #165 rounds 5, 7):** writing a
-    numbered procedure that only works in one state -- a close-out step
-    that says "add a row" when the row already exists, a sufficiency
-    gate that requires a definition file that does not exist between
-    batches, a validation gate ordered before the work it validates.
-    Walk every procedure through its edge states (active vs between
-    batches, first run vs re-run, item present vs absent) before
+12. **Lossy or contradictory consolidation:** collapsing a duplicated
+    rule to a single owner, but (a) leaving the copies in place while
+    the new text claims they were removed, (b) dropping a specific
+    prohibition during the collapse -- a bulk-staging ban was nearly
+    lost this way, because the canonical text said which files to stage
+    but not which command never to use -- or (c) writing canonical text
+    that contradicts another section of the same file, as when a
+    "document before committing" rule was added while Side-Task
+    Handling still instructed agents to commit first. When
+    consolidating: re-read the **whole** destination file rather than
+    the diff, and compare the removed text against the new pointer to
+    confirm no requirement was silently dropped.
+13. **Assertions over sets, ranges, and citations:** stating a property
+    of a group without checking each member. Real examples from this
+    repository: a claim that a variable is read across all seven page
+    CSS files when one of them does not use it; a differential baseline
+    headed "Open findings" that listed an ID already marked resolved; a
+    cross-reference to an anti-pattern that does not cover the case
+    being argued; and a citation naming a gitignored file no
+    contributor can open. Ranges (`X through Y`) and "all N" phrasings
+    are the highest-risk constructions here: expand them and verify
+    member by member, or rewrite the claim so it does not depend on the
+    membership.
+14. **Happy-path-only procedures:** a numbered procedure that only
+    works in one state. Examples that reached the canonical docs: a
+    close-out step saying "add a row" for a table row that already
+    exists, a bootstrap sufficiency gate requiring a batch definition
+    file that by design does not exist between batches, and a
+    validation gate ordered before the work it validates. Walk every
+    procedure through its edge states -- active batch vs between
+    batches, first run vs re-run, item present vs absent -- before
     committing it.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,7 +337,8 @@ When all WPs in the active batch are committed and validated:
 2. **Archive the definition file:** rename `BATCHN_PROPOSAL.md` (or equivalent)
    to `docs/history/definitions/BATCHN_DEFINITION.md` using `git mv`.
 3. **Update PLAYBOOK Section 2** table: add a row for the batch linking to
-   `docs/history/definitions/BATCHN_DEFINITION.md`.
+   `docs/history/definitions/BATCHN_DEFINITION.md`, and fill the Log column
+   with `docs/history/logs/BATCHN_LOG.md`.
 4. **Update SESSION_CONTEXT** Section 1 batch status row: `**Complete**. All N WPs done.
    Definition: docs/history/definitions/BATCHN_DEFINITION.md.`
 5. **Run `--fix` again** to refresh the STATUS block.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,9 +164,12 @@ Conventional Commits, imperative mood, no trailing period:
 4. Update PLAYBOOK Section 3 + Section 4 BEFORE committing. Batch log
    entries carry a `(Batch N WP-X)` tag in the heading; side-task entries
    are untagged (see Side-Task Handling).
-5. Stage only files changed for this work package. Stage
-   `.claude/SESSION_CONTEXT.md` together with PLAYBOOK whenever it changed
-   -- do not leave it modified and unstaged.
+5. Stage specific paths by name. **Never `git add -A` or `git add .`**,
+   not even when every changed file belongs to this work package -- the
+   prohibition is on the command, because it silently picks up whatever
+   else is in the tree. Stage only files changed for this work package,
+   and stage `.claude/SESSION_CONTEXT.md` together with PLAYBOOK whenever
+   it changed -- do not leave it modified and unstaged.
 6. Commit after each WP (do not batch multiple WPs into one commit).
    Do not push without explicit owner instruction. Pause after each commit
    for owner review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -506,10 +506,16 @@ Agents must check their work against this list before committing.
     headed "Open findings" that listed an ID already marked resolved; a
     cross-reference to an anti-pattern that does not cover the case
     being argued; and a citation naming a gitignored file no
-    contributor can open. Ranges (`X through Y`) and "all N" phrasings
-    are the highest-risk constructions here: expand them and verify
-    member by member, or rewrite the claim so it does not depend on the
-    membership.
+    contributor can open. Ranges and universal quantifiers are the
+    highest-risk constructions here: expand them and verify member by
+    member, or rewrite the claim so it does not depend on the
+    membership. Grep the whole quantifier vocabulary rather than the one
+    phrasing that failed last time -- `all`, `each`, `every`, `both`,
+    `none`, `always`, `never`, `X through Y` -- because a check narrowed
+    to the previous wording misses the next variant. A statement that
+    "close-out entries for each batch live in the monolith" survived one
+    such narrow sweep and was false for the batch that tagged its
+    close-out differently.
 14. **Happy-path-only procedures:** a numbered procedure that only
     works in one state. Examples that reached the canonical docs: a
     close-out step saying "add a row" for a table row that already

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,11 @@ explicitly depends on batch-acceptance or historical context.
 This list is the single canonical bootstrap order; `HANDOFF_PROMPT.md` links
 here and adds only the post-read verification steps.
 
-If PLAYBOOK Section 3, the batch definition, and SESSION_CONTEXT Section 1
-all agree on the current batch and next WP, you have enough context to start.
+Bootstrap is complete when the sources agree. During an active batch that
+means PLAYBOOK Section 3, the batch definition, and SESSION_CONTEXT
+Section 1 all agree on the current batch and next WP. Between batches no
+definition exists, so the gate is PLAYBOOK Section 3 and SESSION_CONTEXT
+Section 1 agreeing that the last batch is closed and none is open.
 If two bootstrap files conflict, follow the stricter safety rule and pause
 only when the conflict affects the next action.
 
@@ -191,6 +194,26 @@ the doc update cannot check it, and `pre-commit` includes the
    the unmodified rule above.
    When authorized to push in a GitHub Copilot session, use the platform
    progress/reporting tool; do not push directly with shell `git`/`gh`.
+
+**Pre-push self-review.** The validation gates check mechanics (tests,
+formatting, docsync markers); nothing in the toolchain checks whether one
+document now contradicts another. That gap is what turns a single review
+comment into a chain of rounds, each fixing damage from the last. Before
+pushing, spend the two minutes these four checks cost:
+
+1. Read each changed file **whole**, not as a diff -- contradictions hide
+   in the unchanged text next to the edit.
+2. Run the blast-radius greps described in the Anti-Pattern Registry
+   under "Fixing the instance instead of the class", "Lossy or
+   contradictory consolidation", and "Assertions over sets, ranges, and
+   citations": citations of anything renumbered or renamed, sibling
+   copies of any corrected claim, and every set or range the change
+   asserts.
+3. Walk any procedure touched through its edge states, per
+   "Happy-path-only procedures".
+4. Prefer deletion to addition. Every added sentence is new surface area
+   that a later change can contradict; collapsing a duplicate to a
+   pointer removes surface area permanently.
 
 **Co-author prohibition:** Do NOT add `Co-authored-by` trailers or any co-author
 metadata to commits. This repo uses multi-agent orchestration; attribution is
@@ -357,9 +380,12 @@ When all WPs in the active batch are committed and validated:
    (purges old non-current entries from PLAYBOOK Section 4 to keep it lean).
 2. **Archive the definition file:** rename `BATCHN_PROPOSAL.md` (or equivalent)
    to `docs/history/definitions/BATCHN_DEFINITION.md` using `git mv`.
-3. **Update PLAYBOOK Section 2** table: add a row for the batch linking to
-   `docs/history/definitions/BATCHN_DEFINITION.md`, and fill the Log column
-   with `docs/history/logs/BATCHN_LOG.md`.
+3. **Update PLAYBOOK Section 2** table: the active batch already has a row
+   (its Definition cell points at the root file and its Log cell reads
+   `active -- Section 4`). Repoint that existing row at
+   `docs/history/definitions/BATCHN_DEFINITION.md` and fill the Log cell
+   with `docs/history/logs/BATCHN_LOG.md`. Add a new row only if the batch
+   has none.
 4. **Update SESSION_CONTEXT** Section 1 batch status row: `**Complete**. All N WPs done.
    Definition: docs/history/definitions/BATCHN_DEFINITION.md.`
 5. **Run `--fix` again** to refresh the STATUS block.
@@ -458,6 +484,33 @@ Agents must check their work against this list before committing.
       copies and link to the single owner (Anti-duplication rule).
     A fix that leaves siblings behind is half a fix and costs another
     review round.
+12. **Lossy or contradictory consolidation (PR #165 rounds 1-4, 7):**
+    collapsing a duplicated rule to a single owner, but (a) leaving the
+    copies in place while claiming they were removed, (b) dropping a
+    specific prohibition during the collapse -- the `git add -A` ban was
+    nearly lost this way -- or (c) writing canonical text that
+    contradicts another section of the same file, as when a "document
+    before committing" rule landed while Side-Task Handling still said
+    to commit first. When consolidating: re-read the **whole**
+    destination file, not the diff, and diff the old text against the
+    new pointer to confirm no requirement was silently dropped.
+13. **Assertions over sets, ranges, and citations (PR #163 rounds 2, 4;
+    PR #165 rounds 2, 5, 7):** stating a property of a group without
+    checking each member -- "read across all seven CSS files" when one
+    does not, "Open findings: F-DOCSYNC-1 through F-DOCSYNC-4" when the
+    fourth is resolved, citing anti-pattern #10 for a rule it does not
+    cover, or citing a gitignored file as a source. Ranges and "all X"
+    phrasings are the highest-risk constructions in this repo: expand
+    them and verify member by member, or write the claim so it does not
+    depend on the membership.
+14. **Happy-path-only procedures (PR #165 rounds 5, 7):** writing a
+    numbered procedure that only works in one state -- a close-out step
+    that says "add a row" when the row already exists, a sufficiency
+    gate that requires a definition file that does not exist between
+    batches, a validation gate ordered before the work it validates.
+    Walk every procedure through its edge states (active vs between
+    batches, first run vs re-run, item present vs absent) before
+    committing it.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ serve as external memory shared across sessions.
 | File | Role | Contains |
 |------|------|----------|
 | `AGENTS.md` (this file) | **Rules** | How agents must behave. Stable; rarely changes. |
-| `HANDOFF_PROMPT.md` | **Bootstrap procedure** | Step-by-step session start, validation gates, commit discipline, handoff checklist. |
+| `HANDOFF_PROMPT.md` | **Session-start procedure** | Post-read verification steps and the end-of-session handoff checklist. Rules (bootstrap order, gates, commit discipline) live in `AGENTS.md`. |
 | `AGENT_NOTES.md` | **Owner context** | Owner preferences, local dev setup, architectural constraints, known issues. |
 | `.claude/SESSION_CONTEXT.md` | **Dashboard** | Current project state snapshot. No rules, no history. |
 | `PLAYBOOK.md` | **Work order** | What to do next, what was just done. Active batch + execution log. |
@@ -43,18 +43,26 @@ only the minimum bootstrap/context files needed to answer that thread. Open
 batch definitions or archive/history docs only when the linked comment
 explicitly depends on batch-acceptance or historical context.
 
-1. `PLAYBOOK.md` Section 3 (next action) + Section 4 (current-batch log).
-2. The batch definition file named in Section 3 (repo root while active;
-   under `docs/history/definitions/` once the batch is closed).
-3. `.claude/SESSION_CONTEXT.md` -- current batch, test count, architecture, risks.
-4. `AGENT_NOTES.md` -- owner preferences, local dev setup, constraints.
-5. Relevant `docs/history/` doc only if the log references one.
-6. `FINDINGS.md` -- read on demand only: when PLAYBOOK Section 4 or your
+1. `AGENTS.md` (this file) -- rules, commit format, doc sync policy,
+   anti-patterns.
+2. `PLAYBOOK.md` Section 3 (next action) + Section 4 (current-batch log).
+3. The batch definition file named in Section 3 (repo root while active;
+   under `docs/history/definitions/` once the batch is closed; between
+   batches no file exists -- skip this step).
+4. `.claude/SESSION_CONTEXT.md` -- current batch, test count, architecture, risks.
+5. `AGENT_NOTES.md` -- owner preferences, local dev setup, constraints.
+6. Relevant `docs/history/` doc only if the log references one.
+7. `FINDINGS.md` -- read on demand only: when PLAYBOOK Section 4 or your
    task explicitly references an F-* finding ID or an open P0/P1 item.
    Not part of the mandatory bootstrap set.
 
-If SESSION_CONTEXT Section 1 and PLAYBOOK Section 3 agree on the current batch
-and next WP, you have enough context to start.
+This list is the single canonical bootstrap order; `HANDOFF_PROMPT.md` links
+here and adds only the post-read verification steps.
+
+If PLAYBOOK Section 3, the batch definition, and SESSION_CONTEXT Section 1
+all agree on the current batch and next WP, you have enough context to start.
+If two bootstrap files conflict, follow the stricter safety rule and pause
+only when the conflict affects the next action.
 
 **Token discipline for bootstrap:**
 - Always read Sections 1-2 of `.claude/SESSION_CONTEXT.md`; Sections 3-5 only if structure, dependency, or architecture detail is needed.
@@ -151,9 +159,17 @@ Conventional Commits, imperative mood, no trailing period:
 **Procedure before every commit:**
 1. `pytest -q` -- all tests pass.
 2. `pre-commit run --all-files` -- all hooks pass.
-3. Stage only files changed for this work package.
-4. Commit after each WP (do not batch multiple WPs into one commit).
-   Do not push without explicit owner instruction (see HANDOFF_PROMPT.md Section 3).
+3. `python scripts/doc_state_sync.py --check` -- exits 0 (the root
+   `BATCHN_DEFINITION.md` warning is expected while a batch is active).
+4. Update PLAYBOOK Section 3 + Section 4 BEFORE committing. Batch log
+   entries carry a `(Batch N WP-X)` tag in the heading; side-task entries
+   are untagged (see Side-Task Handling).
+5. Stage only files changed for this work package. Stage
+   `.claude/SESSION_CONTEXT.md` together with PLAYBOOK whenever it changed
+   -- do not leave it modified and unstaged.
+6. Commit after each WP (do not batch multiple WPs into one commit).
+   Do not push without explicit owner instruction. Pause after each commit
+   for owner review.
    When authorized to push in a GitHub Copilot session, use the platform
    progress/reporting tool; do not push directly with shell `git`/`gh`.
 
@@ -350,6 +366,9 @@ When all WPs in the active batch are committed and validated:
    (rename, move, split, merge modules) without first verifying that
    existing tests cover the affected paths. If coverage is insufficient,
    add tests in a preceding WP.
+5. **Docstrings and comments:** every function has a comprehensive
+   docstring; inline comments explain non-obvious logic (the why, not the
+   what). SoC/DRY is the constraint on file content, not line count.
 
 ---
 
@@ -390,6 +409,18 @@ Agents must check their work against this list before committing.
    and assert on a date that would shift under a naive interpretation.
    Canonical example: `tests/test_heatmap.py::TestAggregateDailyCounts::`
    `test_utc_decode_invariant_against_local_tz_drift`.
+7. **Skipping hooks:** Never commit with `--no-verify`. Fix the failing
+   hook instead.
+8. **Stale PLAYBOOK Section 3:** Section 3 not reflecting the true state
+   of every WP at all times (see Doc Sync Rules, mid-batch handoff
+   discipline).
+9. **Missing log entries:** a WP or side-task commit without its dated
+   PLAYBOOK Section 4 entry.
+10. **Stale dashboard figures (coverage incident 2026-07-28):** quoting a
+    canonical number (coverage, test count, module count) from docs
+    without re-measuring. The "~72%" coverage figure survived five months
+    of doc passes while the real figure was 89%. Re-run the measuring
+    command before repeating a number in any doc.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,20 +157,27 @@ Conventional Commits, imperative mood, no trailing period:
 **Subject:** imperative ("Add", "Fix", "Extract") -- NOT "Added", "Fixes".
 
 **Procedure before every commit:**
-1. `pytest -q` -- all tests pass.
-2. `pre-commit run --all-files` -- all hooks pass.
-3. `python scripts/doc_state_sync.py --check` -- exits 0 (the root
-   `BATCHN_DEFINITION.md` warning is expected while a batch is active).
-4. Update PLAYBOOK Section 3 + Section 4 BEFORE committing. Batch log
-   entries carry a `(Batch N WP-X)` tag in the heading; side-task entries
-   are untagged (see Side-Task Handling).
-5. Stage specific paths by name. **Never `git add -A` or `git add .`**,
+Documentation is written first, then validated -- a gate that runs before
+the doc update cannot check it, and `pre-commit` includes the
+`doc-state-sync-check` hook.
+
+1. Update PLAYBOOK Section 3 + Section 4. Batch log entries carry a
+   `(Batch N WP-X)` tag in the heading; side-task entries are untagged
+   (see Side-Task Handling).
+2. `python scripts/doc_state_sync.py --fix` -- rotates and refreshes the
+   managed blocks from the text you just wrote.
+3. `pytest -q` -- all tests pass.
+4. `pre-commit run --all-files` -- all hooks pass.
+5. `python scripts/doc_state_sync.py --check` -- exits 0 on the final
+   state (the root `BATCHN_DEFINITION.md` warning is expected while a
+   batch is active).
+6. Stage specific paths by name. **Never `git add -A` or `git add .`**,
    not even when every changed file belongs to this work package -- the
    prohibition is on the command, because it silently picks up whatever
    else is in the tree. Stage only files changed for this work package,
    and stage `.claude/SESSION_CONTEXT.md` together with PLAYBOOK whenever
    it changed -- do not leave it modified and unstaged.
-6. Commit after each WP (do not batch multiple WPs into one commit).
+7. Commit after each WP (do not batch multiple WPs into one commit).
    Do not push without explicit owner instruction. Pause after each commit
    for owner review.
    **Standing exception -- Claude Code and Codex sessions only (granted

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,15 @@ Conventional Commits, imperative mood, no trailing period:
 6. Commit after each WP (do not batch multiple WPs into one commit).
    Do not push without explicit owner instruction. Pause after each commit
    for owner review.
+   **Standing exception -- Claude Code and Codex sessions only (granted
+   2026-07-31):** commits that respond to review feedback on an
+   already-open PR may be pushed without asking each time, followed by one
+   batched reply per review round. This covers review-fix commits only.
+   Batch and WP commits still pause for owner review, and force-pushes,
+   history rewrites, and anything targeting `main` always require explicit
+   instruction. The exception does **not** extend to GitHub Copilot task
+   sessions or their subagents, Jules, or any other agent -- those follow
+   the unmodified rule above.
    When authorized to push in a GitHub Copilot session, use the platform
    progress/reporting tool; do not push directly with shell `git`/`gh`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,7 +486,13 @@ Agents must check their work against this list before committing.
       repo-wide and fix every copy in the same commit, or delete the
       copies and link to the single owner (Anti-duplication rule).
     A fix that leaves siblings behind is half a fix and costs another
-    review round.
+    review round. The same applies when the change *is* a rule: adding
+    or tightening one instantly makes every pre-existing violation
+    non-conformant, so sweep the whole corpus against the new rule in
+    the same commit, or record the remaining backlog explicitly. A rule
+    is not retroactive on its own -- this registry's own name-based
+    citation requirement shipped while three numeric citations sat
+    elsewhere in the repository, written before it existed.
 12. **Lossy or contradictory consolidation:** collapsing a duplicated
     rule to a single owner, but (a) leaving the copies in place while
     the new text claims they were removed, (b) dropping a specific

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,9 +179,10 @@ For non-batch changes:
    **Insert the new entry directly after the end marker** (top of the
    non-current list), not at the bottom. The list is ordered newest-first
    and rotation keeps the first `--keep-non-current` entries positionally,
-   rotating the rest -- a bottom-appended entry is treated as oldest and
-   archived by the very next `--fix` run instead of staying in the
-   active window.
+   rotating the rest -- once the window is at capacity, a bottom-appended
+   entry is treated as oldest and archived by the very next `--fix` run
+   instead of staying in the active window (below capacity it is
+   retained, but top placement is still correct).
 3. Run `doc_state_sync.py --fix`.
 4. Update SESSION_CONTEXT Section 1 if the change affects test count or project state.
 

--- a/AGENT_NOTES.md
+++ b/AGENT_NOTES.md
@@ -5,9 +5,8 @@ Rules live in `AGENTS.md`. Work orders live in `PLAYBOOK.md`.
 This file contains preferences, local dev setup, and discovered constraints
 that agents need but that do not belong in either of those files.
 
-**Active batch:** `PLAYBOOK.md` Section 3 is the single source of truth for
-batch state; it names the active `BATCHN_DEFINITION.md` at repo root. This
-file does not track batch status.
+**Batch state:** owned by `PLAYBOOK.md` Section 3 -- this file does not
+track it.
 
 ---
 

--- a/AGENT_NOTES.md
+++ b/AGENT_NOTES.md
@@ -5,6 +5,10 @@ Rules live in `AGENTS.md`. Work orders live in `PLAYBOOK.md`.
 This file contains preferences, local dev setup, and discovered constraints
 that agents need but that do not belong in either of those files.
 
+**Active batch:** `PLAYBOOK.md` Section 3 is the single source of truth for
+batch state; it names the active `BATCHN_DEFINITION.md` at repo root. This
+file does not track batch status.
+
 ---
 
 ## Owner Preferences
@@ -18,9 +22,14 @@ that agents need but that do not belong in either of those files.
 - Always explain why in log entries and inline comments -- not just what.
 - Owner tests locally in Firefox (+ Responsive Design Mode for mobile)
   between WPs before approving the next one.
-- Software principles enforced: DRY, SoC, SRP, KISS, Dependency Inversion,
-  Composition over Inheritance, Clean Architecture, Boy Scout Rule, Least
-  Knowledge Principle, Fail Fast. Not aspirational -- mandatory.
+- Software principles enforced -- not aspirational, mandatory: DRY (don't
+  repeat yourself), SoC (separation of concerns), SRP (single
+  responsibility per module/function), KISS (keep it simple), Dependency
+  Inversion (depend on abstractions, not concretions), Composition over
+  Inheritance, Clean Architecture (dependencies point inward, see
+  SESSION_CONTEXT Section 4), Boy Scout Rule (leave touched code cleaner
+  than found), Least Knowledge / Law of Demeter (talk only to immediate
+  collaborators), Fail Fast (validate early, raise loudly).
 - Testing pyramid: unit tests (mocked, base), integration tests (routes,
   middle), E2E (owner-driven, top). Every test must fail if the function
   under test is deleted.
@@ -61,10 +70,9 @@ python -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1
 
 ## Architectural Constraints
 
-- `MAX_ACTIVE_JOBS` (default 10) caps concurrent background jobs via `worker.py`.
-- `_GlobalThrottle` in `utils.py` caps aggregate API throughput across all threads.
-- `_cache_lock` in `utils.py` guards `REQUEST_CACHE` thread safety.
-- `_PLAYTIME_ALBUM_CAP = 500` in `orchestrator.py` limits Spotify fetch for playtime sort.
+- Runtime concurrency constants (`MAX_ACTIVE_JOBS`, `_GlobalThrottle`,
+  `_cache_lock`, `_PLAYTIME_ALBUM_CAP`): see SESSION_CONTEXT Section 1
+  "Key runtime facts" (single source; do not restate values here).
 - **Single worker, multiple threads:** Gunicorn runs `--workers 1 --threads 4`.
   Multiple workers would break the in-process `JOBS` dict. This is intentional.
 - **Windows asyncio:** `background_task()` in `orchestrator.py` explicitly uses
@@ -83,13 +91,9 @@ python -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1
 
 ## Venv and Pip Rules
 
-- The ONLY virtualenv is `.venv/` in the repo root.
-- Local dev (Windows): always use `.venv/Scripts/pip`, never bare `pip`.
-- Local dev (Linux): always use `.venv/bin/pip`.
-- CI (GitHub Actions): bare `pip` is correct -- the runner manages its own environment.
-- All packages pinned with `==` in both `requirements.txt` and `requirements-dev.txt`.
-- Never install packages not in requirements files without explicit owner approval.
-- Never start a Flask server process via the Bash tool -- the owner runs the app.
+Owned by `AGENTS.md` (Environment Setup + Anti-Pattern Registry entries 4
+and 5). In short: `.venv/` only with qualified pip paths, `==` pins, no
+unapproved installs, never start a Flask server via the Bash tool.
 
 ---
 
@@ -124,55 +128,37 @@ only in the current process environment and is gone when the shell exits.
 
 ---
 
-## Heatmap Feature (Batch 18 iteration 1 + Batch 19 polish)
+## Heatmap Feature Notes (shipped -- Batches 18/19)
 
-- **Core feature definition:** `docs/history/definitions/BATCH18_DEFINITION.md`.
-- **Batch 19 polish definition (archived):** `docs/history/definitions/BATCH19_DEFINITION.md`.
-  Closed out 2026-05-19; PR #152 (`feat/heatmap` -> `main`) merged.
-- **Batch 21 definition (ACTIVE batch):** `BATCH21_DEFINITION.md` at repo
-  root. UI overhaul -- Tailwind v4 + daisyUI v5 migration, expanded from
-  the owner's Claude Design audit (UI Audit v3), approved 2026-07-24.
-  WP-0 done; WP-1 (toolchain + themes) is next on `wip/batch-21` (PR #163).
-  Batch 20 (file-hygiene + docs methodology refresh) is complete; its
-  definition is archived at `docs/history/definitions/BATCH20_DEFINITION.md`.
-- **Batch 19 scope:** frame/headline/KPIs result redesign, "Top Albums" pill
-  rename, pinwheel/loading polish, mobile heatmap layout, and stale
-  documentation cleanup. Full app palette/font rebrand remains deferred.
+- **Definitions (archived):** `docs/history/definitions/BATCH18_DEFINITION.md`
+  (core feature) and `docs/history/definitions/BATCH19_DEFINITION.md`
+  (polish; closed out 2026-05-19, PR #152 merged).
 - **Key decisions:** username-only input (last 365 days), pill tabs on index.html,
   all states on one page (no navigation), GitHub-style 7x52 SVG grid, rocket_r
   palette, log-adjusted intensity, no heatmap-specific caching (REQUEST_CACHE
   covers Last.fm pages), no new Python dependencies, no matplotlib/seaborn.
 - **Cache note:** heatmap uses different `from`/`to` timestamps than album
   search, producing different REQUEST_CACHE keys. No interference.
-- **Windows asyncio:** heatmap_task must use same ProactorEventLoop guard as
-  orchestrator.py background_task. See AGENT_NOTES Architectural Constraints.
-- **Feature may span multiple batches.** Follow-up candidates: orchestrator
-  split, export, date range, summary stats.
-- **Heatmap perf (measured 2026-05-16):** `flounder14` took 10.9 seconds for
-  103 Last.fm pages. `lastfm.py` already uses `limit=200`, concurrent
-  `as_completed` fetching, `MAX_CONCURRENT_LASTFM=10`, and the global
-  10 req/s throttle. That makes 10.9s effectively the rate-limit floor
-  (103 pages / 10 req/s = 10.3s minimum). Further speedups require
-  heatmap-specific caching, progressive rendering, or higher rate-limit risk.
-- **Batch 19 owner-review follow-up (2026-05-19):** the remaining visual work is
-  loading-state polish and heatmap sizing. The pinwheel should be unframed,
-  SVG-scaled, mobile-bounded, and preserve the original breathing blade
-  animation; the heatmap grid should use more desktop width and a sequential
-  mobile activity strip that fills the frame width without calendar
-  constraints. Global
-  font/palette/Bootstrap
-  theming remains a future-batch concern unless a small local change is needed
-  to make the heatmap work.
+- **Windows asyncio:** heatmap_task must use the same ProactorEventLoop guard
+  as orchestrator.py background_task. See Architectural Constraints above.
+- **Perf:** fetch speed is rate-limit bound; the measurement and rationale
+  live in FINDINGS.md F-B18-11 (single source).
+- **Follow-up candidates:** export, date range, summary stats (future
+  batches; the orchestrator split is tracked as FINDINGS F-B20-2).
 
 ---
 
 ## Known Open Issues / Future Candidates
 
 - Flask-Talisman (CSP) was attempted in Batch 17 WP-5 and dropped (YAGNI).
-  The templates use inline styles (SVG logo `<defs><style>`, Bootstrap progress
-  bar `style="width: 0%"`, album cover fallback) that would need refactoring
-  before a strict CSP is viable. See PLAYBOOK WP-5 entry for details.
-- Scaling path if needed: Celery/Redis RQ -- out of scope until features complete.
-- Orchestrator monolith split: deferred until heatmap exists alongside album
-  pipeline. Natural SoC cleanup candidate for a follow-up batch.
-- Cache + bounded semaphore load testing: per `load-test-findings.md`.
+  Templates use inline styles that would need refactoring before a strict
+  CSP is viable. Details: `docs/history/logs/BATCH17_LOG.md` and
+  `docs/history/definitions/BATCH17_DEFINITION.md`.
+- Scaling path if needed: Celery/Redis RQ -- out of scope until features
+  complete (FINDINGS F-MAS-6).
+- Orchestrator monolith split: precondition met (heatmap shipped as the
+  second pipeline); tracked as FINDINGS F-B20-2 (open P1).
+- Load testing (2026-03-04): 2/3/5 concurrent users ran clean; the 10-user
+  run never completed (N jobs share the global 10 req/s throttle, so each
+  gets ~10/N req/s). Conclusions live here and in FINDINGS F-LOAD-1..5;
+  the raw run data is agent-side memory, not in the repo.

--- a/AGENT_NOTES.md
+++ b/AGENT_NOTES.md
@@ -155,6 +155,9 @@ only in the current process environment and is gone when the shell exits.
 - Orchestrator monolith split: precondition met (heatmap shipped as the
   second pipeline); tracked as FINDINGS F-B20-2 (open P1).
 - Load testing (2026-03-04): 2/3/5 concurrent users ran clean; the 10-user
-  run never completed (N jobs share the global 10 req/s throttle, so each
-  gets ~10/N req/s). Conclusions live here and in FINDINGS F-LOAD-1..5;
-  the raw run data is agent-side memory, not in the repo.
+  run never completed. Each API has its own global throttle and neither
+  does per-job accounting, so N jobs sharing the Last.fm phase average
+  ~10/N req/s rather than each being guaranteed it -- see the
+  `MAX_ACTIVE_JOBS` comment in `scrobblescope/config.py` for the full
+  rationale. Conclusions also in FINDINGS F-LOAD-1..5; the raw run data
+  is agent-side memory, not in the repo.

--- a/AGENT_NOTES.md
+++ b/AGENT_NOTES.md
@@ -13,9 +13,7 @@ file does not track batch status.
 
 ## Owner Preferences
 
-- Commit mechanics (incremental staging by name, no co-author trailers,
-  push only on explicit owner instruction, pause after each commit for
-  owner review): owned by AGENTS.md Commit Rules -- stated once there.
+- Commit mechanics: owned by `AGENTS.md` Commit Rules -- read them there.
 - Concise responses; no emojis unless asked.
 - Pause and notify owner if Docker config or external MCP setup is needed.
 - Always explain why in log entries and inline comments -- not just what.
@@ -91,8 +89,7 @@ python -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1
 ## Venv and Pip Rules
 
 Owned by `AGENTS.md` (Environment Setup + Anti-Pattern Registry entries 4
-and 5). In short: `.venv/` only with qualified pip paths, `==` pins, no
-unapproved installs, never start a Flask server via the Bash tool.
+and 5) -- read them there.
 
 ---
 

--- a/AGENT_NOTES.md
+++ b/AGENT_NOTES.md
@@ -13,11 +13,10 @@ file does not track batch status.
 
 ## Owner Preferences
 
-- Commits staged incrementally -- specific files by name, never `git add -A`.
-- Each WP commit is reviewed individually before push. Wait for explicit push instruction.
-- No co-author trailers in commit messages.
+- Commit mechanics (incremental staging by name, no co-author trailers,
+  push only on explicit owner instruction, pause after each commit for
+  owner review): owned by AGENTS.md Commit Rules -- stated once there.
 - Concise responses; no emojis unless asked.
-- Pause after each WP commit for owner review.
 - Pause and notify owner if Docker config or external MCP setup is needed.
 - Always explain why in log entries and inline comments -- not just what.
 - Owner tests locally in Firefox (+ Responsive Design Mode for mobile)

--- a/AGENT_NOTES.md
+++ b/AGENT_NOTES.md
@@ -87,8 +87,8 @@ python -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1
 
 ## Venv and Pip Rules
 
-Owned by `AGENTS.md` (Environment Setup + Anti-Pattern Registry entries 4
-and 5) -- read them there.
+Owned by `AGENTS.md`: Environment Setup, plus the Anti-Pattern Registry
+entries "Wrong venv or bare pip" and "Background server processes".
 
 ---
 

--- a/BATCH21_DEFINITION.md
+++ b/BATCH21_DEFINITION.md
@@ -121,11 +121,14 @@ kickoff log entry.
 - Pin exact Tailwind + daisyUI versions in the fetch script: the WP-8
   drift hook requires byte-identical output across machines and CI.
 - Commit per-platform SHA-256 digests alongside the pinned versions;
-  `tailwind_build.py` verifies every downloaded artifact (CLI binary
-  and daisyUI plugin files) against its digest before executing or
-  loading it, failing closed on mismatch. A pinned version alone still
-  trusts whatever asset the release serves at fetch time; without
-  digests the WP-8 CI hook would execute a silently replaced binary.
+  `tailwind_build.py` verifies every artifact (CLI binary and daisyUI
+  plugin files) against its digest on every use, not only at download
+  time -- gitignored `scripts/bin/` persists between runs, so a stale,
+  corrupt, or modified cached artifact must be caught too. On mismatch:
+  refetch once, re-verify, fail closed if the replacement also
+  mismatches. A pinned version alone still trusts whatever asset the
+  release serves at fetch time; without digests the WP-8 CI hook would
+  execute a silently replaced binary.
 - daisyUI v5 bundled plugin files for standalone-CLI use: `daisyui.mjs`
   (components) plus `daisyui-theme.mjs`, which the two custom `@plugin`
   theme definitions below require -- the component bundle alone cannot
@@ -186,10 +189,13 @@ kickoff log entry.
   component shape as heatmap KPIs), parameter chip row replacing the
   table.
 - Decision 1 lands here (rotating messages).
-- "Cancel" affordance = quiet link back home (+ existing
-  `/reset_progress`); note: the background job itself keeps running --
-  true server-side cancellation is a Batch 22+ candidate, not claimed
-  in the UI copy.
+- Leaving the page: a quiet "Back home" link only -- no
+  `/reset_progress` call and no "Cancel" label. The endpoint cannot
+  cancel anything: it clears stored job state only
+  (`routes.py:227-238`) while the daemon worker keeps its concurrency
+  slot and keeps writing into the same job id afterward, so invoking it
+  is misleading and racy. True server-side cancellation stays a
+  Batch 22+ candidate.
 `feat(ui): unified pinwheel loading screen for both pipelines`
 
 ### WP-5 -- Results leaderboard

--- a/BATCH21_DEFINITION.md
+++ b/BATCH21_DEFINITION.md
@@ -134,8 +134,15 @@ kickoff log entry.
   theme definitions below require -- the component bundle alone cannot
   register custom themes.
 - `static/css/tailwind.src.css` defining the two themes from the audit
-  token sheet; 4px spacing ladder; radius 8/14/999; `--bars-color`
-  aliased in both themes.
+  token sheet, pinned here so any executor can implement without
+  re-fetching the audit: light bg `#faf8f3` / bg-2 `#f0ebe0` / ink
+  `#1a1820` / primary `#6a4baf`; dark bg `#0e0c12` / surface `#181520` /
+  text `#f1ede4` (warm cream) / primary `#b39dde`. Type (self-hosted per
+  decision 4): Geist 300-700 (body 14-16px, labels 11.5-13px),
+  Instrument Serif 400 + italic (>= 24px only), JetBrains Mono 400-600
+  (numerals, eyebrow labels, pills). 4px spacing ladder
+  (4/8/12/16/24/32/48 only); radius 8 (inputs/small cards), 14 (large
+  cards), 999 (pills); `--bars-color` aliased in both themes.
 - Compiled `static/css/tailwind.css` committed; build/watch commands
   documented in DEVELOPMENT.md; CI unaffected (no Node).
 `feat(ui): add tailwind + daisyui toolchain and theme tokens`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,8 +47,10 @@ read-on-demand `FINDINGS.md`, and two archive directories. Each has a primary
 concern, and the design goal is that canonical facts live in exactly one
 place.
 
-`HANDOFF_PROMPT.md` condenses key rules and procedures from `AGENTS.md` into a cold-start
-checklist -- it is a convenience summary for session handoffs, not a second source of truth.
+`HANDOFF_PROMPT.md` carries only what is unique to starting and ending a
+session. It links to `AGENTS.md` for rules rather than summarising them:
+earlier versions did condense the rules into a cold-start checklist, and
+every summary eventually drifted from the text it summarised.
 
 `AGENT_NOTES.md` cross-references `AGENTS.md` for venv rules rather than
 restating them. `README.md` is excluded from the agent memory layer; it
@@ -65,13 +67,18 @@ current state, nor does it contain history. It is rarely subject to change.
 The language is deliberately prescriptive ("Must", "Do not", "Forbidden")
 because LLMs handle ambiguity poorly, and incorrect inference can lead to a broken pipeline or a mis-scoped commit.
 
-### `HANDOFF_PROMPT.md` -- Bootstrap Procedure
+### `HANDOFF_PROMPT.md` -- Session Start and Handoff
 
-The step-by-step session-start checklist given to any agent beginning
-work. Lists which files to read in what order, the validation gates to
-run before every commit, commit discipline rules, and the handoff
-procedure when leaving work for the next agent. Intended to be passed
-verbatim as context when delegating to a new agent session.
+Given to any agent beginning work, and intended to be passed verbatim as
+context when delegating to a new session. It holds the two things that
+belong to no other file: verifying that repository reality matches what
+the bootstrap documents claim (branch, recent commits, test count), and
+the checklist for handing work to the next session.
+
+The read order, validation gates, and commit discipline it once restated
+now live only in `AGENTS.md`. Each restatement had drifted from the
+canonical text -- in one case a copy silently outlived the rule it
+described -- so the copies were replaced with pointers.
 
 ### `AGENT_NOTES.md` -- Owner Context
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,6 +1,6 @@
 # ScrobbleScope Findings & Open Issues
 
-Last updated: 2026-07-28
+Last updated: 2026-07-31
 Status: Batch 21 (UI overhaul -- Tailwind + daisyUI migration) is ACTIVE;
 WP-0 done, WP-1 next. 390 tests across 22 test modules.
 
@@ -45,16 +45,18 @@ roadmap; absorbs F-B18-7. Status: open. Source: Batch 18 audit.
 ### F-B20-3: Bootstrap CDN source consolidation
 
 `base.html` loads Bootstrap CSS from cdnjs while `index.html` loads the
-JS bundle from jsdelivr; other pages use cdnjs. Consolidate to a single
-provider before any Bootstrap 5.1 -> 5.3 upgrade.
-Status: open. Source: F-B19-4 owner review; README roadmap companion.
+JS bundle from jsdelivr; other pages use cdnjs. The original remedy
+(consolidate to one provider before a Bootstrap 5.1 -> 5.3 upgrade) is
+dead: Batch 21 removes Bootstrap entirely and resolves the split by
+elimination (`BATCH21_DEFINITION.md` WP-8 "closes F-B20-3").
+Status: open; closes at Batch 21 WP-8. Source: F-B19-4 owner review.
 
-### F-B20-4: UI overhaul (driven by owner audit PDF)
+### F-B20-4: UI overhaul (driven by owner audit)
 
-Global font stack, palette integration, index card rework, and the
-remaining F-B19-4 audit notes; Batch 21 main scope, possible Batch 22
-contingency. Status: open; scope lands via `BATCH21_DEFINITION.md`.
-Source: owner audit PDF + F-B19-4 owner review.
+Scope, locked decisions, and acceptance criteria live entirely in
+`BATCH21_DEFINITION.md` (active batch) -- this entry is a pointer, not a
+second copy. Status: in progress (Batch 21 active, WP-0 done).
+Source: owner audit (UI Audit v3) + F-B19-4 owner review.
 
 ### F-B18-11: heatmap Last.fm page fetch is rate-limit bound
 
@@ -73,8 +75,10 @@ Status: open. Source: load testing 2026-03-04.
 
 ### F-AUDIT-1: dark-mode toggle placement on mobile
 
-Fixed-position footer toggle may overlap content on small screens; minor
-CSS polish, also a Batch 21 note. Status: open. Source: AUDIT_2026-02-11.
+Fixed-position footer toggle may overlap content on small screens.
+Batch 21 moves the toggle into the standing header bar; acceptance
+criterion 8 states "toggle meets tap-target size (closes F-AUDIT-1)".
+Status: open; closes at Batch 21 WP-2. Source: AUDIT_2026-02-11.
 
 ### F-LOAD-2: no integration tests in CI
 
@@ -102,6 +106,18 @@ README roadmap. Status: open. Source: DOCSYNC_AUDIT Finding 6.
 
 Suggested split: integration / cross-validate / archive-routing.
 Status: open. Source: MULTI_AGENT_SWEEP.
+
+### F-SWE-1: SWE-principles audit chartered, pending execution
+
+No differential check of the ten mandated software principles
+(AGENT_NOTES.md Owner Preferences) has run since the 2026-02 audits.
+`docs/SWE_AUDIT_CHARTER.md` defines scope (Python only until Batch 21
+ships), the do-not-re-report baseline, method, and output contract; any
+dedicated single-purpose agent session (Claude or Codex) can execute it
+cold. Report lands as `docs/history/SWE_PRINCIPLES_AUDIT_<date>.md` with
+net-new findings as F-SWE-2 onward; this entry closes by pointing at the
+report. Status: open (chartered 2026-07-31, execution pending).
+Source: owner request 2026-07-31.
 
 ### F-MAS-4: broad `except Exception` catches
 
@@ -136,6 +152,19 @@ then one-time re-route of the existing close-out entries); hand-retagging
 machine-rotated archive content was declined in PR #162 round 3 and again
 in PR #163 round 3 on the same point-in-time principle.
 Status: open (P2). Source: PR #163 review round 3.
+
+### F-DOCSYNC-4: per-batch logs were undiscoverable; tombstones retained
+
+Until 2026-07-31 the 18 `docs/history/logs/BATCHN_LOG.md` files were
+referenced by no working doc (PLAYBOOK Section 2 had no Log column), so
+batch history was reachable only via a directory glob. Fixed: Section 2
+gained a Log column and the AGENTS.md close-out procedure fills it per
+batch. Related disposition: the two ~300-byte
+`PLAYBOOK_EXECUTION_LOG_ARCHIVE.md` files under `docs/history/` and
+`docs/history/logs/` are deliberate Batch 14 "Moved:" tombstones kept
+for backward references -- not cruft, do not delete.
+Status: resolved 2026-07-31; rotates to the archive at Batch 21
+close-out. Source: PR #163 doc-hygiene pass.
 
 ### F-MAS-5: in-memory JOBS dict limits horizontal scaling
 
@@ -194,7 +223,8 @@ audits; 2026-03-04 load-test data is in the findings archive.
 - F-B18-7: duplicated win32 event-loop guard -- absorbed into F-B20-2.
 - F-B18-10: heatmap + album jobs share the 10 req/s throttle (by design).
 - F-B18-12: mode pills differ in width (no `min-width` on `.mode-pill`);
-  Batch 21 UI candidate.
+  in Batch 21 scope (WP-6, acceptance criterion 8) -- no longer a
+  future-batch candidate.
 - F-B19-3: last.timer aggregate endpoints are not a drop-in heatmap
   speedup; future perf experiments listed in the archive.
 - F-B19-4: front-end UI audit notes -- basis of `BATCH21_DEFINITION.md`.
@@ -208,8 +238,8 @@ audits; 2026-03-04 load-test data is in the findings archive.
 Rank most-played tracks for a year (separate task type + loading/results
 flow). Status: deferred; on the README roadmap. Source: owner roadmap.
 
-F-FEATURE-2 (listening heatmap) shipped in Batches 18/19 and is now
-archived; perf follow-ups continue as F-B18-11.
+- F-FEATURE-2: listening heatmap -- shipped in Batches 18/19, archived;
+  perf follow-ups continue as F-B18-11.
 
 ---
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -166,13 +166,19 @@ so a boolean still collides variant-against-variant. Retaining the
 stripped tokens as a variant tag would work but reintroduces the
 fragmentation above.
 
-Open questions, answerable from the cache rather than by speculation:
+Open questions, answerable by investigation rather than speculation:
 1. Do the scrobbles themselves carry the deluxe title? Last.fm stores
    whatever album metadata the player reported, which is a second
    independent path to the same result.
-2. Which other albums are affected? Group `spotify_cache` by
-   `artist_norm + album_norm` and flag rows whose `release_date` is
-   later than the earliest known release for that album.
+2. Which other albums are affected? **Not answerable from the cache
+   alone:** `(artist_norm, album_norm)` is the primary key
+   (`init_db.py:42`) and the upsert overwrites the single stored
+   `release_date`, so there are no sibling rows and no losing candidate
+   dates to compare against. Detection requires re-running the Spotify
+   search for each cached album and flagging rows whose stored date is
+   later than the earliest candidate in the fresh result set, or
+   cross-checking against an external original-release source
+   (MusicBrainz, per the note below).
 3. Can both a Latin-script deluxe and a JP deluxe surface at once? Only
    if the JP title carries Japanese characters -- NFKC preserves those,
    so it would not collapse; a Latin-script `(Deluxe Edition)` always

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -69,8 +69,9 @@ session 2026-05-16.
 
 ### F-LOAD-1: concurrent-user UX when job slots are full
 
-With all 10 `MAX_ACTIVE_JOBS` slots busy, users get "Too many requests in
-progress" with no occupancy hint; "N/10 slots in use" would help.
+With all `MAX_ACTIVE_JOBS` slots busy (default 5 since 2026-07-31; was
+10), users get "Too many requests in progress" with no occupancy hint;
+"N/5 slots in use" would help.
 Status: open. Source: load testing 2026-03-04.
 
 ### F-AUDIT-1: dark-mode toggle placement on mobile

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -215,9 +215,11 @@ Status: open (P2). Source: PR #162 review round 4.
 Close-out headings use a `(Batch N close-out)` suffix that `ENTRY_BATCH_RE`
 does not recognize as batch-tagged, so rotation routes them into the
 untagged monolith archive instead of `docs/history/logs/BATCHN_LOG.md`.
-Consistent across batches: neither BATCH19_LOG.md nor BATCH20_LOG.md
-contains its close-out entry; both sit in the monolith. Per-batch history
-is therefore incomplete without a monolith grep. Fix belongs in a docsync
+Affects only close-outs written with that suffix: BATCH19_LOG.md and
+BATCH20_LOG.md lack their close-out entries (both sit in the monolith),
+while Batch 18's close-out was tagged `(Batch 18 WP-5)` and routed
+correctly. Per-batch history is therefore incomplete for the affected
+batches without a monolith grep. Fix belongs in a docsync
 WP together with F-DOCSYNC-1/F-DOCSYNC-2 (make close-out tags parseable,
 then one-time re-route of the existing close-out entries); hand-retagging
 machine-rotated archive content was declined in PR #162 round 3 and again

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -130,6 +130,66 @@ Source: owner request 2026-07-31.
 the original sweep); narrow or add structured logging per exception
 class. Status: open. Source: MULTI_AGENT_SWEEP.
 
+### F-DATA-1: reissue editions collapse onto the original's cache row
+
+`normalize_name()` strips `deluxe`/`edition`/`remastered`/`anniversary`
+and seven more words from the album string, so
+`"viagr aboys (Deluxe Edition)"` and `"viagr aboys"` both normalize to
+`viagr aboys`. The `spotify_cache` primary key is
+`artist_norm + album_norm`, so **both editions share one row** holding
+whichever release populated it first, for the 30-day TTL. When the
+reissue wins that race its `release_date` is served for the original.
+
+Observed 2026-07-31: Viagra Boys "viagr aboys" (2025) appears under
+`release_scope: same` for 2026, matching the JP deluxe released
+2026-01-09, on an account that never played the deluxe.
+
+The collapse is not a bug on its own -- it is what makes matching work
+across Last.fm's inconsistent album strings, where the same record is
+scrobbled as `Album`, `Album (Deluxe Edition)`, and `Album - Deluxe`
+depending on the reporting client. Keying editions apart would fragment
+one album into several leaderboard rows with split playcounts, which is
+a worse defect than an occasional wrong year. Collapsing is correct for
+*counting* and wrong for *dating*; the two need decoupling, not one
+shared key.
+
+Candidate fix (untested): keep the collapse for aggregation, but when
+resolving `release_date`, select the **earliest** date among candidate
+Spotify matches instead of whichever cached first. The original predates
+its reissues by construction, and this approximates the "Original
+Release Date" that Deezer's API team confirmed is a separate field from
+the digital release date labels supply. No schema change required.
+
+Rejected: a boolean `is_deluxe` discriminator. The stopword list has 11
+entries that combine freely (deluxe, expanded, anniversary, JP deluxe),
+so a boolean still collides variant-against-variant. Retaining the
+stripped tokens as a variant tag would work but reintroduces the
+fragmentation above.
+
+Open questions, answerable from the cache rather than by speculation:
+1. Do the scrobbles themselves carry the deluxe title? Last.fm stores
+   whatever album metadata the player reported, which is a second
+   independent path to the same result.
+2. Which other albums are affected? Group `spotify_cache` by
+   `artist_norm + album_norm` and flag rows whose `release_date` is
+   later than the earliest known release for that album.
+3. Can both a Latin-script deluxe and a JP deluxe surface at once? Only
+   if the JP title carries Japanese characters -- NFKC preserves those,
+   so it would not collapse; a Latin-script `(Deluxe Edition)` always
+   merges to one row.
+
+Note: Spotify exposes no original-release-date field. `release_date`
+belongs to the matched release object, and `release_date_precision`
+(`year`/`month`/`day`) only reports granularity. Disambiguation must
+come from the search result set, the discarded `(Deluxe Edition)`
+suffix, or `total_tracks`. MusicBrainz does carry original release
+dates -- a lookup narrowed to that single field, cached, is far smaller
+than the full-enrichment attempt abandoned in 2025.
+
+Status: open (P2). Low user impact -- one recalled instance across ~14
+years of scrobbles, and `release_scope: all` bypasses date filtering
+entirely. Source: session 2026-07-31.
+
 ---
 
 ## P2 -- Scaling roadmap

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -70,8 +70,12 @@ session 2026-05-16.
 ### F-LOAD-1: concurrent-user UX when job slots are full
 
 With all `MAX_ACTIVE_JOBS` slots busy (default 5 since 2026-07-31; was
-10), users get "Too many requests in progress" with no occupancy hint;
-"N/5 slots in use" would help.
+10), users get "Too many requests in progress" with no occupancy hint.
+An "N/<cap> slots in use" hint would help, with the cap read from the
+configured `MAX_ACTIVE_JOBS` at render time rather than written as a
+literal -- deployments that override the env var must show their own
+capacity, and a literal silently goes stale at the next default change
+(it read "N/10" until 2026-07-31).
 Status: open. Source: load testing 2026-03-04.
 
 ### F-AUDIT-1: dark-mode toggle placement on mobile

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -81,8 +81,8 @@ Status: open. Source: load testing 2026-03-04.
 ### F-AUDIT-1: dark-mode toggle placement on mobile
 
 Fixed-position footer toggle may overlap content on small screens.
-Batch 21 moves the toggle into the standing header bar; acceptance
-criterion 8 states "toggle meets tap-target size (closes F-AUDIT-1)".
+Batch 21 moves the toggle into the standing header bar; its acceptance
+criterion on tap-target size names this finding as closed by that work.
 Status: open; closes at Batch 21 WP-2. Source: AUDIT_2026-02-11.
 
 ### F-LOAD-2: no integration tests in CI
@@ -296,8 +296,8 @@ audits; 2026-03-04 load-test data is in the findings archive.
 - F-B18-7: duplicated win32 event-loop guard -- absorbed into F-B20-2.
 - F-B18-10: heatmap + album jobs share the 10 req/s throttle (by design).
 - F-B18-12: mode pills differ in width (no `min-width` on `.mode-pill`);
-  in Batch 21 scope (WP-6, acceptance criterion 8) -- no longer a
-  future-batch candidate.
+  in Batch 21 scope (WP-6, and the acceptance criterion requiring equal
+  mode-pill width) -- no longer a future-batch candidate.
 - F-B19-3: last.timer aggregate endpoints are not a drop-in heatmap
   speedup; future perf experiments listed in the archive.
 - F-B19-4: front-end UI audit notes -- basis of `BATCH21_DEFINITION.md`.

--- a/HANDOFF_PROMPT.md
+++ b/HANDOFF_PROMPT.md
@@ -51,8 +51,9 @@ list before every commit.
 
 ## 5) Handoff when you are done or interrupted
 
-Documentation lands *in* the commit, not after it: AGENTS.md Commit Rules
-step 4 and Anti-Pattern Registry #9 require the dated Section 4 entry to
+Documentation lands *in* the commit, not after it: the documentation step
+of AGENTS.md Commit Rules, plus "Missing log entries" in the Anti-Pattern
+Registry, require the dated Section 4 entry to
 be part of the same commit as the work it describes. So before you commit:
 
 1. Update PLAYBOOK Section 3 (mark WP done or note interruption point).

--- a/HANDOFF_PROMPT.md
+++ b/HANDOFF_PROMPT.md
@@ -53,13 +53,15 @@ list before every commit.
 
 ## 5) Handoff when you are done or interrupted
 
-After your changes are committed (following AGENTS.md commit rules and
-side-task handling), document completion:
+Documentation lands *in* the commit, not after it: AGENTS.md Commit Rules
+step 4 and Anti-Pattern Registry #9 require the dated Section 4 entry to
+be part of the same commit as the work it describes. So before you commit:
 
 1. Update PLAYBOOK Section 3 (mark WP done or note interruption point).
 2. Add a dated entry to PLAYBOOK Section 4 (inside current-batch markers
    for batch work; directly after the end marker for side-tasks).
 3. Run `python scripts/doc_state_sync.py --fix`.
 4. Verify `python scripts/doc_state_sync.py --check` exits 0.
-5. Stage and commit PLAYBOOK.md + `.claude/SESSION_CONTEXT.md` together.
+5. Stage PLAYBOOK.md and `.claude/SESSION_CONTEXT.md` alongside the files
+   you changed, and commit them together.
 6. State clearly what remains for the next agent.

--- a/HANDOFF_PROMPT.md
+++ b/HANDOFF_PROMPT.md
@@ -1,77 +1,42 @@
 # Agent Hand-Off Prompt
 
-You are continuing work on ScrobbleScope. Follow the comment-job fast-path in
-`AGENTS.md` when the task is a PR comment/review-comment fix. Otherwise, read
-the bootstrap files below before doing anything else.
+You are continuing work on ScrobbleScope. Follow the comment-job fast-paths
+in `AGENTS.md` (Session Bootstrap) when the task is a PR comment or
+review-comment fix. Otherwise bootstrap first.
 
 ---
 
-## 1) Bootstrap (required -- read in this order)
+## 1) Bootstrap
 
-**Comment/review-job fast-path:**
-- When no direct review-comment link is supplied: first determine whether
-  there is any actionable new `@copilot` comment. If none are actionable,
-  stop immediately without full bootstrap.
-- If the prompt links to a single review comment or `discussion_r...` URL,
-  fetch that thread first and inspect only the touched file plus the minimum
-  nearby bootstrap context needed for that thread.
-- Open the batch definition, archive/history docs, and `AGENT_NOTES.md` only
-  when the linked comment depends on them.
-
-Canonical source order:
-- `AGENTS.md` owns stable rules.
-- `HANDOFF_PROMPT.md` owns session-start procedure and commit discipline.
-- `PLAYBOOK.md` owns active work order and execution log.
-- `.claude/SESSION_CONTEXT.md` mirrors current state for fast orientation.
-- `AGENT_NOTES.md` owns owner preferences and local constraints.
-
-If two bootstrap files conflict, follow the stricter safety rule and pause
-only when the conflict affects the next action. In particular, never push
+The canonical read order, document roles, token discipline, and sufficiency
+gate are defined once in `AGENTS.md` ("Document Roles" and "Session
+Bootstrap") -- follow them exactly; they are not restated here. If two
+bootstrap files conflict, follow the stricter safety rule and pause only
+when the conflict affects the next action. In particular, never push
 without explicit owner instruction.
 
-1. `AGENTS.md` -- rules, commit format, docsync policy, anti-patterns.
-2. `PLAYBOOK.md` Section 3 (active batch + next WP) + Section 4 (log).
-3. The batch definition file named in PLAYBOOK Section 3.
-   Active batch: definition file is at repo root (`BATCHN_DEFINITION.md`).
-   Between batches: no definition file exists yet -- skip this step.
-   Completed batches: file is under `docs/history/definitions/`.
-4. `.claude/SESSION_CONTEXT.md` -- **required**, not optional.
-   Read Section 1 (current state + test count) and Section 2 (status block)
-   at minimum. Sections 3-5 if you need structure, dependency, or architecture detail.
-5. `AGENT_NOTES.md` (repo root) -- owner preferences, local dev setup,
-   architectural constraints, and known issues. Tracked in the repo;
-   readable by all agents.
-6. `FINDINGS.md` -- on demand only: read when PLAYBOOK Section 4 or your
-   task references an F-* finding ID or an open P0/P1 item. Not part of
-   the mandatory set. Finding-writing rules live in `AGENTS.md`.
-
-After reading the five core files, run:
+After reading the bootstrap files, verify reality matches the docs:
 
 ```bash
 git status
 git log --oneline -5
 ```
 
-Verify the branch, last commits, and any staged/modified files match what
-PLAYBOOK Section 3 describes. If they do not match, resolve the discrepancy
-before doing any work.
-
-If PLAYBOOK Section 3, the definition file, and SESSION_CONTEXT Section 1
-all agree on what is done and what is next, you have enough context to start.
+Confirm the branch, last commits, and any staged/modified files match what
+PLAYBOOK Section 3 describes, and that `pytest -q` matches the test count
+in SESSION_CONTEXT Section 1. If anything does not match, resolve the
+discrepancy before doing any work.
 
 ---
 
 ## 2) Validation gates (run before every commit)
 
-```bash
-pytest -q
-pre-commit run --all-files
-python scripts/doc_state_sync.py --check
-```
-
-A `Root BATCH file detected` warning is expected while an active batch
-definition is intentionally at repo root and named in PLAYBOOK Section 3.
-It should disappear during batch close-out after the definition is archived.
+The three-command gate (`pytest -q`, `pre-commit run --all-files`,
+`python scripts/doc_state_sync.py --check`) is defined in `AGENTS.md`
+Commit Rules ("Procedure before every commit"). A `Root BATCH file
+detected` warning from `--check` is expected while an active batch
+definition is intentionally at repo root and named in PLAYBOOK Section 3;
+it disappears at batch close-out.
 
 After editing PLAYBOOK Section 4:
 
@@ -83,39 +48,26 @@ python scripts/doc_state_sync.py --fix
 
 ## 3) Commit discipline
 
-- Conventional Commits, imperative mood, max 72 chars. No co-author trailers.
-- Stage files by name only. Never `git add -A` or `git add .`.
-- One commit per WP.
-- **Do NOT push without explicit owner instruction.** Pause after each commit.
-- Update PLAYBOOK Section 3 + Section 4 BEFORE committing.
-- Batch log entries use `(Batch N WP-X)` tag in the heading.
-- `.claude/SESSION_CONTEXT.md` is committed and shared across all agents.
-  Stage and commit it whenever it changes -- do not leave it modified and unstaged.
+Owned by `AGENTS.md` (Commit Rules and Side-Task Handling). Do not restate
+or re-derive it here -- read it there.
 
 ---
 
-## 4) Anti-patterns (do not do these)
+## 4) Anti-patterns
 
-1. **SoC/DRY violations:** Each module has one responsibility. Extract shared
-   logic rather than duplicating it. File size is not the constraint -- SoC/DRY
-   is. All functions require comprehensive docstrings and inline comments on
-   non-obvious logic.
-2. **Vacuous tests:** Every test must fail if the function under test is deleted.
-3. **Bulk staging:** Never `git add -A` or `git add .`. Stage specific files only.
-4. **Skipping hooks:** Never `--no-verify`. Fix the hook failure instead.
-5. **Stale Section 3:** PLAYBOOK Section 3 must reflect true WP state at all times.
-6. **Missing log entries:** Every WP commit needs a dated Section 4 entry inside
-   the `DOCSYNC:CURRENT-BATCH-START/END` markers.
+Owned by `AGENTS.md` (Anti-Pattern Registry). Check your work against that
+list before every commit.
 
 ---
 
 ## 5) Handoff when you are done or interrupted
 
-After your code changes are committed (following AGENTS.md commit rules
-and side-task handling), document completion:
+After your changes are committed (following AGENTS.md commit rules and
+side-task handling), document completion:
 
 1. Update PLAYBOOK Section 3 (mark WP done or note interruption point).
-2. Add dated entry to PLAYBOOK Section 4 (inside current-batch markers).
+2. Add a dated entry to PLAYBOOK Section 4 (inside current-batch markers
+   for batch work; directly after the end marker for side-tasks).
 3. Run `python scripts/doc_state_sync.py --fix`.
 4. Verify `python scripts/doc_state_sync.py --check` exits 0.
 5. Stage and commit PLAYBOOK.md + `.claude/SESSION_CONTEXT.md` together.

--- a/HANDOFF_PROMPT.md
+++ b/HANDOFF_PROMPT.md
@@ -8,12 +8,10 @@ review-comment fix. Otherwise bootstrap first.
 
 ## 1) Bootstrap
 
-The canonical read order, document roles, token discipline, and sufficiency
-gate are defined once in `AGENTS.md` ("Document Roles" and "Session
-Bootstrap") -- follow them exactly; they are not restated here. If two
-bootstrap files conflict, follow the stricter safety rule and pause only
-when the conflict affects the next action. In particular, never push
-without explicit owner instruction.
+The canonical read order, document roles, token discipline, sufficiency
+gate, and bootstrap-conflict handling are defined once in `AGENTS.md`
+("Document Roles" and "Session Bootstrap") -- follow them exactly; they
+are not restated here.
 
 After reading the bootstrap files, verify reality matches the docs:
 

--- a/HANDOFF_PROMPT.md
+++ b/HANDOFF_PROMPT.md
@@ -31,18 +31,9 @@ discrepancy before doing any work.
 
 ## 2) Validation gates (run before every commit)
 
-The three-command gate (`pytest -q`, `pre-commit run --all-files`,
-`python scripts/doc_state_sync.py --check`) is defined in `AGENTS.md`
-Commit Rules ("Procedure before every commit"). A `Root BATCH file
-detected` warning from `--check` is expected while an active batch
-definition is intentionally at repo root and named in PLAYBOOK Section 3;
-it disappears at batch close-out.
-
-After editing PLAYBOOK Section 4:
-
-```bash
-python scripts/doc_state_sync.py --fix
-```
+Owned by `AGENTS.md` (Commit Rules "Procedure before every commit", and
+Doc Sync Rules for the `--fix` step). Do not restate or re-derive them
+here -- read them there.
 
 ---
 

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,57 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-08-01 - PR #165 round 7 + review-loop pattern sweep (side-task)
+
+- Scope: owner asked for the round-7 findings to be verified but not
+  fixed until a sweep across every review round on PRs #163/#164/#165
+  identified why fixes keep producing new findings. Corpus: ~40
+  findings over 12 rounds.
+- Round 7 findings (all three valid):
+  - `AGENTS.md` close-out step 3 said "add a row" to PLAYBOOK Section 2,
+    but the active batch already has one -- following it literally
+    duplicates the row. Now says repoint the existing row, add only if
+    absent.
+  - The sufficiency gate required agreement with "the batch definition"
+    while bootstrap step 3 states no definition exists between batches,
+    so the gate was unsatisfiable in that state. Both states now
+    stated.
+  - `docs/SWE_AUDIT_CHARTER.md` labelled its differential baseline
+    "Open findings" while including F-DOCSYNC-4, resolved earlier in
+    this same PR. Relabelled as already-tracked regardless of status,
+    with an instruction to check each `Status:` line.
+- Sweep results -- four recurring classes, now in the Anti-Pattern
+  Registry. Two were already logged; two are new:
+  - *Fixing the instance instead of the class* (logged previously): the
+    dominant cause. Rounds 6 and 7 findings were created almost
+    entirely by rounds 5 and 6 fixes.
+  - *Lossy or contradictory consolidation* (new): collapsing duplicated
+    rules to one owner while leaving copies, dropping a specific
+    prohibition (the `git add -A` ban nearly vanished this way), or
+    contradicting another section of the same file.
+  - *Assertions over sets, ranges, and citations* (new): "all seven CSS
+    files", "F-DOCSYNC-1 through F-DOCSYNC-4", citing a gitignored
+    file, citing an anti-pattern that does not cover the case.
+  - *Happy-path-only procedures* (new): steps that break in an edge
+    state -- row already present, no definition between batches, gate
+    ordered before the work it validates.
+- Why the loop exists, and the structural fix: the validation gates
+  check mechanics only -- nothing verifies that one document still
+  agrees with another, so each fix's damage is discoverable only by the
+  next review round. Added a "Pre-push self-review" block to Commit
+  Rules: read changed files whole rather than as diffs, run the
+  blast-radius greps, walk procedures through edge states, and prefer
+  deletion to addition because every added sentence is new surface area.
+- Deviations: none. The new checklist caught its own first violation --
+  the draft cited registry entries by number, which the same registry
+  forbids; now cited by name.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: the honest test is round 8. If it finds fresh
+  self-inflicted drift, the checklist is not enough and the next step is
+  mechanical enforcement (a consistency-lint hook) rather than more
+  prose.
+
 ### 2026-08-01 - PR #165 review round 6; self-inflicted-drift anti-pattern (side-task)
 
 - Scope: round 6 returned three suppressed comments, zero visible. All
@@ -254,36 +305,3 @@ non-current operational logs. Older dated entries live in
   an investigation -- run it before designing any fix. Sequenced behind
   Batch 21, the F-B20-2 orchestrator split, and the test/docstring pass
   per owner priority.
-
-### 2026-07-31 - DEVELOPMENT.md: correct HANDOFF_PROMPT description (side-task)
-
-- Scope: DEVELOPMENT.md described `HANDOFF_PROMPT.md` as a condensed
-  checklist of rules, gates, read order, and commit discipline. That was
-  accurate until this branch, which reduced the file to post-read
-  verification plus the handoff checklist and replaced everything else
-  with pointers. The description was left describing the architecture
-  this PR removed.
-- Plan vs implementation: two passages corrected -- the architecture
-  overview and the per-file section, which was also retitled from
-  "Bootstrap Procedure" to "Session Start and Handoff" to match what the
-  file now contains. Both now state why the summaries were removed
-  (each restatement drifted from its source), which is the reasoning the
-  rest of the document uses.
-- Deviations: scope-limited on purpose. Only the passages this branch
-  made wrong were touched. DEVELOPMENT.md has other known staleness --
-  the `gemini-pr-triage` skill is now `pr-bot-triage`, the
-  review-suggestions section predates repo-aware review tooling, and the
-  closing paragraph needs a rewrite -- all deferred to a post-merge
-  documentation pass, per the same in-scope test applied to
-  `concurrent_users_test.py` in review round 1.
-- Note: this class of staleness is invisible to diff-scoped review.
-  Copilot reported "13/13 changed files" across four rounds and
-  DEVELOPMENT.md was never among them, so a file made wrong by the diff
-  but not part of it cannot be flagged. Worth remembering when relying on
-  automated review for consistency.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: the post-merge pass should reframe the review section
-  around how the tooling changed rather than around rejection, and
-  `README.md:492` must move with it -- it currently promises a section on
-  suggestions "evaluated and rejected".

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,42 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - PR #165 Copilot review round 4 (side-task)
+
+- Scope: zero visible comments, two suppressed, both valid and both real
+  defects rather than the judgement-call trade-offs round 3 predicted.
+  The convergence call made after round 3 was wrong; recorded here
+  because the wrong prediction is the useful part. Tally 18/18.
+- Plan vs implementation:
+  - **A rule was silently deleted by this PR, and round 1 removed the
+    last copy.** The prohibition on `git add -A` / `git add .` lived in
+    two places before this branch: AGENT_NOTES.md Owner Preferences and
+    the old HANDOFF_PROMPT anti-pattern list. The PR's HANDOFF_PROMPT
+    rewrite dropped its copy, and the round-1 dedup replaced the
+    AGENT_NOTES copy with a pointer to AGENTS.md Commit Rules -- which
+    never contained the prohibition. Step 5 only said "stage only files
+    changed for this work package", which `git add -A` can satisfy when
+    every changed file happens to belong to the WP. Restored explicitly
+    in Commit Rules step 5, the canonical location the pointer targets.
+  - Lesson: verifying that a pointer's target "covers it in substance"
+    is not enough. Round 1 checked AGENTS.md:167 and accepted a
+    paraphrase as equivalent when it dropped a prohibition. Before
+    deleting a rule copy, diff the *specific obligations*, not the topic.
+  - `scripts/testing/concurrent_users_test.py` promised queuing in three
+    places. `acquire_job_slot()` uses `acquire(blocking=False)` and both
+    call sites (`routes.py:460`, `routes.py:570`) return an error
+    immediately, so excess submissions are rejected and never queued.
+    Round 1 edited one of those lines for the cap change without
+    questioning the surrounding claim. Now describes rejection, matching
+    README's "capacity rejections" wording.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: do not call convergence from the *shape* of a round's
+  findings. Rounds 2 and 3 returned zero visible comments and were still
+  productive; round 4 found a deleted rule. Stop when a round returns
+  nothing, not when the findings look minor.
+
 ### 2026-07-31 - PR #165 Copilot review round 3 (side-task)
 
 - Scope: round 3 again returned zero visible comments and three
@@ -267,22 +303,3 @@ non-current operational logs. Older dated entries live in
 - Forward guidance: the suppressed-comment block again held a real
   finding (8/8 across PRs #163/#164/#165), so keep expanding it. Batch 21
   WP-1 remains the next action.
-
-### 2026-07-31 - WP-1 token values pinned in the definition (side-task)
-
-- Scope: make WP-1 executor-agnostic. The definition referenced "the
-  audit token sheet" but only carried headline values; the full sheet
-  lived in the Claude Design project and one agent's session notes,
-  blocking a cold-start executor (e.g. a Codex session) from
-  implementing WP-1 faithfully.
-- Plan vs implementation: the WP-1 theme bullet now pins the complete
-  sheet -- all eight colors (light bg/bg-2/ink/primary, dark
-  bg/surface/text/primary), the three-family type system with sizes,
-  the 4px spacing ladder, and the radius set. Values transcribed from
-  "ScrobbleScope UI Audit v3" section "A starter palette and type
-  system you can ship today" (2026-07-28 fetch).
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: WP-1 can now be executed by any agent from the
-  definition alone; compiled CSS remains the WP-1 deliverable.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,32 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - Push rule: standing exception for review-fix commits (side-task)
+
+- Scope: owner-directed policy change, not a review finding. During PR
+  #165 triage the owner granted a standing authorization to push
+  review-driven commits without asking per round, on the reasoning that
+  the agent reaches the diminishing-returns point on its own and a
+  per-round approval round-trip only stalls the loop.
+- Plan vs implementation: encoded in AGENTS.md Commit Rules step 6 rather
+  than left as an agent-side preference, because AGENTS.md is the rules
+  SSOT and a spoken rule that contradicts the written one is exactly the
+  defect this PR spent four rounds removing. Scoped per owner: **Claude
+  Code and Codex sessions only.** GitHub Copilot task sessions and their
+  subagents, Jules, and any other agent follow the unmodified rule --
+  the owner does not extend equal trust to agents of varying quality
+  that it cannot inspect per-invocation. Step 6 already carried a
+  Copilot-specific clause, so per-agent scoping had precedent.
+- Deviations: the exception is deliberately narrow. Review-fix commits on
+  an open PR only; batch and WP commits still pause, and force-pushes,
+  history rewrites, and anything touching `main` still require explicit
+  instruction.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: if the agent roster changes, this clause names
+  specific agents and will need revisiting -- it is an allowlist, not a
+  capability test.
+
 ### 2026-07-31 - PR #165 Copilot review round 4 (side-task)
 
 - Scope: zero visible comments, two suppressed, both valid and both real
@@ -269,37 +295,3 @@ non-current operational logs. Older dated entries live in
   -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: Batch 21 WP-1 remains the next action. `gh` writes
   are still unavailable this session, so the round-2 reply is unposted.
-
-### 2026-07-31 - PR #165 Copilot review round 1 (side-task)
-
-- Scope: triaged the five comments on PR #165 (four inline, one inside
-  the suppressed low-confidence block). All five were valid; none were
-  declined. Two themes: an overstated concurrency claim and three
-  leftover copies of rules AGENTS.md now owns.
-- Plan vs implementation:
-  - `config.py`: the MAX_ACTIVE_JOBS rationale claimed a cap of 5 "keeps
-    >=2 req/s per job". `_GlobalThrottle.next_wait()` (utils.py) advances
-    a single next-allowed timestamp under one lock, serializing callers
-    in arrival order with no per-job accounting, so a busy job can take
-    more slots than an idle one. Reworded as an average, matching the
-    "~10/N req/s" framing already used in AGENT_NOTES.md.
-  - `scripts/testing/concurrent_users_test.py`: module docstring and
-    `build_parser()` still said the default was 10 and told operators to
-    set `--concurrency` above 10. Both now say 5. A repo-wide sweep found
-    no other live stale reference; remaining "default 10" hits are all
-    under `docs/history/` and stay as written (point-in-time records).
-  - `AGENT_NOTES.md`: the Owner Preferences commit-mechanics bullet and
-    the Venv "In short:" line each pointed at AGENTS.md and then restated
-    its content anyway. Both reduced to pointers after verifying AGENTS.md
-    genuinely carries every rule involved.
-  - `HANDOFF_PROMPT.md`: Section 2 restated the full three-command gate
-    and the root-BATCH warning, contradicting the Document Roles contract
-    added by this same PR, which assigns gates to AGENTS.md. Collapsed to
-    a pointer matching the wording Sections 3 and 4 already use.
-- Deviations: none. No test changes -- all five edits are comment or
-  documentation text with no behavior change.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: the suppressed-comment block again held a real
-  finding (8/8 across PRs #163/#164/#165), so keep expanding it. Batch 21
-  WP-1 remains the next action.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,45 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - PR #165 Copilot review round 3 (side-task)
+
+- Scope: round 3 again returned zero visible comments and three
+  suppressed ones. Two acted on in full, one acted on in part.
+  Suppressed-block tally now 16/16 across #163, #164, and #165.
+- Plan vs implementation:
+  - `docs/SWE_AUDIT_CHARTER.md` Section 3 copied the ten principle names
+    from AGENT_NOTES.md and **had already drifted**: the copy dropped the
+    definitions for Dependency Inversion, Least Knowledge, and Fail Fast,
+    and truncated SRP from "single responsibility per module/function".
+    This is the rare case where the drift was demonstrable rather than
+    hypothetical, so the copy is gone. The section now points at
+    AGENT_NOTES.md and keeps only the two audit-specific methods (Clean
+    Architecture via the SESSION_CONTEXT Section 4 acyclic graph, Boy
+    Scout via git history).
+  - `docs/SWE_AUDIT_CHARTER.md` Section 6 restated side-task entry
+    placement that AGENTS.md Side-Task Handling owns -- and round 2 had
+    just renumbered that section, so the charter was already a rewrite
+    away from being wrong. Delegated.
+  - `HANDOFF_PROMPT.md` Section 1 restated the bootstrap-conflict rule
+    verbatim from AGENTS.md:64-65 inside a paragraph that claims rules
+    "are not restated here". Removed.
+- Deviations: **partially declined** the reviewer's request to also strip
+  "Do not push without owner instruction" from the charter's commit step.
+  Verified AGENTS.md:171 owns it, so the SSOT argument is technically
+  right, but that line sits at the point of action for a cold-start
+  executor (the charter is written so Codex can run it without prior
+  context) and a push is not reversible. Deliberate safety redundancy is
+  worth one line. Removed the same sentence from HANDOFF_PROMPT Section 1
+  by contrast, because there the reader is being sent to AGENTS.md in the
+  very same paragraph, so the copy buys nothing.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: watch for diminishing returns. Rounds 1-3 were all
+  genuine, but the remaining duplication is increasingly load-bearing
+  context for cold-start executors; judge each on whether the copy can
+  drift *and* whether losing it costs a reader who cannot see the source.
+  Batch 21 WP-1 remains the next action.
+
 ### 2026-07-31 - PR #165 Copilot review round 2 (side-task)
 
 - Scope: round 2 returned **zero visible comments and five suppressed
@@ -247,19 +286,3 @@ non-current operational logs. Older dated entries live in
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: WP-1 can now be executed by any agent from the
   definition alone; compiled CSS remains the WP-1 deliverable.
-
-### 2026-07-31 - Owner-preferences commit-rule dedup (side-task)
-
-- Scope: final SSOT sweep found AGENT_NOTES.md Owner Preferences still
-  restating three commit-mechanics rules AGENTS.md now owns
-  (incremental staging, no co-author trailers, push/pause discipline).
-- Plan vs implementation: the four bullets collapsed into one pointer at
-  AGENTS.md Commit Rules; preference-only items (concise responses,
-  Docker/MCP pause, explain-why, Firefox testing, principles, testing
-  pyramid) stay -- they are owner context, not rules.
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: hygiene plan complete (6 commits); Batch 21 WP-1 is
-  next. SSOT sweep contract now holds: commit-rule keywords, venv rules,
-  the heatmap perf figure, and batch state each have exactly one owner.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -152,6 +152,36 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-08-01 - PR #165 round 9; new rules are not retroactive (side-task)
+
+- Scope: three suppressed comments, all valid -- numeric citations into
+  ordered lists (`Anti-Pattern Registry entries 4 and 5`, two
+  `acceptance criterion 8` references) that the registry's own
+  name-based citation rule prohibits.
+- Cause, established from history rather than assumed: the citations
+  were written in the SSOT pass and the FINDINGS refresh; the rule
+  banning them was written two commits later. Nothing swept the
+  existing corpus against the new rule, so the rule shipped with a
+  backlog of its own violations. The pre-push checklist greps the blast
+  radius of *the change*; when the change is a rule, the blast radius is
+  the whole repository, and that leap was never made.
+- Plan vs implementation: all three citations repointed by name. A
+  repo-wide sweep for `entries N`, `Registry #N`, `criterion N`,
+  `step N`, `rule N`, `item N` across every canonical doc now returns
+  nothing. The lesson was folded into the existing blast-radius
+  anti-pattern as one sentence rather than becoming a fifteenth
+  registry entry -- see the verbosity note below.
+- Deliberate non-action: AGENTS.md is now 475 lines and the registry
+  holds fourteen entries. Documentation across the agent-orchestration
+  set (1,685 lines) stands at roughly 60 percent of the production
+  Python it governs (2,787 lines), and several recent findings were
+  caused by rule text rather than caught by it. Adding rules is no
+  longer cheap. A consolidation pass is a batch-scoped candidate, not
+  something to attempt mid-PR.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: merge rather than iterate further.
+
 ### 2026-08-01 - PR #165 round 8; over-broad claims narrowed (side-task)
 
 - Scope: three suppressed comments, all valid, all fixed.
@@ -272,37 +302,3 @@ non-current operational logs. Older dated entries live in
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: pushed under the standing review-fix exception with
   a batched reply.
-
-### 2026-08-01 - PR #165 Copilot review round 5 (side-task)
-
-- Scope: round 5 returned "not ready to approve" with four suppressed
-  comments and zero visible ones. All four verified valid against the
-  code; all four acted on.
-- Plan vs implementation:
-  - `config.py`: the MAX_ACTIVE_JOBS rationale claimed "one global
-    10 req/s API throttle". Wrong -- `utils.py:81-82` builds separate
-    `_LASTFM_THROTTLE` and `_SPOTIFY_THROTTLE`. Comment now names the
-    Last.fm scrobble-fetch phase as the binding constraint.
-  - `AGENTS.md` commit procedure: the docsync `--check` gate sat at
-    step 3 while the PLAYBOOK update was step 4, so the gate ran before
-    the documentation it validates (and `pre-commit` carries the
-    `doc-state-sync-check` hook). Reordered: write docs, `--fix`, then
-    the three gates on the final state. This matches what sessions
-    already do in practice; only the written rule was wrong. Fixed a
-    duplicate step number introduced by the renumber.
-  - `FINDINGS.md` F-DATA-1 open question 2 proposed grouping
-    `spotify_cache` by `artist_norm + album_norm` -- which is the
-    primary key (`init_db.py:42`), so every group holds exactly one row
-    and the upsert has already overwritten any rival date. Replaced
-    with the two methods that can actually work (re-run the Spotify
-    search and compare against the earliest fresh candidate, or
-    cross-check MusicBrainz).
-  - `docs/SWE_AUDIT_CHARTER.md`: prescribed commit subject was a noun
-    phrase, violating the imperative-subject rule the charter tells
-    executors to follow. Now imperative.
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: pushed under the standing review-fix exception with
-  a batched reply. PR #165 remains merge-ready pending the next
-  auto-review.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,52 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - PR #165 Copilot review round 2 (side-task)
+
+- Scope: round 2 returned **zero visible comments and five suppressed
+  ones**. All five were valid. The suppressed-block hit rate is now 13/13
+  across PRs #163, #164, and #165 while the visible stream has gone dry
+  twice; treat that block as the primary signal, not an appendix.
+- Plan vs implementation:
+  - `AGENTS.md` Side-Task Handling read as an ordered procedure whose
+    step 1 was "commit" and step 2 "add the log entry", contradicting
+    Commit Rules step 4 and Anti-Pattern Registry #9, which require the
+    entry to be in the same commit. Since AGENTS.md is now the rules
+    SSOT, an internal contradiction there is load-bearing. Reworded so
+    side-tasks inherit the commit rules unchanged and differ only in
+    entry placement and tagging; the remaining steps renumbered.
+  - `HANDOFF_PROMPT.md` Section 5 told agents to document completion
+    *after* committing and to commit the docs separately -- the same
+    conflict, one level down. Now states that docs land in the commit.
+  - Resolution was evidence-based, not a judgement call: registry #9
+    forbids a commit without its entry, and all four recent side-task
+    commits (`2559f39`, `2b9b095`, `98cc50c`, `900d0e6`) bundle
+    PLAYBOOK + archive with the change. Docs were wrong; practice was
+    right.
+  - `FINDINGS.md` F-LOAD-1 proposed an "N/5 slots in use" hint, which
+    hard-codes a value that is env-configurable. This PR had changed it
+    from "N/10" -- swapping one literal for another. Now specifies
+    reading the cap from `MAX_ACTIVE_JOBS` at render time.
+  - `.claude/SESSION_CONTEXT.md` header said 2026-07-28 while the body
+    recorded a 2026-07-31 runtime change. Header updated.
+  - `docs/SWE_AUDIT_CHARTER.md` cited "AGENTS.md registry #10" for
+    silent scope reduction; #10 is about re-measuring canonical figures
+    and says nothing about audit coverage. The charter was added in this
+    PR, so this was a sourcing error at write time, not staleness --
+    corrected rather than left as a point-in-time record. Now states the
+    requirement directly.
+- Deviations: round 1 split its fixes across two commits, and `07c4f5b`
+  therefore landed without its own Section 4 entry -- a violation of
+  Anti-Pattern Registry #9, the rule this round clarifies. Not rewritten:
+  both commits were already pushed and history rewrites need owner
+  instruction. Round 2 is a single commit. Standing lesson: this repo's
+  #9 outranks the generic "prefer small atomic commits" heuristic, and
+  the one-commit-per-review-round precedent from PR #163 was correct.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: Batch 21 WP-1 remains the next action. `gh` writes
+  are still unavailable this session, so the round-2 reply is unposted.
+
 ### 2026-07-31 - PR #165 Copilot review round 1 (side-task)
 
 - Scope: triaged the five comments on PR #165 (four inline, one inside
@@ -217,24 +263,3 @@ non-current operational logs. Older dated entries live in
 - Forward guidance: hygiene plan complete (6 commits); Batch 21 WP-1 is
   next. SSOT sweep contract now holds: commit-rule keywords, venv rules,
   the heatmap perf figure, and batch state each have exactly one owner.
-
-### 2026-07-31 - SWE-principles audit charter (side-task)
-
-- Scope: charter the owner-requested audit of the ten mandated software
-  principles so a dedicated single-purpose session (Claude or Codex) can
-  execute it cold, without this session's context.
-- Plan vs implementation: new `docs/SWE_AUDIT_CHARTER.md` front-loads
-  all judgment -- Python-only scope (JS/templates excluded until
-  Batch 21 ships them), a do-not-re-report differential baseline
-  (F-MAS-*, F-B20-2, prior 2026-02 audits, standing design decisions),
-  pre-identified hotspots (the three ~110-150 line functions and the 17
-  `except Exception` sites), a 10-principle x module grading matrix
-  with per-cell evidence, and a strict output contract (a dated
-  SWE_PRINCIPLES_AUDIT report under the history archive plus net-new
-  F-SWE-N findings only; read-only, no code changes). Tracked as
-  F-SWE-1.
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: execution is decoupled -- run whenever convenient
-  (Codex costs no Claude tokens). Batch 21 WP-1 is unblocked and next.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,32 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - MAX_ACTIVE_JOBS default 10 -> 5 (side-task)
+
+- Scope: owner decision. The 2026-03-04 load test ran 2/3/5 concurrent
+  users clean while the 10-user run never completed; all jobs share the
+  global 10 req/s API throttle, so 10 slots starve each job below
+  1 req/s on the single small Fly.io machine.
+- Plan vs implementation: `scrobblescope/config.py` default changed to
+  `"5"` with a rationale comment (still env-overridable); README (three
+  mentions), SESSION_CONTEXT key-runtime-facts line, and FINDINGS
+  F-LOAD-1 phrasing updated to match. `fly.toml` sets no
+  `MAX_ACTIVE_JOBS` override, so the new default takes effect on next
+  deploy.
+- Deviations: pre-change scouting claimed no test depends on the
+  default (capacity tests inject their own semaphores) -- true for
+  assertions but not for shared state. Route tests that mock
+  start_job_thread acquire a real slot that is never released, and the
+  session's accumulated leaks crossed the new cap of 5, failing
+  `test_heatmap_loading_json_body` with a real 429. Fixed properly: a
+  new autouse `fresh_job_slots` fixture in `tests/conftest.py` resets
+  the semaphore per test, removing the hidden inter-test ordering
+  coupling the lower cap exposed.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: owner can observe the 5-slot cap locally; the
+  "N/5 slots in use" occupancy hint remains open as F-LOAD-1.
+
 ### 2026-07-31 - FINDINGS refresh: batch-closure pointers, F-DOCSYNC-4, F-SWE-1 (side-task)
 
 - Scope: owner-flagged staleness in FINDINGS.md -- open P1 items that
@@ -232,30 +258,3 @@ non-current operational logs. Older dated entries live in
 - Forward guidance: commits 2-5 of the approved hygiene plan follow
   (PLAYBOOK log column, FINDINGS refresh, MAX_ACTIVE_JOBS 5, SWE audit
   charter); then Batch 21 WP-1.
-
-### 2026-07-29 - PR #164 phantom cleanup + review response (side-task)
-
-- Scope: PR #163 was rebase-merged, leaving `wip/batch-21` "8 ahead /
-  8 behind" (identical content, different SHAs -- normal rebase-merge
-  artifact). The owner opened PR #164 from the stale branch; Copilot
-  re-reviewed the phantom diff and left three NEW valid comments that
-  four prior rounds missed. PR #164 closed with explanation; branch
-  force-pushed to match `main`; all three fixes applied here.
-- Plan vs implementation:
-  - WP-4: leaving the loading page is now a plain "Back home" link with
-    no `/reset_progress` call -- the endpoint clears stored job state
-    only (`routes.py:227-238`); the daemon worker keeps its slot and
-    rewrites the job afterward, so a "Cancel" label would be misleading
-    and the reset racy.
-  - WP-1: digest verification extended to cached artifacts (verify on
-    every use, refetch once on mismatch, fail closed) -- gitignored
-    `scripts/bin/` persists between runs, so download-time-only checks
-    leave a bypass.
-  - AGENTS.md: rotation note qualified -- bottom-appended entries are
-    archived on the next `--fix` only once the non-current window is at
-    capacity; placement rule unchanged.
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: WP-1 next on the realigned branch; open a fresh PR
-  for the next review cycle when WP work lands.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,22 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - Owner-preferences commit-rule dedup (side-task)
+
+- Scope: final SSOT sweep found AGENT_NOTES.md Owner Preferences still
+  restating three commit-mechanics rules AGENTS.md now owns
+  (incremental staging, no co-author trailers, push/pause discipline).
+- Plan vs implementation: the four bullets collapsed into one pointer at
+  AGENTS.md Commit Rules; preference-only items (concise responses,
+  Docker/MCP pause, explain-why, Firefox testing, principles, testing
+  pyramid) stay -- they are owner context, not rules.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: hygiene plan complete (6 commits); Batch 21 WP-1 is
+  next. SSOT sweep contract now holds: commit-rule keywords, venv rules,
+  the heatmap perf figure, and batch state each have exactly one owner.
+
 ### 2026-07-31 - SWE-principles audit charter (side-task)
 
 - Scope: charter the owner-requested audit of the ten mandated software
@@ -218,23 +234,3 @@ non-current operational logs. Older dated entries live in
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: F-LOAD-1's "N/10" phrasing updates with the
   MAX_ACTIVE_JOBS default change (next commit); charter follows.
-
-### 2026-07-31 - PLAYBOOK Section 2 log column; tombstone disposition (side-task)
-
-- Scope: the 18 per-batch logs under `docs/history/logs/` were referenced
-  from no working doc (Section 2 had no Log column), making batch history
-  discoverable only via a directory glob.
-- Plan vs implementation: Section 2 table gained a Log column linking
-  `BATCH3_LOG.md` through `BATCH20_LOG.md` (batches 0-2 predate per-batch
-  logging); a note under the table points close-out-entry seekers at the
-  monolith archive per F-DOCSYNC-3. AGENTS.md Batch Close-Out step 3 now
-  requires filling the Log column at close-out so the column cannot go
-  stale. Investigated the two 300-byte `PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
-  files under `docs/history/` and `docs/history/logs/`: they are
-  deliberate "Moved:" tombstones from the Batch 14 restructure kept for
-  backward references -- retained, disposition recorded in F-DOCSYNC-4.
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: hygiene commits 3-5 follow (FINDINGS refresh,
-  MAX_ACTIVE_JOBS 5, SWE audit charter).

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,39 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - DEVELOPMENT.md: correct HANDOFF_PROMPT description (side-task)
+
+- Scope: DEVELOPMENT.md described `HANDOFF_PROMPT.md` as a condensed
+  checklist of rules, gates, read order, and commit discipline. That was
+  accurate until this branch, which reduced the file to post-read
+  verification plus the handoff checklist and replaced everything else
+  with pointers. The description was left describing the architecture
+  this PR removed.
+- Plan vs implementation: two passages corrected -- the architecture
+  overview and the per-file section, which was also retitled from
+  "Bootstrap Procedure" to "Session Start and Handoff" to match what the
+  file now contains. Both now state why the summaries were removed
+  (each restatement drifted from its source), which is the reasoning the
+  rest of the document uses.
+- Deviations: scope-limited on purpose. Only the passages this branch
+  made wrong were touched. DEVELOPMENT.md has other known staleness --
+  the `gemini-pr-triage` skill is now `pr-bot-triage`, the
+  review-suggestions section predates repo-aware review tooling, and the
+  closing paragraph needs a rewrite -- all deferred to a post-merge
+  documentation pass, per the same in-scope test applied to
+  `concurrent_users_test.py` in review round 1.
+- Note: this class of staleness is invisible to diff-scoped review.
+  Copilot reported "13/13 changed files" across four rounds and
+  DEVELOPMENT.md was never among them, so a file made wrong by the diff
+  but not part of it cannot be flagged. Worth remembering when relying on
+  automated review for consistency.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: the post-merge pass should reframe the review section
+  around how the tooling changed rather than around rejection, and
+  `README.md:492` must move with it -- it currently promises a section on
+  suggestions "evaluated and rejected".
+
 ### 2026-07-31 - Push rule: standing exception for review-fix commits (side-task)
 
 - Scope: owner-directed policy change, not a review finding. During PR
@@ -249,49 +282,3 @@ non-current operational logs. Older dated entries live in
   context for cold-start executors; judge each on whether the copy can
   drift *and* whether losing it costs a reader who cannot see the source.
   Batch 21 WP-1 remains the next action.
-
-### 2026-07-31 - PR #165 Copilot review round 2 (side-task)
-
-- Scope: round 2 returned **zero visible comments and five suppressed
-  ones**. All five were valid. The suppressed-block hit rate is now 13/13
-  across PRs #163, #164, and #165 while the visible stream has gone dry
-  twice; treat that block as the primary signal, not an appendix.
-- Plan vs implementation:
-  - `AGENTS.md` Side-Task Handling read as an ordered procedure whose
-    step 1 was "commit" and step 2 "add the log entry", contradicting
-    Commit Rules step 4 and Anti-Pattern Registry #9, which require the
-    entry to be in the same commit. Since AGENTS.md is now the rules
-    SSOT, an internal contradiction there is load-bearing. Reworded so
-    side-tasks inherit the commit rules unchanged and differ only in
-    entry placement and tagging; the remaining steps renumbered.
-  - `HANDOFF_PROMPT.md` Section 5 told agents to document completion
-    *after* committing and to commit the docs separately -- the same
-    conflict, one level down. Now states that docs land in the commit.
-  - Resolution was evidence-based, not a judgement call: registry #9
-    forbids a commit without its entry, and all four recent side-task
-    commits (`2559f39`, `2b9b095`, `98cc50c`, `900d0e6`) bundle
-    PLAYBOOK + archive with the change. Docs were wrong; practice was
-    right.
-  - `FINDINGS.md` F-LOAD-1 proposed an "N/5 slots in use" hint, which
-    hard-codes a value that is env-configurable. This PR had changed it
-    from "N/10" -- swapping one literal for another. Now specifies
-    reading the cap from `MAX_ACTIVE_JOBS` at render time.
-  - `.claude/SESSION_CONTEXT.md` header said 2026-07-28 while the body
-    recorded a 2026-07-31 runtime change. Header updated.
-  - `docs/SWE_AUDIT_CHARTER.md` cited "AGENTS.md registry #10" for
-    silent scope reduction; #10 is about re-measuring canonical figures
-    and says nothing about audit coverage. The charter was added in this
-    PR, so this was a sourcing error at write time, not staleness --
-    corrected rather than left as a point-in-time record. Now states the
-    requirement directly.
-- Deviations: round 1 split its fixes across two commits, and `07c4f5b`
-  therefore landed without its own Section 4 entry -- a violation of
-  Anti-Pattern Registry #9, the rule this round clarifies. Not rewritten:
-  both commits were already pushed and history rewrites need owner
-  instruction. Round 2 is a single commit. Standing lesson: this repo's
-  #9 outranks the generic "prefer small atomic commits" heuristic, and
-  the one-commit-per-review-round precedent from PR #163 was correct.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: Batch 21 WP-1 remains the next action. `gh` writes
-  are still unavailable this session, so the round-2 reply is unposted.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -26,30 +26,33 @@ Completed batch definitions are archived individually under `docs/history/`.
 
 ### Completed batches (definitions archived)
 
-| Batch | Title | Definition |
-|-------|-------|------------|
-| 0 | Baseline freeze + approval parity suite | `docs/history/definitions/BATCH0_DEFINITION.md` |
-| 1 | Proper upstream failure state + retry UX | `docs/history/definitions/BATCH1_DEFINITION.md` |
-| 2 | Personalized minimum listening year | `docs/history/definitions/BATCH2_DEFINITION.md` |
-| 3 | Remove nested thread pattern | `docs/history/definitions/BATCH3_DEFINITION.md` |
-| 4 | Expand test coverage significantly | `docs/history/definitions/BATCH4_DEFINITION.md` |
-| 5 | Docstring + comment normalization | `docs/history/definitions/BATCH5_DEFINITION.md` |
-| 6 | Frontend refinement/tweaks | `docs/history/definitions/BATCH6_DEFINITION.md` |
-| 7 | Persistent metadata layer (Postgres) | `docs/history/definitions/BATCH7_DEFINITION.md` |
-| 8 | Modular refactor (app factory + blueprints) | `docs/history/definitions/BATCH8_DEFINITION.md` |
-| 9 | Audit remediation (WP-1 through WP-8) | `docs/history/definitions/BATCH9_DEFINITION.md` |
-| 10 | Gemini audit remediation (WP-1 through WP-9) | `docs/history/definitions/BATCH10_DEFINITION_2026-02-21.md` |
-| 11 | Gemini Priority 2 audit remediation (SoC, DRY, architecture) | `docs/history/definitions/BATCH11_DEFINITION.md` |
-| 12 | Polish and observability (CSS, formatting, SoC, progress) | `docs/history/definitions/BATCH12_DEFINITION.md` |
-| 13 | Internal decomposition and coverage hardening | `docs/history/definitions/BATCH13_DEFINITION.md` |
-| 14 | Doc hygiene (archive restructure, docsync package, per-batch routing) | `docs/history/definitions/BATCH14_DEFINITION.md` |
-| 15 | Alignment, hardening, and handoff | `docs/history/definitions/BATCH15_DEFINITION.md` |
-| 16 | Script hygiene, local dev hardening, and integration testing | `docs/history/definitions/BATCH16_DEFINITION.md` |
-| 17 | Agent bootstrap hardening, CI/CD improvements, and dep pinning | `docs/history/definitions/BATCH17_DEFINITION.md` |
-| 18 | Scrobble heatmap -- iteration 1 | `docs/history/definitions/BATCH18_DEFINITION.md` |
-| 19 | Heatmap polish -- frame, KPIs, mobile layout | `docs/history/definitions/BATCH19_DEFINITION.md` |
-| 20 | File-hygiene + docs methodology refresh | `docs/history/definitions/BATCH20_DEFINITION.md` |
-| 21 | UI overhaul -- Tailwind + daisyUI migration | `BATCH21_DEFINITION.md` |
+| Batch | Title | Definition | Log |
+|-------|-------|------------|-----|
+| 0 | Baseline freeze + approval parity suite | `docs/history/definitions/BATCH0_DEFINITION.md` | -- |
+| 1 | Proper upstream failure state + retry UX | `docs/history/definitions/BATCH1_DEFINITION.md` | -- |
+| 2 | Personalized minimum listening year | `docs/history/definitions/BATCH2_DEFINITION.md` | -- |
+| 3 | Remove nested thread pattern | `docs/history/definitions/BATCH3_DEFINITION.md` | `docs/history/logs/BATCH3_LOG.md` |
+| 4 | Expand test coverage significantly | `docs/history/definitions/BATCH4_DEFINITION.md` | `docs/history/logs/BATCH4_LOG.md` |
+| 5 | Docstring + comment normalization | `docs/history/definitions/BATCH5_DEFINITION.md` | `docs/history/logs/BATCH5_LOG.md` |
+| 6 | Frontend refinement/tweaks | `docs/history/definitions/BATCH6_DEFINITION.md` | `docs/history/logs/BATCH6_LOG.md` |
+| 7 | Persistent metadata layer (Postgres) | `docs/history/definitions/BATCH7_DEFINITION.md` | `docs/history/logs/BATCH7_LOG.md` |
+| 8 | Modular refactor (app factory + blueprints) | `docs/history/definitions/BATCH8_DEFINITION.md` | `docs/history/logs/BATCH8_LOG.md` |
+| 9 | Audit remediation (WP-1 through WP-8) | `docs/history/definitions/BATCH9_DEFINITION.md` | `docs/history/logs/BATCH9_LOG.md` |
+| 10 | Gemini audit remediation (WP-1 through WP-9) | `docs/history/definitions/BATCH10_DEFINITION_2026-02-21.md` | `docs/history/logs/BATCH10_LOG.md` |
+| 11 | Gemini Priority 2 audit remediation (SoC, DRY, architecture) | `docs/history/definitions/BATCH11_DEFINITION.md` | `docs/history/logs/BATCH11_LOG.md` |
+| 12 | Polish and observability (CSS, formatting, SoC, progress) | `docs/history/definitions/BATCH12_DEFINITION.md` | `docs/history/logs/BATCH12_LOG.md` |
+| 13 | Internal decomposition and coverage hardening | `docs/history/definitions/BATCH13_DEFINITION.md` | `docs/history/logs/BATCH13_LOG.md` |
+| 14 | Doc hygiene (archive restructure, docsync package, per-batch routing) | `docs/history/definitions/BATCH14_DEFINITION.md` | `docs/history/logs/BATCH14_LOG.md` |
+| 15 | Alignment, hardening, and handoff | `docs/history/definitions/BATCH15_DEFINITION.md` | `docs/history/logs/BATCH15_LOG.md` |
+| 16 | Script hygiene, local dev hardening, and integration testing | `docs/history/definitions/BATCH16_DEFINITION.md` | `docs/history/logs/BATCH16_LOG.md` |
+| 17 | Agent bootstrap hardening, CI/CD improvements, and dep pinning | `docs/history/definitions/BATCH17_DEFINITION.md` | `docs/history/logs/BATCH17_LOG.md` |
+| 18 | Scrobble heatmap -- iteration 1 | `docs/history/definitions/BATCH18_DEFINITION.md` | `docs/history/logs/BATCH18_LOG.md` |
+| 19 | Heatmap polish -- frame, KPIs, mobile layout | `docs/history/definitions/BATCH19_DEFINITION.md` | `docs/history/logs/BATCH19_LOG.md` |
+| 20 | File-hygiene + docs methodology refresh | `docs/history/definitions/BATCH20_DEFINITION.md` | `docs/history/logs/BATCH20_LOG.md` |
+| 21 | UI overhaul -- Tailwind + daisyUI migration | `BATCH21_DEFINITION.md` | active -- Section 4 |
+
+Close-out entries for each batch currently live in the monolith archive,
+not the per-batch log (see FINDINGS F-DOCSYNC-3).
 
 ### Open decisions (owner confirmation needed)
 
@@ -146,6 +149,26 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - PLAYBOOK Section 2 log column; tombstone disposition (side-task)
+
+- Scope: the 18 per-batch logs under `docs/history/logs/` were referenced
+  from no working doc (Section 2 had no Log column), making batch history
+  discoverable only via a directory glob.
+- Plan vs implementation: Section 2 table gained a Log column linking
+  `BATCH3_LOG.md` through `BATCH20_LOG.md` (batches 0-2 predate per-batch
+  logging); a note under the table points close-out-entry seekers at the
+  monolith archive per F-DOCSYNC-3. AGENTS.md Batch Close-Out step 3 now
+  requires filling the Log column at close-out so the column cannot go
+  stale. Investigated the two 300-byte `PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
+  files under `docs/history/` and `docs/history/logs/`: they are
+  deliberate "Moved:" tombstones from the Batch 14 restructure kept for
+  backward references -- retained, disposition recorded in F-DOCSYNC-4.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: hygiene commits 3-5 follow (FINDINGS refresh,
+  MAX_ACTIVE_JOBS 5, SWE audit charter).
+
 ### 2026-07-31 - Bootstrap-doc SSOT pass: single-source rules and state (side-task)
 
 - Scope: owner-requested hygiene sweep before Batch 21 WP-1. Exploration
@@ -232,29 +255,3 @@ non-current operational logs. Older dated entries live in
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: review rounds have reached citation polish;
   recommend merging or pausing auto-review re-requests. WP-1 next.
-
-### 2026-07-28 - PR #163 review response, round 3 (side-task)
-
-- Scope: Copilot round 3 -- three suppressed low-confidence comments.
-  Two acted on, one deferred to FINDINGS with a decline on the PR.
-- Plan vs implementation:
-  - Acted: `global.css` joins the WP-2 legacy per-page stack -- verified
-    it carries Bootstrap-coupled `.card`/`.card-body`/`.modal-*` rules
-    (`global.css:141-199`) that would restyle daisyUI components if it
-    stayed in `base.html`; token/wordmark/shell concerns redistributed
-    (daisyUI themes + `shell.css`).
-  - Acted: WP-8 drift hook diff scoped with a pathspec
-    (`git diff --exit-code -- static/css/tailwind.css`) so unrelated
-    dirty files or rewrites from earlier hooks in the same run cannot
-    produce false drift failures.
-  - Deferred: retagging the Batch 20 close-out entry in the monolith
-    archive. The routing claim is correct, but it is consistent tool
-    behavior (`(Batch N close-out)` is not parser-recognized;
-    BATCH19_LOG.md lacks its close-out too), and hand-editing
-    machine-rotated archive content in a docs PR was declined and
-    accepted in PR #162 round 3. Logged as F-DOCSYNC-3 (open P2) for a
-    docsync WP alongside F-DOCSYNC-1/2.
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: WP-1 remains next; batched reply posted on PR #163.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,29 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - FINDINGS refresh: batch-closure pointers, F-DOCSYNC-4, F-SWE-1 (side-task)
+
+- Scope: owner-flagged staleness in FINDINGS.md -- open P1 items that
+  Batch 21's definition already promises to close carried no pointer,
+  and F-B20-4 paraphrased the whole definition.
+- Plan vs implementation:
+  - F-B20-3: remedy rewritten -- the 5.1->5.3 CDN-consolidation path is
+    dead; Batch 21 resolves the split by eliminating Bootstrap (closes
+    at WP-8). F-AUDIT-1: closes at Batch 21 WP-2 via acceptance
+    criterion 8. F-B18-12 deferred-block line marked as in-batch scope
+    (WP-6). F-B20-4 compressed to a pointer at `BATCH21_DEFINITION.md`.
+    F-FEATURE-2 line reformatted as a greppable cross-ref bullet.
+  - New F-DOCSYNC-4 (resolved): per-batch logs were undiscoverable until
+    the Section 2 Log column landed; records the tombstone disposition.
+  - New F-SWE-1 (open P1): SWE-principles audit chartered via
+    `docs/SWE_AUDIT_CHARTER.md` (next commit), executable cold by a
+    dedicated Claude or Codex session; closes by pointing at the report.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: F-LOAD-1's "N/10" phrasing updates with the
+  MAX_ACTIVE_JOBS default change (next commit); charter follows.
+
 ### 2026-07-31 - PLAYBOOK Section 2 log column; tombstone disposition (side-task)
 
 - Scope: the 18 per-batch logs under `docs/history/logs/` were referenced
@@ -236,22 +259,3 @@ non-current operational logs. Older dated entries live in
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: WP-1 next on the realigned branch; open a fresh PR
   for the next review cycle when WP work lands.
-
-### 2026-07-29 - PR #163 review response, round 4 (side-task)
-
-- Scope: Copilot round 4 -- one suppressed comment. Verified valid and
-  acted on.
-- Plan vs implementation: the archived coverage-refresh entry cited
-  "the CLAUDE.md canonical command", but CLAUDE.md is gitignored
-  (`.gitignore:49`) and repo-invisible; the command is documented at
-  README.md "Running Tests". Reference corrected in the monolith
-  archive entry.
-- Deviations: none. Distinction from the PR #162 round-3 decline on
-  editing rotated entries: that citation was accurate at write time and
-  went stale (point-in-time record, left alone); this one was
-  repo-invisible at write time -- a sourcing error that defeats the
-  record's verifiability, so it is corrected rather than preserved.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: review rounds have reached citation polish;
-  recommend merging or pausing auto-review re-requests. WP-1 next.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,40 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-08-01 - PR #165 Copilot review round 5 (side-task)
+
+- Scope: round 5 returned "not ready to approve" with four suppressed
+  comments and zero visible ones. All four verified valid against the
+  code; all four acted on.
+- Plan vs implementation:
+  - `config.py`: the MAX_ACTIVE_JOBS rationale claimed "one global
+    10 req/s API throttle". Wrong -- `utils.py:81-82` builds separate
+    `_LASTFM_THROTTLE` and `_SPOTIFY_THROTTLE`. Comment now names the
+    Last.fm scrobble-fetch phase as the binding constraint.
+  - `AGENTS.md` commit procedure: the docsync `--check` gate sat at
+    step 3 while the PLAYBOOK update was step 4, so the gate ran before
+    the documentation it validates (and `pre-commit` carries the
+    `doc-state-sync-check` hook). Reordered: write docs, `--fix`, then
+    the three gates on the final state. This matches what sessions
+    already do in practice; only the written rule was wrong. Fixed a
+    duplicate step number introduced by the renumber.
+  - `FINDINGS.md` F-DATA-1 open question 2 proposed grouping
+    `spotify_cache` by `artist_norm + album_norm` -- which is the
+    primary key (`init_db.py:42`), so every group holds exactly one row
+    and the upsert has already overwritten any rival date. Replaced
+    with the two methods that can actually work (re-run the Spotify
+    search and compare against the earliest fresh candidate, or
+    cross-check MusicBrainz).
+  - `docs/SWE_AUDIT_CHARTER.md`: prescribed commit subject was a noun
+    phrase, violating the imperative-subject rule the charter tells
+    executors to follow. Now imperative.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: pushed under the standing review-fix exception with
+  a batched reply. PR #165 remains merge-ready pending the next
+  auto-review.
+
 ### 2026-07-31 - FINDINGS: record reissue cache-key collapse (side-task)
 
 - Scope: capture a data-quality mechanism found while discussing the
@@ -243,39 +277,3 @@ non-current operational logs. Older dated entries live in
 - Forward guidance: if the agent roster changes, this clause names
   specific agents and will need revisiting -- it is an allowlist, not a
   capability test.
-
-### 2026-07-31 - PR #165 Copilot review round 4 (side-task)
-
-- Scope: zero visible comments, two suppressed, both valid and both real
-  defects rather than the judgement-call trade-offs round 3 predicted.
-  The convergence call made after round 3 was wrong; recorded here
-  because the wrong prediction is the useful part. Tally 18/18.
-- Plan vs implementation:
-  - **A rule was silently deleted by this PR, and round 1 removed the
-    last copy.** The prohibition on `git add -A` / `git add .` lived in
-    two places before this branch: AGENT_NOTES.md Owner Preferences and
-    the old HANDOFF_PROMPT anti-pattern list. The PR's HANDOFF_PROMPT
-    rewrite dropped its copy, and the round-1 dedup replaced the
-    AGENT_NOTES copy with a pointer to AGENTS.md Commit Rules -- which
-    never contained the prohibition. Step 5 only said "stage only files
-    changed for this work package", which `git add -A` can satisfy when
-    every changed file happens to belong to the WP. Restored explicitly
-    in Commit Rules step 5, the canonical location the pointer targets.
-  - Lesson: verifying that a pointer's target "covers it in substance"
-    is not enough. Round 1 checked AGENTS.md:167 and accepted a
-    paraphrase as equivalent when it dropped a prohibition. Before
-    deleting a rule copy, diff the *specific obligations*, not the topic.
-  - `scripts/testing/concurrent_users_test.py` promised queuing in three
-    places. `acquire_job_slot()` uses `acquire(blocking=False)` and both
-    call sites (`routes.py:460`, `routes.py:570`) return an error
-    immediately, so excess submissions are rejected and never queued.
-    Round 1 edited one of those lines for the cap change without
-    questioning the surrounding claim. Now describes rejection, matching
-    README's "capacity rejections" wording.
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: do not call convergence from the *shape* of a round's
-  findings. Rounds 2 and 3 returned zero visible comments and were still
-  productive; round 4 found a deleted rule. Stop when a round returns
-  nothing, not when the findings look minor.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -79,11 +79,8 @@ Completed batch definitions are archived individually under `docs/history/`.
 - **Next action:** Batch 21 WP-1 (Tailwind + daisyUI toolchain and theme
   tokens; no template changes).
 - Batch 21 WP status: WP-0 done. WP-1 through WP-8 not yet started.
-- **Perf note (measured 2026-05-16):** Heatmap fetch for `flounder14`
-  (103 pages) took 10.9s. `lastfm.py` already uses `limit=200` and concurrent
-  `as_completed` fetching. 10.9s is the rate-limit floor (103 pages /
-  10 req/s = 10.3s minimum). No further optimization without heatmap-specific
-  caching or rate-limit risk. Documented in FINDINGS.md F-B18-11.
+- **Perf note:** heatmap fetch speed is rate-limit bound; measurement and
+  rationale live in FINDINGS.md F-B18-11 (single source).
 - **Last.timer note (checked 2026-05-19):** the referenced project uses
   aggregate `user.gettopartists`/`user.gettoptracks` calls with page fan-out,
   not exact per-scrobble recent-track timestamps. Useful for future perf
@@ -148,6 +145,47 @@ non-current operational logs. Older dated entries live in
   sheet, and commits the compiled CSS. No template changes until WP-2.
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
+
+### 2026-07-31 - Bootstrap-doc SSOT pass: single-source rules and state (side-task)
+
+- Scope: owner-requested hygiene sweep before Batch 21 WP-1. Exploration
+  confirmed AGENTS.md and HANDOFF_PROMPT.md contradicted each other
+  (bootstrap order, sufficiency gate, pre-commit gate, ownership map),
+  commit discipline existed in 3-4 copies, the heatmap perf measurement
+  in 4 copies, and AGENT_NOTES.md carried live batch state under a
+  shipped-feature heading plus Batch 19 residue and a pointer to a
+  non-repo file.
+- Plan vs implementation:
+  - AGENTS.md is now the single owner of rules: canonical 7-step
+    bootstrap order (AGENTS.md itself is step 1), the stricter 3-way
+    sufficiency gate, a 6-step pre-commit procedure including the
+    doc_state_sync --check gate, the conflict-resolution rule, and four
+    new anti-patterns (never --no-verify; stale Section 3; missing log
+    entries; stale dashboard figures -- the ~72% coverage figure
+    survived five months while reality was 89%). Docstring mandate moved
+    into Proposal and Design Rules.
+  - HANDOFF_PROMPT.md reduced to what it uniquely owns: post-read
+    verification (git status/log + pytest count reconciliation) and the
+    end-of-session handoff checklist; all rule sections now link to
+    AGENTS.md instead of restating.
+  - AGENT_NOTES.md: batch state moved out (PLAYBOOK Section 3 declared
+    the single source); Heatmap section retitled shipped and trimmed of
+    Batch 19 residue; venv rules and runtime constants replaced with
+    links to their owners; load-test pointer now inlines the conclusion
+    (2/3/5 clean, 10 never completed) and flags the raw data as
+    agent-side; Talisman note repointed to the archived Batch 17 log;
+    orchestrator-split note repointed to F-B20-2; the ten software
+    principles expanded from bare acronyms.
+  - SESSION_CONTEXT: Section 3 now lists all 7 CSS / 7 JS files and the
+    template set (Batch 21 touches exactly these); heatmap perf trimmed
+    to an F-B18-11 pointer here and in PLAYBOOK Section 3 -- F-B18-11 is
+    the only full copy of the measurement.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: commits 2-5 of the approved hygiene plan follow
+  (PLAYBOOK log column, FINDINGS refresh, MAX_ACTIVE_JOBS 5, SWE audit
+  charter); then Batch 21 WP-1.
 
 ### 2026-07-29 - PR #164 phantom cleanup + review response (side-task)
 
@@ -216,34 +254,6 @@ non-current operational logs. Older dated entries live in
     machine-rotated archive content in a docs PR was declined and
     accepted in PR #162 round 3. Logged as F-DOCSYNC-3 (open P2) for a
     docsync WP alongside F-DOCSYNC-1/2.
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: WP-1 remains next; batched reply posted on PR #163.
-
-### 2026-07-28 - PR #163 review response, round 2 (side-task)
-
-- Scope: Copilot round 2 -- no new top-level comments, four suppressed
-  low-confidence comments. All four verified valid (same pattern as
-  PR #162: the suppression filter is too conservative); all acted on.
-- Plan vs implementation:
-  - Stale bootstrap docs: AGENT_NOTES.md still called Batch 21 a TBD
-    stub with "no WP work until scope lands"; FINDINGS.md header said
-    scope pending; README roadmap listed scoping as open. All three now
-    reflect the active batch (the definition's own Status line already
-    carried Active from WP-0).
-  - Compiled-CSS drift window: validation gate now requires any WP
-    touching templates or `tailwind.src.css` (WP-2..WP-7) to rebuild
-    and commit `tailwind.css` in the same commit; the drift hook
-    deliberately stays in WP-8 (moving it to WP-1 would front-load the
-    headless-CI fetch problem before any template exists to protect).
-  - Stack-restriction conflict: `toast` + `alert` added to the
-    permitted daisyUI set for the WP-5 toast rewrite.
-  - `--bars-color` inventory corrected: six of seven page CSS files
-    (`unmatched.css` hardcodes its own `--header-bg`), pinwheel via
-    `var()`; the wordmark hardcodes `#6a4baf` and only the dark-mode
-    override (`global.css:49-50`) uses the variable, so light-mode
-    wordmark recoloring is explicit migration work.
 - Deviations: none.
 - Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,42 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-08-01 - PR #165 review round 6; self-inflicted-drift anti-pattern (side-task)
+
+- Scope: round 6 returned three suppressed comments, zero visible. All
+  three verified valid -- and all three were created by round 5's own
+  fixes, which is the finding that matters more than the fixes.
+- Plan vs implementation:
+  - Acted: `AGENTS.md` Side-Task Handling and `HANDOFF_PROMPT.md` both
+    cited "Commit Rules step 4" for the documentation requirement; the
+    round-5 reorder moved it to step 1. Repointed **by name** ("the
+    documentation step", "Missing log entries") rather than by number,
+    so a future reorder cannot re-stale them.
+  - Acted: `AGENT_NOTES.md` load-testing bullet still asserted the
+    per-job guarantee and single-throttle model that round 5 corrected
+    in `config.py`. Rewritten to match and to point at `config.py` as
+    the single owner of the rationale.
+  - Declined (precedent): PLAYBOOK Section 4 entries at :163 and :262
+    also contain "step 3/4/6" references that no longer match the
+    current numbering. They are dated point-in-time records of what was
+    true when written; retro-editing rotated log content was declined
+    and accepted in PR #162 round 3 and PR #163 round 3.
+  - Root-cause fix: new Anti-Pattern Registry entry 11, "Fixing the
+    instance instead of the class" -- requires a blast-radius grep
+    before the gates (references to anything renumbered/renamed, and
+    sibling copies of any corrected claim), and prefers name-based
+    cross-references over numeric ones.
+  - Swept beyond the three findings: verified the remaining numeric
+    references (`AGENTS.md` close-out step 2, charter bootstrap step 1)
+    still resolve correctly, and that the `req/s` claims in F-B18-11 and
+    F-B18-10 are accurate because the heatmap and album pipelines are
+    both Last.fm-only.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: pushed under the standing review-fix exception with
+  a batched reply.
+
 ### 2026-08-01 - PR #165 Copilot review round 5 (side-task)
 
 - Scope: round 5 returned "not ready to approve" with four suppressed
@@ -251,29 +287,3 @@ non-current operational logs. Older dated entries live in
   around how the tooling changed rather than around rejection, and
   `README.md:492` must move with it -- it currently promises a section on
   suggestions "evaluated and rejected".
-
-### 2026-07-31 - Push rule: standing exception for review-fix commits (side-task)
-
-- Scope: owner-directed policy change, not a review finding. During PR
-  #165 triage the owner granted a standing authorization to push
-  review-driven commits without asking per round, on the reasoning that
-  the agent reaches the diminishing-returns point on its own and a
-  per-round approval round-trip only stalls the loop.
-- Plan vs implementation: encoded in AGENTS.md Commit Rules step 6 rather
-  than left as an agent-side preference, because AGENTS.md is the rules
-  SSOT and a spoken rule that contradicts the written one is exactly the
-  defect this PR spent four rounds removing. Scoped per owner: **Claude
-  Code and Codex sessions only.** GitHub Copilot task sessions and their
-  subagents, Jules, and any other agent follow the unmodified rule --
-  the owner does not extend equal trust to agents of varying quality
-  that it cannot inspect per-invocation. Step 6 already carried a
-  Copilot-specific clause, so per-agent scoping had precedent.
-- Deviations: the exception is deliberately narrow. Review-fix commits on
-  an open PR only; batch and WP commits still pause, and force-pushes,
-  history rewrites, and anything touching `main` still require explicit
-  instruction.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: if the agent roster changes, this clause names
-  specific agents and will need revisiting -- it is an allowlist, not a
-  capability test.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,33 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-29 - PR #164 phantom cleanup + review response (side-task)
+
+- Scope: PR #163 was rebase-merged, leaving `wip/batch-21` "8 ahead /
+  8 behind" (identical content, different SHAs -- normal rebase-merge
+  artifact). The owner opened PR #164 from the stale branch; Copilot
+  re-reviewed the phantom diff and left three NEW valid comments that
+  four prior rounds missed. PR #164 closed with explanation; branch
+  force-pushed to match `main`; all three fixes applied here.
+- Plan vs implementation:
+  - WP-4: leaving the loading page is now a plain "Back home" link with
+    no `/reset_progress` call -- the endpoint clears stored job state
+    only (`routes.py:227-238`); the daemon worker keeps its slot and
+    rewrites the job afterward, so a "Cancel" label would be misleading
+    and the reset racy.
+  - WP-1: digest verification extended to cached artifacts (verify on
+    every use, refetch once on mismatch, fail closed) -- gitignored
+    `scripts/bin/` persists between runs, so download-time-only checks
+    leave a bypass.
+  - AGENTS.md: rotation note qualified -- bottom-appended entries are
+    archived on the next `--fix` only once the non-current window is at
+    capacity; placement rule unchanged.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: WP-1 next on the realigned branch; open a fresh PR
+  for the next review cycle when WP work lands.
+
 ### 2026-07-29 - PR #163 review response, round 4 (side-task)
 
 - Scope: Copilot round 4 -- one suppressed comment. Verified valid and
@@ -221,35 +248,3 @@ non-current operational logs. Older dated entries live in
 - Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: WP-1 remains next; batched reply posted on PR #163.
-
-### 2026-07-28 - PR #163 review response (side-task)
-
-- Scope: address the Copilot auto-review on PR #163 (Batch 21 open +
-  doc refreshes). Five inline comments, all on `BATCH21_DEFINITION.md`;
-  all five verified valid against the code and acted on.
-- Plan vs implementation:
-  - WP-1: per-platform SHA-256 digests committed alongside pinned
-    versions; `tailwind_build.py` must verify every downloaded artifact
-    before executing it (pin-only trusts the release asset at fetch
-    time, and the WP-8 CI hook executes that binary headless).
-  - WP-1: daisyUI standalone needs both `daisyui.mjs` and
-    `daisyui-theme.mjs`; the component bundle alone cannot register the
-    two custom `@plugin` themes.
-  - WP-2: explicit coexistence isolation -- one framework stylesheet
-    per template via the per-page block, shared shell styled by a
-    framework-neutral `shell.css` absorbed at WP-8. Rejected daisyUI
-    prefix alternative (WP-8 removal churn) with reasoning recorded.
-  - WP-5: dropped "CSV walker untouched" -- `results.js` exports
-    rendered cell text, so `MMM YY` display dates would truncate CSV
-    release dates; date cells keep ISO in `data-export`, walker
-    prefers it.
-  - WP-7 + acceptance criterion 6: `below_min_plays`/`below_min_tracks`
-    removed from the reason-code set -- `fetch_top_albums_async` drops
-    threshold failures before the pipeline (`orchestrator.py:112-116`),
-    and near-miss retention is explicitly Batch 22+. Two reason cards,
-    not three; out-of-scope entry cross-references the deferred codes.
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: WP-1 implementation must honor the amended digest
-  and dual-plugin-file requirements; batched reply posted on PR #163.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,40 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - PR #165 Copilot review round 1 (side-task)
+
+- Scope: triaged the five comments on PR #165 (four inline, one inside
+  the suppressed low-confidence block). All five were valid; none were
+  declined. Two themes: an overstated concurrency claim and three
+  leftover copies of rules AGENTS.md now owns.
+- Plan vs implementation:
+  - `config.py`: the MAX_ACTIVE_JOBS rationale claimed a cap of 5 "keeps
+    >=2 req/s per job". `_GlobalThrottle.next_wait()` (utils.py) advances
+    a single next-allowed timestamp under one lock, serializing callers
+    in arrival order with no per-job accounting, so a busy job can take
+    more slots than an idle one. Reworded as an average, matching the
+    "~10/N req/s" framing already used in AGENT_NOTES.md.
+  - `scripts/testing/concurrent_users_test.py`: module docstring and
+    `build_parser()` still said the default was 10 and told operators to
+    set `--concurrency` above 10. Both now say 5. A repo-wide sweep found
+    no other live stale reference; remaining "default 10" hits are all
+    under `docs/history/` and stay as written (point-in-time records).
+  - `AGENT_NOTES.md`: the Owner Preferences commit-mechanics bullet and
+    the Venv "In short:" line each pointed at AGENTS.md and then restated
+    its content anyway. Both reduced to pointers after verifying AGENTS.md
+    genuinely carries every rule involved.
+  - `HANDOFF_PROMPT.md`: Section 2 restated the full three-command gate
+    and the root-BATCH warning, contradicting the Document Roles contract
+    added by this same PR, which assigns gates to AGENTS.md. Collapsed to
+    a pointer matching the wording Sections 3 and 4 already use.
+- Deviations: none. No test changes -- all five edits are comment or
+  documentation text with no behavior change.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: the suppressed-comment block again held a real
+  finding (8/8 across PRs #163/#164/#165), so keep expanding it. Batch 21
+  WP-1 remains the next action.
+
 ### 2026-07-31 - WP-1 token values pinned in the definition (side-task)
 
 - Scope: make WP-1 executor-agnostic. The definition referenced "the
@@ -204,29 +238,3 @@ non-current operational logs. Older dated entries live in
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: execution is decoupled -- run whenever convenient
   (Codex costs no Claude tokens). Batch 21 WP-1 is unblocked and next.
-
-### 2026-07-31 - MAX_ACTIVE_JOBS default 10 -> 5 (side-task)
-
-- Scope: owner decision. The 2026-03-04 load test ran 2/3/5 concurrent
-  users clean while the 10-user run never completed; all jobs share the
-  global 10 req/s API throttle, so 10 slots starve each job below
-  1 req/s on the single small Fly.io machine.
-- Plan vs implementation: `scrobblescope/config.py` default changed to
-  `"5"` with a rationale comment (still env-overridable); README (three
-  mentions), SESSION_CONTEXT key-runtime-facts line, and FINDINGS
-  F-LOAD-1 phrasing updated to match. `fly.toml` sets no
-  `MAX_ACTIVE_JOBS` override, so the new default takes effect on next
-  deploy.
-- Deviations: pre-change scouting claimed no test depends on the
-  default (capacity tests inject their own semaphores) -- true for
-  assertions but not for shared state. Route tests that mock
-  start_job_thread acquire a real slot that is never released, and the
-  session's accumulated leaks crossed the new cap of 5, failing
-  `test_heatmap_loading_json_body` with a real 429. Fixed properly: a
-  new autouse `fresh_job_slots` fixture in `tests/conftest.py` resets
-  the semaphore per test, removing the hidden inter-test ordering
-  coupling the lower cap exposed.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: owner can observe the 5-slot cap locally; the
-  "N/5 slots in use" occupancy hint remains open as F-LOAD-1.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,42 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - FINDINGS: record reissue cache-key collapse (side-task)
+
+- Scope: capture a data-quality mechanism found while discussing the
+  DEVELOPMENT.md rewrite, before the reasoning was lost to chat. No code
+  change -- this is a finding, not a fix.
+- Plan vs implementation: added `F-DATA-1` under P2.
+  `normalize_name()` strips `deluxe`/`edition`/`remastered` and eight
+  more words, so a reissue and its original normalize identically; since
+  the `spotify_cache` PK is `artist_norm + album_norm`, they share one
+  row and whichever populated it first serves its `release_date` for 30
+  days. Owner observed this with Viagra Boys "viagr aboys" (2025)
+  surfacing under 2026 via the JP deluxe released 2026-01-09, on an
+  account that never played it.
+- The finding records why the collapse is nonetheless correct (Last.fm
+  scrobbles the same record under inconsistent album strings; keying
+  editions apart would split one album into several leaderboard rows
+  with divided playcounts), the candidate fix (decouple counting from
+  dating -- keep the collapse for aggregation, take the *earliest*
+  candidate release date when resolving the year, no schema change), the
+  rejected boolean discriminator and why, three questions answerable by
+  querying the cache, and the note that Spotify exposes no
+  original-release-date field at all.
+- Deviations: earlier in the session an agent claim that release-date
+  drift was a systemic risk was walked back. The owner has ~14 years of
+  scrobbles and one recalled instance; the claim had been reasoned from
+  a plausible mechanism rather than measured. Filed P2 with low user
+  impact stated explicitly, and `release_scope: all` already bypasses
+  date filtering. Recording the correction so the finding is not read as
+  more urgent than the evidence supports.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: question 2 (which other albums) is a cache query, not
+  an investigation -- run it before designing any fix. Sequenced behind
+  Batch 21, the F-B20-2 orchestrator split, and the test/docstring pass
+  per owner priority.
+
 ### 2026-07-31 - DEVELOPMENT.md: correct HANDOFF_PROMPT description (side-task)
 
 - Scope: DEVELOPMENT.md described `HANDOFF_PROMPT.md` as a condensed
@@ -243,42 +279,3 @@ non-current operational logs. Older dated entries live in
   findings. Rounds 2 and 3 returned zero visible comments and were still
   productive; round 4 found a deleted rule. Stop when a round returns
   nothing, not when the findings look minor.
-
-### 2026-07-31 - PR #165 Copilot review round 3 (side-task)
-
-- Scope: round 3 again returned zero visible comments and three
-  suppressed ones. Two acted on in full, one acted on in part.
-  Suppressed-block tally now 16/16 across #163, #164, and #165.
-- Plan vs implementation:
-  - `docs/SWE_AUDIT_CHARTER.md` Section 3 copied the ten principle names
-    from AGENT_NOTES.md and **had already drifted**: the copy dropped the
-    definitions for Dependency Inversion, Least Knowledge, and Fail Fast,
-    and truncated SRP from "single responsibility per module/function".
-    This is the rare case where the drift was demonstrable rather than
-    hypothetical, so the copy is gone. The section now points at
-    AGENT_NOTES.md and keeps only the two audit-specific methods (Clean
-    Architecture via the SESSION_CONTEXT Section 4 acyclic graph, Boy
-    Scout via git history).
-  - `docs/SWE_AUDIT_CHARTER.md` Section 6 restated side-task entry
-    placement that AGENTS.md Side-Task Handling owns -- and round 2 had
-    just renumbered that section, so the charter was already a rewrite
-    away from being wrong. Delegated.
-  - `HANDOFF_PROMPT.md` Section 1 restated the bootstrap-conflict rule
-    verbatim from AGENTS.md:64-65 inside a paragraph that claims rules
-    "are not restated here". Removed.
-- Deviations: **partially declined** the reviewer's request to also strip
-  "Do not push without owner instruction" from the charter's commit step.
-  Verified AGENTS.md:171 owns it, so the SSOT argument is technically
-  right, but that line sits at the point of action for a cold-start
-  executor (the charter is written so Codex can run it without prior
-  context) and a push is not reversible. Deliberate safety redundancy is
-  worth one line. Removed the same sentence from HANDOFF_PROMPT Section 1
-  by contrast, because there the reader is being sent to AGENTS.md in the
-  very same paragraph, so the copy buys nothing.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: watch for diminishing returns. Rounds 1-3 were all
-  genuine, but the remaining duplication is increasingly load-bearing
-  context for cold-start executors; judge each on whether the copy can
-  drift *and* whether losing it costs a reader who cannot see the source.
-  Batch 21 WP-1 remains the next action.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -24,7 +24,7 @@ Rules for agent behaviour live in `AGENTS.md`; current-state snapshot in
 
 Completed batch definitions are archived individually under `docs/history/`.
 
-### Completed batches (definitions archived)
+### Batch index (completed batches archived; the active batch, if any, is listed last)
 
 | Batch | Title | Definition | Log |
 |-------|-------|------------|-----|
@@ -51,8 +51,11 @@ Completed batch definitions are archived individually under `docs/history/`.
 | 20 | File-hygiene + docs methodology refresh | `docs/history/definitions/BATCH20_DEFINITION.md` | `docs/history/logs/BATCH20_LOG.md` |
 | 21 | UI overhaul -- Tailwind + daisyUI migration | `BATCH21_DEFINITION.md` | active -- Section 4 |
 
-Close-out entries for each batch currently live in the monolith archive,
-not the per-batch log (see FINDINGS F-DOCSYNC-3).
+A batch's close-out entry sits in its per-batch log only when the heading
+carried a `(Batch N WP-X)` tag (as Batch 18's did). Close-outs tagged
+`(Batch N close-out)` are not parser-recognized and were routed to the
+monolith archive instead -- Batches 19 and 20 are the current examples.
+See FINDINGS F-DOCSYNC-3.
 
 ### Open decisions (owner confirmation needed)
 
@@ -148,6 +151,40 @@ non-current operational logs. Older dated entries live in
   sheet, and commits the compiled CSS. No template changes until WP-2.
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
+
+### 2026-08-01 - PR #165 round 8; over-broad claims narrowed (side-task)
+
+- Scope: three suppressed comments, all valid, all fixed.
+- Plan vs implementation:
+  - The Section 2 note claimed close-out entries for *each* batch live
+    in the monolith archive. False: `BATCH18_LOG.md` holds its own
+    close-out because that heading carried a `(Batch 18 WP-5)` tag;
+    only the `(Batch N close-out)` spelling misroutes. Narrowed here
+    and in F-DOCSYNC-3, which carried the same over-broad framing.
+  - The Section 2 subsection heading still read "Completed batches
+    (definitions archived)" while the table lists the active batch with
+    a root definition. Retitled to cover both.
+  - `AGENT_NOTES.md` asserted a batch was active and where its
+    definition sits in the same breath as declaring that the file does
+    not track batch state -- self-contradictory, and false between
+    batches. Reduced to the pointer alone.
+  - Anti-Pattern Registry, assertions entry: broadened from the one
+    phrasing that had failed before (`all N`, ranges) to the full
+    quantifier vocabulary, since the narrow sweep is what let "each
+    batch" through.
+- Assessment of the review loop: none of these three were caused by the
+  previous round's fixes -- the fix-causes-finding chain that drove
+  rounds 5 through 7 did not repeat. What remains is pre-existing
+  over-broad wording in text the sweep touched. On that basis the
+  pre-push checklist is working and mechanical enforcement is not yet
+  warranted; a consistency-lint hook stays a docsync-WP candidate rather
+  than scope creep into this PR.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: findings have narrowed to wording precision rather
+  than correctness; this is the diminishing-returns point. Recommend
+  merging rather than requesting another round.
 
 ### 2026-08-01 - PR #165 round 7 + review-loop pattern sweep (side-task)
 
@@ -269,39 +306,3 @@ non-current operational logs. Older dated entries live in
 - Forward guidance: pushed under the standing review-fix exception with
   a batched reply. PR #165 remains merge-ready pending the next
   auto-review.
-
-### 2026-07-31 - FINDINGS: record reissue cache-key collapse (side-task)
-
-- Scope: capture a data-quality mechanism found while discussing the
-  DEVELOPMENT.md rewrite, before the reasoning was lost to chat. No code
-  change -- this is a finding, not a fix.
-- Plan vs implementation: added `F-DATA-1` under P2.
-  `normalize_name()` strips `deluxe`/`edition`/`remastered` and eight
-  more words, so a reissue and its original normalize identically; since
-  the `spotify_cache` PK is `artist_norm + album_norm`, they share one
-  row and whichever populated it first serves its `release_date` for 30
-  days. Owner observed this with Viagra Boys "viagr aboys" (2025)
-  surfacing under 2026 via the JP deluxe released 2026-01-09, on an
-  account that never played it.
-- The finding records why the collapse is nonetheless correct (Last.fm
-  scrobbles the same record under inconsistent album strings; keying
-  editions apart would split one album into several leaderboard rows
-  with divided playcounts), the candidate fix (decouple counting from
-  dating -- keep the collapse for aggregation, take the *earliest*
-  candidate release date when resolving the year, no schema change), the
-  rejected boolean discriminator and why, three questions answerable by
-  querying the cache, and the note that Spotify exposes no
-  original-release-date field at all.
-- Deviations: earlier in the session an agent claim that release-date
-  drift was a systemic risk was walked back. The owner has ~14 years of
-  scrobbles and one recalled instance; the claim had been reasoned from
-  a plausible mechanism rather than measured. Filed P2 with low user
-  impact stated explicitly, and `release_scope: all` already bypasses
-  date filtering. Recording the correction so the finding is not read as
-  more urgent than the evidence supports.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: question 2 (which other albums) is a cache query, not
-  an investigation -- run it before designing any fix. Sequenced behind
-  Batch 21, the F-B20-2 orchestrator split, and the test/docstring pass
-  per owner priority.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,25 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - WP-1 token values pinned in the definition (side-task)
+
+- Scope: make WP-1 executor-agnostic. The definition referenced "the
+  audit token sheet" but only carried headline values; the full sheet
+  lived in the Claude Design project and one agent's session notes,
+  blocking a cold-start executor (e.g. a Codex session) from
+  implementing WP-1 faithfully.
+- Plan vs implementation: the WP-1 theme bullet now pins the complete
+  sheet -- all eight colors (light bg/bg-2/ink/primary, dark
+  bg/surface/text/primary), the three-family type system with sizes,
+  the 4px spacing ladder, and the radius set. Values transcribed from
+  "ScrobbleScope UI Audit v3" section "A starter palette and type
+  system you can ship today" (2026-07-28 fetch).
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: WP-1 can now be executed by any agent from the
+  definition alone; compiled CSS remains the WP-1 deliverable.
+
 ### 2026-07-31 - Owner-preferences commit-rule dedup (side-task)
 
 - Scope: final SSOT sweep found AGENT_NOTES.md Owner Preferences still
@@ -211,26 +230,3 @@ non-current operational logs. Older dated entries live in
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: owner can observe the 5-slot cap locally; the
   "N/5 slots in use" occupancy hint remains open as F-LOAD-1.
-
-### 2026-07-31 - FINDINGS refresh: batch-closure pointers, F-DOCSYNC-4, F-SWE-1 (side-task)
-
-- Scope: owner-flagged staleness in FINDINGS.md -- open P1 items that
-  Batch 21's definition already promises to close carried no pointer,
-  and F-B20-4 paraphrased the whole definition.
-- Plan vs implementation:
-  - F-B20-3: remedy rewritten -- the 5.1->5.3 CDN-consolidation path is
-    dead; Batch 21 resolves the split by eliminating Bootstrap (closes
-    at WP-8). F-AUDIT-1: closes at Batch 21 WP-2 via acceptance
-    criterion 8. F-B18-12 deferred-block line marked as in-batch scope
-    (WP-6). F-B20-4 compressed to a pointer at `BATCH21_DEFINITION.md`.
-    F-FEATURE-2 line reformatted as a greppable cross-ref bullet.
-  - New F-DOCSYNC-4 (resolved): per-batch logs were undiscoverable until
-    the Section 2 Log column landed; records the tombstone disposition.
-  - New F-SWE-1 (open P1): SWE-principles audit chartered via
-    `docs/SWE_AUDIT_CHARTER.md` (next commit), executable cold by a
-    dedicated Claude or Codex session; closes by pointing at the report.
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: F-LOAD-1's "N/10" phrasing updates with the
-  MAX_ACTIVE_JOBS default change (next commit); charter follows.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -171,13 +171,10 @@ non-current operational logs. Older dated entries live in
   nothing. The lesson was folded into the existing blast-radius
   anti-pattern as one sentence rather than becoming a fifteenth
   registry entry -- see the verbosity note below.
-- Deliberate non-action: AGENTS.md is now 475 lines and the registry
-  holds fourteen entries. Documentation across the agent-orchestration
-  set (1,685 lines) stands at roughly 60 percent of the production
-  Python it governs (2,787 lines), and several recent findings were
-  caused by rule text rather than caught by it. Adding rules is no
-  longer cheap. A consolidation pass is a batch-scoped candidate, not
-  something to attempt mid-PR.
+- Deliberate non-action: folded into an existing entry rather than added
+  as a fifteenth, because rule text has begun causing findings as well
+  as preventing them -- the registry grew long enough to need numbers,
+  and the numbers became the defect.
 - Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: merge rather than iterate further.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -149,6 +149,27 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-07-31 - SWE-principles audit charter (side-task)
+
+- Scope: charter the owner-requested audit of the ten mandated software
+  principles so a dedicated single-purpose session (Claude or Codex) can
+  execute it cold, without this session's context.
+- Plan vs implementation: new `docs/SWE_AUDIT_CHARTER.md` front-loads
+  all judgment -- Python-only scope (JS/templates excluded until
+  Batch 21 ships them), a do-not-re-report differential baseline
+  (F-MAS-*, F-B20-2, prior 2026-02 audits, standing design decisions),
+  pre-identified hotspots (the three ~110-150 line functions and the 17
+  `except Exception` sites), a 10-principle x module grading matrix
+  with per-cell evidence, and a strict output contract (a dated
+  SWE_PRINCIPLES_AUDIT report under the history archive plus net-new
+  F-SWE-N findings only; read-only, no code changes). Tracked as
+  F-SWE-1.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: execution is decoupled -- run whenever convenient
+  (Codex costs no Claude tokens). Batch 21 WP-1 is unblocked and next.
+
 ### 2026-07-31 - MAX_ACTIVE_JOBS default 10 -> 5 (side-task)
 
 - Scope: owner decision. The 2026-03-04 load test ran 2/3/5 concurrent
@@ -217,44 +238,3 @@ non-current operational logs. Older dated entries live in
   -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
 - Forward guidance: hygiene commits 3-5 follow (FINDINGS refresh,
   MAX_ACTIVE_JOBS 5, SWE audit charter).
-
-### 2026-07-31 - Bootstrap-doc SSOT pass: single-source rules and state (side-task)
-
-- Scope: owner-requested hygiene sweep before Batch 21 WP-1. Exploration
-  confirmed AGENTS.md and HANDOFF_PROMPT.md contradicted each other
-  (bootstrap order, sufficiency gate, pre-commit gate, ownership map),
-  commit discipline existed in 3-4 copies, the heatmap perf measurement
-  in 4 copies, and AGENT_NOTES.md carried live batch state under a
-  shipped-feature heading plus Batch 19 residue and a pointer to a
-  non-repo file.
-- Plan vs implementation:
-  - AGENTS.md is now the single owner of rules: canonical 7-step
-    bootstrap order (AGENTS.md itself is step 1), the stricter 3-way
-    sufficiency gate, a 6-step pre-commit procedure including the
-    doc_state_sync --check gate, the conflict-resolution rule, and four
-    new anti-patterns (never --no-verify; stale Section 3; missing log
-    entries; stale dashboard figures -- the ~72% coverage figure
-    survived five months while reality was 89%). Docstring mandate moved
-    into Proposal and Design Rules.
-  - HANDOFF_PROMPT.md reduced to what it uniquely owns: post-read
-    verification (git status/log + pytest count reconciliation) and the
-    end-of-session handoff checklist; all rule sections now link to
-    AGENTS.md instead of restating.
-  - AGENT_NOTES.md: batch state moved out (PLAYBOOK Section 3 declared
-    the single source); Heatmap section retitled shipped and trimmed of
-    Batch 19 residue; venv rules and runtime constants replaced with
-    links to their owners; load-test pointer now inlines the conclusion
-    (2/3/5 clean, 10 never completed) and flags the raw data as
-    agent-side; Talisman note repointed to the archived Batch 17 log;
-    orchestrator-split note repointed to F-B20-2; the ten software
-    principles expanded from bare acronyms.
-  - SESSION_CONTEXT: Section 3 now lists all 7 CSS / 7 JS files and the
-    template set (Batch 21 touches exactly these); heatmap perf trimmed
-    to an F-B18-11 pointer here and in PLAYBOOK Section 3 -- F-B18-11 is
-    the only full copy of the measurement.
-- Deviations: none.
-- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
-  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
-- Forward guidance: commits 2-5 of the approved hygiene plan follow
-  (PLAYBOOK log column, FINDINGS refresh, MAX_ACTIVE_JOBS 5, SWE audit
-  charter); then Batch 21 WP-1.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Heatmap
 **Key design decisions:**
 
 * **Per-job state isolation:** UUID-keyed `JOBS` dict with `threading.Lock`. Progress, results, and unmatched data are scoped per job. Jobs expire after 2 hours.
-* **Bounded concurrency:** `MAX_ACTIVE_JOBS` (default 10) caps background jobs via `BoundedSemaphore`. Excess requests are rejected before job creation.
+* **Bounded concurrency:** `MAX_ACTIVE_JOBS` (default 5) caps background jobs via `BoundedSemaphore`. Excess requests are rejected before job creation.
 * **Data normalization:** Artist and album names are cleaned of punctuation and common suffixes ("deluxe edition", "remastered") for robust Last.fm-to-Spotify matching.
 * **Global rate limiting:** `_GlobalThrottle` in `utils.py` caps aggregate API throughput across all threads.
 * **Acyclic module graph:** Leaf modules (`config`, `domain`, `errors`) have no internal imports. `orchestrator.py` sits at the top; `routes.py` imports only what it needs. See `AGENTS.md` for the full dependency graph.
@@ -227,7 +227,7 @@ Heatmap
 
     # Optional tuning (see scrobblescope/config.py and scrobblescope/cache.py for the full list)
     # MAX_CONCURRENT_LASTFM="10"
-    # MAX_ACTIVE_JOBS="10"
+    # MAX_ACTIVE_JOBS="5"
     ```
 
 ### Running the App
@@ -316,7 +316,7 @@ python scripts/testing/concurrent_users_test.py \
 ```
 
 Reports per-thread outcome and aggregate statistics.
-Set `--concurrency` above `MAX_ACTIVE_JOBS` (default 10) to observe semaphore-capacity rejections.
+Set `--concurrency` above `MAX_ACTIVE_JOBS` (default 5) to observe semaphore-capacity rejections.
 
 ### Running Tests
 

--- a/docs/SWE_AUDIT_CHARTER.md
+++ b/docs/SWE_AUDIT_CHARTER.md
@@ -107,5 +107,6 @@ not volume.
 
 Target a single focused session. If module coverage must be cut to fit,
 cut `scripts/docsync/` first (it has the freshest dedicated audit) and
-say so in the report -- silent scope reduction is itself an anti-pattern
-(AGENTS.md registry #10 spirit: never imply coverage you did not do).
+name every skipped module in the report's scope section. A report that
+does not list what it skipped implies coverage it does not have, which
+defeats the purpose of the audit.

--- a/docs/SWE_AUDIT_CHARTER.md
+++ b/docs/SWE_AUDIT_CHARTER.md
@@ -101,8 +101,9 @@ not volume.
   AGENTS.md Side-Task Handling.
 - Validation gates per AGENTS.md Commit Rules (docs-only change; all
   three commands must still pass).
-- Commit subject: `docs(audit): SWE principles audit report + F-SWE
-  findings`. Do not push without owner instruction.
+- Commit subject: `docs(audit): add SWE principles audit report and
+  F-SWE findings` (imperative mood per AGENTS.md Commit Rules).
+  Do not push without owner instruction.
 
 ## 7. Budget guidance
 

--- a/docs/SWE_AUDIT_CHARTER.md
+++ b/docs/SWE_AUDIT_CHARTER.md
@@ -35,12 +35,14 @@ change while the audit runs (it is a read-only side-task).
 
 ## 3. The ten principles (grade each)
 
-DRY (don't repeat yourself), SoC (separation of concerns), SRP (single
-responsibility), KISS (keep it simple), Dependency Inversion, Composition
-over Inheritance, Clean Architecture (dependencies point inward -- check
-against the acyclic graph in SESSION_CONTEXT Section 4), Boy Scout Rule
-(assessed via git history of touched files), Least Knowledge / Law of
-Demeter, Fail Fast.
+The canonical list and its definitions live in `AGENT_NOTES.md` Owner
+Preferences. Grade every principle named there, using that wording --
+do not keep a second copy in this file. Two need audit-specific method:
+
+- **Clean Architecture:** check dependencies against the acyclic graph
+  in SESSION_CONTEXT Section 4.
+- **Boy Scout Rule:** assess via git history of the files each change
+  touched.
 
 ## 4. Differential baseline (do NOT re-report)
 
@@ -95,13 +97,12 @@ not volume.
 - FINDINGS.md: append net-new F-SWE-N entries (start at F-SWE-2;
   F-SWE-1 is this charter's tracking entry). Update F-SWE-1 to
   `Status: resolved -- report at <path>`.
-- PLAYBOOK Section 4: one dated side-task entry (insert directly after
-  the `CURRENT-BATCH-END` marker -- top position; see AGENTS.md
-  Side-Task Handling for why).
-- Validation gates per AGENTS.md (docs-only change; all three commands
-  must still pass).
-- Commit: `docs(audit): SWE principles audit report + F-SWE findings`.
-  Do not push without owner instruction.
+- PLAYBOOK Section 4: one dated side-task entry, placed and tagged per
+  AGENTS.md Side-Task Handling.
+- Validation gates per AGENTS.md Commit Rules (docs-only change; all
+  three commands must still pass).
+- Commit subject: `docs(audit): SWE principles audit report + F-SWE
+  findings`. Do not push without owner instruction.
 
 ## 7. Budget guidance
 

--- a/docs/SWE_AUDIT_CHARTER.md
+++ b/docs/SWE_AUDIT_CHARTER.md
@@ -1,0 +1,111 @@
+# SWE Principles Audit Charter
+
+**Status:** Chartered 2026-07-31, execution pending. Tracked as FINDINGS.md
+F-SWE-1.
+**Executor contract:** any dedicated, single-purpose agent session (Claude,
+Codex, or equivalent) can run this cold. The judgment is front-loaded into
+this charter; the executor's job is careful reading, evidence gathering,
+and honest grading -- not scope invention.
+
+---
+
+## 1. Bootstrap
+
+Follow `AGENTS.md` "Session Bootstrap" first (it is step 1 of its own
+order). This charter is the work order; PLAYBOOK Section 3 status does not
+change while the audit runs (it is a read-only side-task).
+
+## 2. Scope
+
+**In scope (Python only):**
+
+- `scrobblescope/` -- all 13 modules (~3,100 LOC)
+- `app.py` (~150 LOC)
+- `scripts/docsync/` -- parser/renderer/logic/cli/models (~1,000 LOC)
+
+**Explicitly OUT of scope:**
+
+- `static/js/` (~1,860 LOC) and all templates/CSS -- Batch 21 rewrites
+  them; auditing them before it ships wastes the work. A follow-up
+  charter can add them post-Batch-21.
+- Tests are read for evidence (vacuity, coverage) but are not graded
+  cells in the matrix.
+- **No code changes of any kind.** This is a read-only audit. Findings
+  become F-SWE-N entries; fixes are future batch work.
+
+## 3. The ten principles (grade each)
+
+DRY (don't repeat yourself), SoC (separation of concerns), SRP (single
+responsibility), KISS (keep it simple), Dependency Inversion, Composition
+over Inheritance, Clean Architecture (dependencies point inward -- check
+against the acyclic graph in SESSION_CONTEXT Section 4), Boy Scout Rule
+(assessed via git history of touched files), Least Knowledge / Law of
+Demeter, Fail Fast.
+
+## 4. Differential baseline (do NOT re-report)
+
+These are already found, tracked, or deliberately declined. Re-reporting
+any of them is audit failure, not thoroughness:
+
+- Open findings: F-MAS-1 through F-MAS-8, F-B20-2 (orchestrator
+  decomposition -- the single biggest known SoC/SRP item), F-DOCSYNC-1
+  through F-DOCSYNC-4, F-B18-2/3/4/5/10 (deferred block), F-LOAD-1/2.
+- `docs/history/AUDIT_2026-02-27_MULTI_AGENT_SWEEP.md` (lines 113-136
+  list the prior runtime SoC/DRY/code-smell findings).
+- `docs/history/ROUTES_SOC_AUDIT_2026-02-21.md` -- Section 4 "What was
+  NOT changed" documents deliberate declines; respect them.
+- `docs/history/TEST_QUALITY_AUDIT_2026-02-21.md`.
+- Standing design decisions (F-LOAD-3/4/5, AGENT_NOTES.md Architectural
+  Constraints): in-memory REQUEST_CACHE, single-worker JOBS dict,
+  TTL-on-write cache, ProactorEventLoop guard. These are choices, not
+  findings.
+
+The audit's value is NET-NEW findings and a defensible per-module grade,
+not volume.
+
+## 5. Method
+
+1. Read the baseline documents in Section 4 first.
+2. Examine pre-identified hotspots before anything else:
+   - `orchestrator.py:719` `_fetch_and_process` (~153 lines)
+   - `routes.py:405` `results_loading` (~115 lines)
+   - `heatmap.py:89` `_fetch_and_process_heatmap` (~111 lines)
+   - the 17 `except Exception` sites (routes 5, orchestrator 4, cache 2,
+     lastfm 2, utils 2, heatmap 1, worker 1) -- F-MAS-4 tracks the
+     count; the audit grades whether each catch is justified, which
+     F-MAS-4 never did.
+3. Fill a 10-principle x module grading matrix. Grade A/B/C/D per cell
+   with a one-line evidence citation (`file:line`). "Not applicable"
+   is a valid cell value (e.g., Composition over Inheritance in a
+   module with no classes) -- grade what exists.
+4. For every C or D cell, either map it to an existing finding (cite the
+   F-ID, no new entry) or write a net-new F-SWE-N finding per AGENTS.md
+   Finding-Writing Rules (heading, one-sentence problem, Status, Source:
+   `SWE_PRINCIPLES_AUDIT`).
+5. Answer two summary questions in prose: (a) which principle is weakest
+   repo-wide and what single change would most improve it; (b) has code
+   quality drifted since the 2026-02 audits, held, or improved --
+   with evidence.
+
+## 6. Output contract
+
+- Report: `docs/history/SWE_PRINCIPLES_AUDIT_<YYYY-MM-DD>.md` -- the
+  matrix, per-cell evidence, the two prose answers, and a net-new
+  findings list.
+- FINDINGS.md: append net-new F-SWE-N entries (start at F-SWE-2;
+  F-SWE-1 is this charter's tracking entry). Update F-SWE-1 to
+  `Status: resolved -- report at <path>`.
+- PLAYBOOK Section 4: one dated side-task entry (insert directly after
+  the `CURRENT-BATCH-END` marker -- top position; see AGENTS.md
+  Side-Task Handling for why).
+- Validation gates per AGENTS.md (docs-only change; all three commands
+  must still pass).
+- Commit: `docs(audit): SWE principles audit report + F-SWE findings`.
+  Do not push without owner instruction.
+
+## 7. Budget guidance
+
+Target a single focused session. If module coverage must be cut to fit,
+cut `scripts/docsync/` first (it has the freshest dedicated audit) and
+say so in the report -- silent scope reduction is itself an anti-pattern
+(AGENTS.md registry #10 spirit: never imply coverage you did not do).

--- a/docs/SWE_AUDIT_CHARTER.md
+++ b/docs/SWE_AUDIT_CHARTER.md
@@ -49,9 +49,12 @@ do not keep a second copy in this file. Two need audit-specific method:
 These are already found, tracked, or deliberately declined. Re-reporting
 any of them is audit failure, not thoroughness:
 
-- Open findings: F-MAS-1 through F-MAS-8, F-B20-2 (orchestrator
-  decomposition -- the single biggest known SoC/SRP item), F-DOCSYNC-1
-  through F-DOCSYNC-4, F-B18-2/3/4/5/10 (deferred block), F-LOAD-1/2.
+- Already-tracked findings, whatever their current status: F-MAS-1
+  through F-MAS-8, F-B20-2 (orchestrator decomposition -- the single
+  biggest known SoC/SRP item), F-DOCSYNC-1 through F-DOCSYNC-4
+  (F-DOCSYNC-4 is already resolved; listed so it is not re-raised),
+  F-B18-2/3/4/5/10 (deferred block), F-LOAD-1/2. Check each ID's
+  `Status:` line in FINDINGS.md rather than assuming from this list.
 - `docs/history/AUDIT_2026-02-27_MULTI_AGENT_SWEEP.md` (lines 113-136
   list the prior runtime SoC/DRY/code-smell findings).
 - `docs/history/ROUTES_SOC_AUDIT_2026-02-21.md` -- Section 4 "What was

--- a/docs/SWE_AUDIT_CHARTER.md
+++ b/docs/SWE_AUDIT_CHARTER.md
@@ -11,9 +11,9 @@ and honest grading -- not scope invention.
 
 ## 1. Bootstrap
 
-Follow `AGENTS.md` "Session Bootstrap" first (it is step 1 of its own
-order). This charter is the work order; PLAYBOOK Section 3 status does not
-change while the audit runs (it is a read-only side-task).
+Follow `AGENTS.md` "Session Bootstrap" first -- that list names itself as
+the first file to read. This charter is the work order; PLAYBOOK Section 3
+status does not change while the audit runs (it is a read-only side-task).
 
 ## 2. Scope
 

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,42 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - PR #165 Copilot review round 4 (side-task)
+
+- Scope: zero visible comments, two suppressed, both valid and both real
+  defects rather than the judgement-call trade-offs round 3 predicted.
+  The convergence call made after round 3 was wrong; recorded here
+  because the wrong prediction is the useful part. Tally 18/18.
+- Plan vs implementation:
+  - **A rule was silently deleted by this PR, and round 1 removed the
+    last copy.** The prohibition on `git add -A` / `git add .` lived in
+    two places before this branch: AGENT_NOTES.md Owner Preferences and
+    the old HANDOFF_PROMPT anti-pattern list. The PR's HANDOFF_PROMPT
+    rewrite dropped its copy, and the round-1 dedup replaced the
+    AGENT_NOTES copy with a pointer to AGENTS.md Commit Rules -- which
+    never contained the prohibition. Step 5 only said "stage only files
+    changed for this work package", which `git add -A` can satisfy when
+    every changed file happens to belong to the WP. Restored explicitly
+    in Commit Rules step 5, the canonical location the pointer targets.
+  - Lesson: verifying that a pointer's target "covers it in substance"
+    is not enough. Round 1 checked AGENTS.md:167 and accepted a
+    paraphrase as equivalent when it dropped a prohibition. Before
+    deleting a rule copy, diff the *specific obligations*, not the topic.
+  - `scripts/testing/concurrent_users_test.py` promised queuing in three
+    places. `acquire_job_slot()` uses `acquire(blocking=False)` and both
+    call sites (`routes.py:460`, `routes.py:570`) return an error
+    immediately, so excess submissions are rejected and never queued.
+    Round 1 edited one of those lines for the cap change without
+    questioning the surrounding claim. Now describes rejection, matching
+    README's "capacity rejections" wording.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: do not call convergence from the *shape* of a round's
+  findings. Rounds 2 and 3 returned zero visible comments and were still
+  productive; round 4 found a deleted rule. Stop when a round returns
+  nothing, not when the findings look minor.
+
 ### 2026-07-31 - PR #165 Copilot review round 3 (side-task)
 
 - Scope: round 3 again returned zero visible comments and three

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,39 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - DEVELOPMENT.md: correct HANDOFF_PROMPT description (side-task)
+
+- Scope: DEVELOPMENT.md described `HANDOFF_PROMPT.md` as a condensed
+  checklist of rules, gates, read order, and commit discipline. That was
+  accurate until this branch, which reduced the file to post-read
+  verification plus the handoff checklist and replaced everything else
+  with pointers. The description was left describing the architecture
+  this PR removed.
+- Plan vs implementation: two passages corrected -- the architecture
+  overview and the per-file section, which was also retitled from
+  "Bootstrap Procedure" to "Session Start and Handoff" to match what the
+  file now contains. Both now state why the summaries were removed
+  (each restatement drifted from its source), which is the reasoning the
+  rest of the document uses.
+- Deviations: scope-limited on purpose. Only the passages this branch
+  made wrong were touched. DEVELOPMENT.md has other known staleness --
+  the `gemini-pr-triage` skill is now `pr-bot-triage`, the
+  review-suggestions section predates repo-aware review tooling, and the
+  closing paragraph needs a rewrite -- all deferred to a post-merge
+  documentation pass, per the same in-scope test applied to
+  `concurrent_users_test.py` in review round 1.
+- Note: this class of staleness is invisible to diff-scoped review.
+  Copilot reported "13/13 changed files" across four rounds and
+  DEVELOPMENT.md was never among them, so a file made wrong by the diff
+  but not part of it cannot be flagged. Worth remembering when relying on
+  automated review for consistency.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: the post-merge pass should reframe the review section
+  around how the tooling changed rather than around rejection, and
+  `README.md:492` must move with it -- it currently promises a section on
+  suggestions "evaluated and rejected".
+
 ### 2026-07-31 - Push rule: standing exception for review-fix commits (side-task)
 
 - Scope: owner-directed policy change, not a review finding. During PR

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,40 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-08-01 - PR #165 Copilot review round 5 (side-task)
+
+- Scope: round 5 returned "not ready to approve" with four suppressed
+  comments and zero visible ones. All four verified valid against the
+  code; all four acted on.
+- Plan vs implementation:
+  - `config.py`: the MAX_ACTIVE_JOBS rationale claimed "one global
+    10 req/s API throttle". Wrong -- `utils.py:81-82` builds separate
+    `_LASTFM_THROTTLE` and `_SPOTIFY_THROTTLE`. Comment now names the
+    Last.fm scrobble-fetch phase as the binding constraint.
+  - `AGENTS.md` commit procedure: the docsync `--check` gate sat at
+    step 3 while the PLAYBOOK update was step 4, so the gate ran before
+    the documentation it validates (and `pre-commit` carries the
+    `doc-state-sync-check` hook). Reordered: write docs, `--fix`, then
+    the three gates on the final state. This matches what sessions
+    already do in practice; only the written rule was wrong. Fixed a
+    duplicate step number introduced by the renumber.
+  - `FINDINGS.md` F-DATA-1 open question 2 proposed grouping
+    `spotify_cache` by `artist_norm + album_norm` -- which is the
+    primary key (`init_db.py:42`), so every group holds exactly one row
+    and the upsert has already overwritten any rival date. Replaced
+    with the two methods that can actually work (re-run the Spotify
+    search and compare against the earliest fresh candidate, or
+    cross-check MusicBrainz).
+  - `docs/SWE_AUDIT_CHARTER.md`: prescribed commit subject was a noun
+    phrase, violating the imperative-subject rule the charter tells
+    executors to follow. Now imperative.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: pushed under the standing review-fix exception with
+  a batched reply. PR #165 remains merge-ready pending the next
+  auto-review.
+
 ### 2026-07-31 - FINDINGS: record reissue cache-key collapse (side-task)
 
 - Scope: capture a data-quality mechanism found while discussing the

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,45 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - PR #165 Copilot review round 3 (side-task)
+
+- Scope: round 3 again returned zero visible comments and three
+  suppressed ones. Two acted on in full, one acted on in part.
+  Suppressed-block tally now 16/16 across #163, #164, and #165.
+- Plan vs implementation:
+  - `docs/SWE_AUDIT_CHARTER.md` Section 3 copied the ten principle names
+    from AGENT_NOTES.md and **had already drifted**: the copy dropped the
+    definitions for Dependency Inversion, Least Knowledge, and Fail Fast,
+    and truncated SRP from "single responsibility per module/function".
+    This is the rare case where the drift was demonstrable rather than
+    hypothetical, so the copy is gone. The section now points at
+    AGENT_NOTES.md and keeps only the two audit-specific methods (Clean
+    Architecture via the SESSION_CONTEXT Section 4 acyclic graph, Boy
+    Scout via git history).
+  - `docs/SWE_AUDIT_CHARTER.md` Section 6 restated side-task entry
+    placement that AGENTS.md Side-Task Handling owns -- and round 2 had
+    just renumbered that section, so the charter was already a rewrite
+    away from being wrong. Delegated.
+  - `HANDOFF_PROMPT.md` Section 1 restated the bootstrap-conflict rule
+    verbatim from AGENTS.md:64-65 inside a paragraph that claims rules
+    "are not restated here". Removed.
+- Deviations: **partially declined** the reviewer's request to also strip
+  "Do not push without owner instruction" from the charter's commit step.
+  Verified AGENTS.md:171 owns it, so the SSOT argument is technically
+  right, but that line sits at the point of action for a cold-start
+  executor (the charter is written so Codex can run it without prior
+  context) and a push is not reversible. Deliberate safety redundancy is
+  worth one line. Removed the same sentence from HANDOFF_PROMPT Section 1
+  by contrast, because there the reader is being sent to AGENTS.md in the
+  very same paragraph, so the copy buys nothing.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: watch for diminishing returns. Rounds 1-3 were all
+  genuine, but the remaining duplication is increasingly load-bearing
+  context for cold-start executors; judge each on whether the copy can
+  drift *and* whether losing it costs a reader who cannot see the source.
+  Batch 21 WP-1 remains the next action.
+
 ### 2026-07-31 - PR #165 Copilot review round 2 (side-task)
 
 - Scope: round 2 returned **zero visible comments and five suppressed

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,52 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - PR #165 Copilot review round 2 (side-task)
+
+- Scope: round 2 returned **zero visible comments and five suppressed
+  ones**. All five were valid. The suppressed-block hit rate is now 13/13
+  across PRs #163, #164, and #165 while the visible stream has gone dry
+  twice; treat that block as the primary signal, not an appendix.
+- Plan vs implementation:
+  - `AGENTS.md` Side-Task Handling read as an ordered procedure whose
+    step 1 was "commit" and step 2 "add the log entry", contradicting
+    Commit Rules step 4 and Anti-Pattern Registry #9, which require the
+    entry to be in the same commit. Since AGENTS.md is now the rules
+    SSOT, an internal contradiction there is load-bearing. Reworded so
+    side-tasks inherit the commit rules unchanged and differ only in
+    entry placement and tagging; the remaining steps renumbered.
+  - `HANDOFF_PROMPT.md` Section 5 told agents to document completion
+    *after* committing and to commit the docs separately -- the same
+    conflict, one level down. Now states that docs land in the commit.
+  - Resolution was evidence-based, not a judgement call: registry #9
+    forbids a commit without its entry, and all four recent side-task
+    commits (`2559f39`, `2b9b095`, `98cc50c`, `900d0e6`) bundle
+    PLAYBOOK + archive with the change. Docs were wrong; practice was
+    right.
+  - `FINDINGS.md` F-LOAD-1 proposed an "N/5 slots in use" hint, which
+    hard-codes a value that is env-configurable. This PR had changed it
+    from "N/10" -- swapping one literal for another. Now specifies
+    reading the cap from `MAX_ACTIVE_JOBS` at render time.
+  - `.claude/SESSION_CONTEXT.md` header said 2026-07-28 while the body
+    recorded a 2026-07-31 runtime change. Header updated.
+  - `docs/SWE_AUDIT_CHARTER.md` cited "AGENTS.md registry #10" for
+    silent scope reduction; #10 is about re-measuring canonical figures
+    and says nothing about audit coverage. The charter was added in this
+    PR, so this was a sourcing error at write time, not staleness --
+    corrected rather than left as a point-in-time record. Now states the
+    requirement directly.
+- Deviations: round 1 split its fixes across two commits, and `07c4f5b`
+  therefore landed without its own Section 4 entry -- a violation of
+  Anti-Pattern Registry #9, the rule this round clarifies. Not rewritten:
+  both commits were already pushed and history rewrites need owner
+  instruction. Round 2 is a single commit. Standing lesson: this repo's
+  #9 outranks the generic "prefer small atomic commits" heuristic, and
+  the one-commit-per-review-round precedent from PR #163 was correct.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: Batch 21 WP-1 remains the next action. `gh` writes
+  are still unavailable this session, so the round-2 reply is unposted.
+
 ### 2026-07-31 - PR #165 Copilot review round 1 (side-task)
 
 - Scope: triaged the five comments on PR #165 (four inline, one inside

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,32 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-28 - PR #163 review response, round 3 (side-task)
+
+- Scope: Copilot round 3 -- three suppressed low-confidence comments.
+  Two acted on, one deferred to FINDINGS with a decline on the PR.
+- Plan vs implementation:
+  - Acted: `global.css` joins the WP-2 legacy per-page stack -- verified
+    it carries Bootstrap-coupled `.card`/`.card-body`/`.modal-*` rules
+    (`global.css:141-199`) that would restyle daisyUI components if it
+    stayed in `base.html`; token/wordmark/shell concerns redistributed
+    (daisyUI themes + `shell.css`).
+  - Acted: WP-8 drift hook diff scoped with a pathspec
+    (`git diff --exit-code -- static/css/tailwind.css`) so unrelated
+    dirty files or rewrites from earlier hooks in the same run cannot
+    produce false drift failures.
+  - Deferred: retagging the Batch 20 close-out entry in the monolith
+    archive. The routing claim is correct, but it is consistent tool
+    behavior (`(Batch N close-out)` is not parser-recognized;
+    BATCH19_LOG.md lacks its close-out too), and hand-editing
+    machine-rotated archive content in a docs PR was declined and
+    accepted in PR #162 round 3. Logged as F-DOCSYNC-3 (open P2) for a
+    docsync WP alongside F-DOCSYNC-1/2.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: WP-1 remains next; batched reply posted on PR #163.
+
 ### 2026-07-28 - PR #163 review response, round 2 (side-task)
 
 - Scope: Copilot round 2 -- no new top-level comments, four suppressed

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,33 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-29 - PR #164 phantom cleanup + review response (side-task)
+
+- Scope: PR #163 was rebase-merged, leaving `wip/batch-21` "8 ahead /
+  8 behind" (identical content, different SHAs -- normal rebase-merge
+  artifact). The owner opened PR #164 from the stale branch; Copilot
+  re-reviewed the phantom diff and left three NEW valid comments that
+  four prior rounds missed. PR #164 closed with explanation; branch
+  force-pushed to match `main`; all three fixes applied here.
+- Plan vs implementation:
+  - WP-4: leaving the loading page is now a plain "Back home" link with
+    no `/reset_progress` call -- the endpoint clears stored job state
+    only (`routes.py:227-238`); the daemon worker keeps its slot and
+    rewrites the job afterward, so a "Cancel" label would be misleading
+    and the reset racy.
+  - WP-1: digest verification extended to cached artifacts (verify on
+    every use, refetch once on mismatch, fail closed) -- gitignored
+    `scripts/bin/` persists between runs, so download-time-only checks
+    leave a bypass.
+  - AGENTS.md: rotation note qualified -- bottom-appended entries are
+    archived on the next `--fix` only once the non-current window is at
+    capacity; placement rule unchanged.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: WP-1 next on the realigned branch; open a fresh PR
+  for the next review cycle when WP work lands.
+
 ### 2026-07-29 - PR #163 review response, round 4 (side-task)
 
 - Scope: Copilot round 4 -- one suppressed comment. Verified valid and

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,32 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - MAX_ACTIVE_JOBS default 10 -> 5 (side-task)
+
+- Scope: owner decision. The 2026-03-04 load test ran 2/3/5 concurrent
+  users clean while the 10-user run never completed; all jobs share the
+  global 10 req/s API throttle, so 10 slots starve each job below
+  1 req/s on the single small Fly.io machine.
+- Plan vs implementation: `scrobblescope/config.py` default changed to
+  `"5"` with a rationale comment (still env-overridable); README (three
+  mentions), SESSION_CONTEXT key-runtime-facts line, and FINDINGS
+  F-LOAD-1 phrasing updated to match. `fly.toml` sets no
+  `MAX_ACTIVE_JOBS` override, so the new default takes effect on next
+  deploy.
+- Deviations: pre-change scouting claimed no test depends on the
+  default (capacity tests inject their own semaphores) -- true for
+  assertions but not for shared state. Route tests that mock
+  start_job_thread acquire a real slot that is never released, and the
+  session's accumulated leaks crossed the new cap of 5, failing
+  `test_heatmap_loading_json_body` with a real 429. Fixed properly: a
+  new autouse `fresh_job_slots` fixture in `tests/conftest.py` resets
+  the semaphore per test, removing the hidden inter-test ordering
+  coupling the lower cap exposed.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: owner can observe the 5-slot cap locally; the
+  "N/5 slots in use" occupancy hint remains open as F-LOAD-1.
+
 ### 2026-07-31 - FINDINGS refresh: batch-closure pointers, F-DOCSYNC-4, F-SWE-1 (side-task)
 
 - Scope: owner-flagged staleness in FINDINGS.md -- open P1 items that

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,34 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-28 - PR #163 review response, round 2 (side-task)
+
+- Scope: Copilot round 2 -- no new top-level comments, four suppressed
+  low-confidence comments. All four verified valid (same pattern as
+  PR #162: the suppression filter is too conservative); all acted on.
+- Plan vs implementation:
+  - Stale bootstrap docs: AGENT_NOTES.md still called Batch 21 a TBD
+    stub with "no WP work until scope lands"; FINDINGS.md header said
+    scope pending; README roadmap listed scoping as open. All three now
+    reflect the active batch (the definition's own Status line already
+    carried Active from WP-0).
+  - Compiled-CSS drift window: validation gate now requires any WP
+    touching templates or `tailwind.src.css` (WP-2..WP-7) to rebuild
+    and commit `tailwind.css` in the same commit; the drift hook
+    deliberately stays in WP-8 (moving it to WP-1 would front-load the
+    headless-CI fetch problem before any template exists to protect).
+  - Stack-restriction conflict: `toast` + `alert` added to the
+    permitted daisyUI set for the WP-5 toast rewrite.
+  - `--bars-color` inventory corrected: six of seven page CSS files
+    (`unmatched.css` hardcodes its own `--header-bg`), pinwheel via
+    `var()`; the wordmark hardcodes `#6a4baf` and only the dark-mode
+    override (`global.css:49-50`) uses the variable, so light-mode
+    wordmark recoloring is explicit migration work.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: WP-1 remains next; batched reply posted on PR #163.
+
 ### 2026-07-28 - PR #163 review response (side-task)
 
 - Scope: address the Copilot auto-review on PR #163 (Batch 21 open +

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,22 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - Owner-preferences commit-rule dedup (side-task)
+
+- Scope: final SSOT sweep found AGENT_NOTES.md Owner Preferences still
+  restating three commit-mechanics rules AGENTS.md now owns
+  (incremental staging, no co-author trailers, push/pause discipline).
+- Plan vs implementation: the four bullets collapsed into one pointer at
+  AGENTS.md Commit Rules; preference-only items (concise responses,
+  Docker/MCP pause, explain-why, Firefox testing, principles, testing
+  pyramid) stay -- they are owner context, not rules.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: hygiene plan complete (6 commits); Batch 21 WP-1 is
+  next. SSOT sweep contract now holds: commit-rule keywords, venv rules,
+  the heatmap perf figure, and batch state each have exactly one owner.
+
 ### 2026-07-31 - SWE-principles audit charter (side-task)
 
 - Scope: charter the owner-requested audit of the ten mandated software

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,27 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - SWE-principles audit charter (side-task)
+
+- Scope: charter the owner-requested audit of the ten mandated software
+  principles so a dedicated single-purpose session (Claude or Codex) can
+  execute it cold, without this session's context.
+- Plan vs implementation: new `docs/SWE_AUDIT_CHARTER.md` front-loads
+  all judgment -- Python-only scope (JS/templates excluded until
+  Batch 21 ships them), a do-not-re-report differential baseline
+  (F-MAS-*, F-B20-2, prior 2026-02 audits, standing design decisions),
+  pre-identified hotspots (the three ~110-150 line functions and the 17
+  `except Exception` sites), a 10-principle x module grading matrix
+  with per-cell evidence, and a strict output contract (a dated
+  SWE_PRINCIPLES_AUDIT report under the history archive plus net-new
+  F-SWE-N findings only; read-only, no code changes). Tracked as
+  F-SWE-1.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: execution is decoupled -- run whenever convenient
+  (Codex costs no Claude tokens). Batch 21 WP-1 is unblocked and next.
+
 ### 2026-07-31 - MAX_ACTIVE_JOBS default 10 -> 5 (side-task)
 
 - Scope: owner decision. The 2026-03-04 load test ran 2/3/5 concurrent

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,38 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-28 - PR #163 review response (side-task)
+
+- Scope: address the Copilot auto-review on PR #163 (Batch 21 open +
+  doc refreshes). Five inline comments, all on `BATCH21_DEFINITION.md`;
+  all five verified valid against the code and acted on.
+- Plan vs implementation:
+  - WP-1: per-platform SHA-256 digests committed alongside pinned
+    versions; `tailwind_build.py` must verify every downloaded artifact
+    before executing it (pin-only trusts the release asset at fetch
+    time, and the WP-8 CI hook executes that binary headless).
+  - WP-1: daisyUI standalone needs both `daisyui.mjs` and
+    `daisyui-theme.mjs`; the component bundle alone cannot register the
+    two custom `@plugin` themes.
+  - WP-2: explicit coexistence isolation -- one framework stylesheet
+    per template via the per-page block, shared shell styled by a
+    framework-neutral `shell.css` absorbed at WP-8. Rejected daisyUI
+    prefix alternative (WP-8 removal churn) with reasoning recorded.
+  - WP-5: dropped "CSV walker untouched" -- `results.js` exports
+    rendered cell text, so `MMM YY` display dates would truncate CSV
+    release dates; date cells keep ISO in `data-export`, walker
+    prefers it.
+  - WP-7 + acceptance criterion 6: `below_min_plays`/`below_min_tracks`
+    removed from the reason-code set -- `fetch_top_albums_async` drops
+    threshold failures before the pipeline (`orchestrator.py:112-116`),
+    and near-miss retention is explicitly Batch 22+. Two reason cards,
+    not three; out-of-scope entry cross-references the deferred codes.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: WP-1 implementation must honor the amended digest
+  and dual-plugin-file requirements; batched reply posted on PR #163.
+
 ### 2026-07-28 - Side-task entry placement rule in AGENTS.md (side-task)
 
 - Scope: document the doc_state_sync rotation gotcha discovered during

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,26 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - PLAYBOOK Section 2 log column; tombstone disposition (side-task)
+
+- Scope: the 18 per-batch logs under `docs/history/logs/` were referenced
+  from no working doc (Section 2 had no Log column), making batch history
+  discoverable only via a directory glob.
+- Plan vs implementation: Section 2 table gained a Log column linking
+  `BATCH3_LOG.md` through `BATCH20_LOG.md` (batches 0-2 predate per-batch
+  logging); a note under the table points close-out-entry seekers at the
+  monolith archive per F-DOCSYNC-3. AGENTS.md Batch Close-Out step 3 now
+  requires filling the Log column at close-out so the column cannot go
+  stale. Investigated the two 300-byte `PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
+  files under `docs/history/` and `docs/history/logs/`: they are
+  deliberate "Moved:" tombstones from the Batch 14 restructure kept for
+  backward references -- retained, disposition recorded in F-DOCSYNC-4.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: hygiene commits 3-5 follow (FINDINGS refresh,
+  MAX_ACTIVE_JOBS 5, SWE audit charter).
+
 ### 2026-07-31 - Bootstrap-doc SSOT pass: single-source rules and state (side-task)
 
 - Scope: owner-requested hygiene sweep before Batch 21 WP-1. Exploration

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,32 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - Push rule: standing exception for review-fix commits (side-task)
+
+- Scope: owner-directed policy change, not a review finding. During PR
+  #165 triage the owner granted a standing authorization to push
+  review-driven commits without asking per round, on the reasoning that
+  the agent reaches the diminishing-returns point on its own and a
+  per-round approval round-trip only stalls the loop.
+- Plan vs implementation: encoded in AGENTS.md Commit Rules step 6 rather
+  than left as an agent-side preference, because AGENTS.md is the rules
+  SSOT and a spoken rule that contradicts the written one is exactly the
+  defect this PR spent four rounds removing. Scoped per owner: **Claude
+  Code and Codex sessions only.** GitHub Copilot task sessions and their
+  subagents, Jules, and any other agent follow the unmodified rule --
+  the owner does not extend equal trust to agents of varying quality
+  that it cannot inspect per-invocation. Step 6 already carried a
+  Copilot-specific clause, so per-agent scoping had precedent.
+- Deviations: the exception is deliberately narrow. Review-fix commits on
+  an open PR only; batch and WP commits still pause, and force-pushes,
+  history rewrites, and anything touching `main` still require explicit
+  instruction.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: if the agent roster changes, this clause names
+  specific agents and will need revisiting -- it is an allowlist, not a
+  capability test.
+
 ### 2026-07-31 - PR #165 Copilot review round 4 (side-task)
 
 - Scope: zero visible comments, two suppressed, both valid and both real

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,25 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-29 - PR #163 review response, round 4 (side-task)
+
+- Scope: Copilot round 4 -- one suppressed comment. Verified valid and
+  acted on.
+- Plan vs implementation: the archived coverage-refresh entry cited
+  "the CLAUDE.md canonical command", but CLAUDE.md is gitignored
+  (`.gitignore:49`) and repo-invisible; the command is documented at
+  README.md "Running Tests". Reference corrected in the monolith
+  archive entry.
+- Deviations: none. Distinction from the PR #162 round-3 decline on
+  editing rotated entries: that citation was accurate at write time and
+  went stale (point-in-time record, left alone); this one was
+  repo-invisible at write time -- a sourcing error that defeats the
+  record's verifiability, so it is corrected rather than preserved.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: review rounds have reached citation polish;
+  recommend merging or pausing auto-review re-requests. WP-1 next.
+
 ### 2026-07-28 - PR #163 review response, round 3 (side-task)
 
 - Scope: Copilot round 3 -- three suppressed low-confidence comments.

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,47 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - Bootstrap-doc SSOT pass: single-source rules and state (side-task)
+
+- Scope: owner-requested hygiene sweep before Batch 21 WP-1. Exploration
+  confirmed AGENTS.md and HANDOFF_PROMPT.md contradicted each other
+  (bootstrap order, sufficiency gate, pre-commit gate, ownership map),
+  commit discipline existed in 3-4 copies, the heatmap perf measurement
+  in 4 copies, and AGENT_NOTES.md carried live batch state under a
+  shipped-feature heading plus Batch 19 residue and a pointer to a
+  non-repo file.
+- Plan vs implementation:
+  - AGENTS.md is now the single owner of rules: canonical 7-step
+    bootstrap order (AGENTS.md itself is step 1), the stricter 3-way
+    sufficiency gate, a 6-step pre-commit procedure including the
+    doc_state_sync --check gate, the conflict-resolution rule, and four
+    new anti-patterns (never --no-verify; stale Section 3; missing log
+    entries; stale dashboard figures -- the ~72% coverage figure
+    survived five months while reality was 89%). Docstring mandate moved
+    into Proposal and Design Rules.
+  - HANDOFF_PROMPT.md reduced to what it uniquely owns: post-read
+    verification (git status/log + pytest count reconciliation) and the
+    end-of-session handoff checklist; all rule sections now link to
+    AGENTS.md instead of restating.
+  - AGENT_NOTES.md: batch state moved out (PLAYBOOK Section 3 declared
+    the single source); Heatmap section retitled shipped and trimmed of
+    Batch 19 residue; venv rules and runtime constants replaced with
+    links to their owners; load-test pointer now inlines the conclusion
+    (2/3/5 clean, 10 never completed) and flags the raw data as
+    agent-side; Talisman note repointed to the archived Batch 17 log;
+    orchestrator-split note repointed to F-B20-2; the ten software
+    principles expanded from bare acronyms.
+  - SESSION_CONTEXT: Section 3 now lists all 7 CSS / 7 JS files and the
+    template set (Batch 21 touches exactly these); heatmap perf trimmed
+    to an F-B18-11 pointer here and in PLAYBOOK Section 3 -- F-B18-11 is
+    the only full copy of the measurement.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: commits 2-5 of the approved hygiene plan follow
+  (PLAYBOOK log column, FINDINGS refresh, MAX_ACTIVE_JOBS 5, SWE audit
+  charter); then Batch 21 WP-1.
+
 ### 2026-07-29 - PR #164 phantom cleanup + review response (side-task)
 
 - Scope: PR #163 was rebase-merged, leaving `wip/batch-21` "8 ahead /

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,25 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - WP-1 token values pinned in the definition (side-task)
+
+- Scope: make WP-1 executor-agnostic. The definition referenced "the
+  audit token sheet" but only carried headline values; the full sheet
+  lived in the Claude Design project and one agent's session notes,
+  blocking a cold-start executor (e.g. a Codex session) from
+  implementing WP-1 faithfully.
+- Plan vs implementation: the WP-1 theme bullet now pins the complete
+  sheet -- all eight colors (light bg/bg-2/ink/primary, dark
+  bg/surface/text/primary), the three-family type system with sizes,
+  the 4px spacing ladder, and the radius set. Values transcribed from
+  "ScrobbleScope UI Audit v3" section "A starter palette and type
+  system you can ship today" (2026-07-28 fetch).
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: WP-1 can now be executed by any agent from the
+  definition alone; compiled CSS remains the WP-1 deliverable.
+
 ### 2026-07-31 - Owner-preferences commit-rule dedup (side-task)
 
 - Scope: final SSOT sweep found AGENT_NOTES.md Owner Preferences still

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,29 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - FINDINGS refresh: batch-closure pointers, F-DOCSYNC-4, F-SWE-1 (side-task)
+
+- Scope: owner-flagged staleness in FINDINGS.md -- open P1 items that
+  Batch 21's definition already promises to close carried no pointer,
+  and F-B20-4 paraphrased the whole definition.
+- Plan vs implementation:
+  - F-B20-3: remedy rewritten -- the 5.1->5.3 CDN-consolidation path is
+    dead; Batch 21 resolves the split by eliminating Bootstrap (closes
+    at WP-8). F-AUDIT-1: closes at Batch 21 WP-2 via acceptance
+    criterion 8. F-B18-12 deferred-block line marked as in-batch scope
+    (WP-6). F-B20-4 compressed to a pointer at `BATCH21_DEFINITION.md`.
+    F-FEATURE-2 line reformatted as a greppable cross-ref bullet.
+  - New F-DOCSYNC-4 (resolved): per-batch logs were undiscoverable until
+    the Section 2 Log column landed; records the tombstone disposition.
+  - New F-SWE-1 (open P1): SWE-principles audit chartered via
+    `docs/SWE_AUDIT_CHARTER.md` (next commit), executable cold by a
+    dedicated Claude or Codex session; closes by pointing at the report.
+- Deviations: none.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: F-LOAD-1's "N/10" phrasing updates with the
+  MAX_ACTIVE_JOBS default change (next commit); charter follows.
+
 ### 2026-07-31 - PLAYBOOK Section 2 log column; tombstone disposition (side-task)
 
 - Scope: the 18 per-batch logs under `docs/history/logs/` were referenced

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,40 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - PR #165 Copilot review round 1 (side-task)
+
+- Scope: triaged the five comments on PR #165 (four inline, one inside
+  the suppressed low-confidence block). All five were valid; none were
+  declined. Two themes: an overstated concurrency claim and three
+  leftover copies of rules AGENTS.md now owns.
+- Plan vs implementation:
+  - `config.py`: the MAX_ACTIVE_JOBS rationale claimed a cap of 5 "keeps
+    >=2 req/s per job". `_GlobalThrottle.next_wait()` (utils.py) advances
+    a single next-allowed timestamp under one lock, serializing callers
+    in arrival order with no per-job accounting, so a busy job can take
+    more slots than an idle one. Reworded as an average, matching the
+    "~10/N req/s" framing already used in AGENT_NOTES.md.
+  - `scripts/testing/concurrent_users_test.py`: module docstring and
+    `build_parser()` still said the default was 10 and told operators to
+    set `--concurrency` above 10. Both now say 5. A repo-wide sweep found
+    no other live stale reference; remaining "default 10" hits are all
+    under `docs/history/` and stay as written (point-in-time records).
+  - `AGENT_NOTES.md`: the Owner Preferences commit-mechanics bullet and
+    the Venv "In short:" line each pointed at AGENTS.md and then restated
+    its content anyway. Both reduced to pointers after verifying AGENTS.md
+    genuinely carries every rule involved.
+  - `HANDOFF_PROMPT.md`: Section 2 restated the full three-command gate
+    and the root-BATCH warning, contradicting the Document Roles contract
+    added by this same PR, which assigns gates to AGENTS.md. Collapsed to
+    a pointer matching the wording Sections 3 and 4 already use.
+- Deviations: none. No test changes -- all five edits are comment or
+  documentation text with no behavior change.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: the suppressed-comment block again held a real
+  finding (8/8 across PRs #163/#164/#165), so keep expanding it. Batch 21
+  WP-1 remains the next action.
+
 ### 2026-07-31 - WP-1 token values pinned in the definition (side-task)
 
 - Scope: make WP-1 executor-agnostic. The definition referenced "the

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,42 @@ Read helpers:
 - `rg -n "^### 20" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/history/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-07-31 - FINDINGS: record reissue cache-key collapse (side-task)
+
+- Scope: capture a data-quality mechanism found while discussing the
+  DEVELOPMENT.md rewrite, before the reasoning was lost to chat. No code
+  change -- this is a finding, not a fix.
+- Plan vs implementation: added `F-DATA-1` under P2.
+  `normalize_name()` strips `deluxe`/`edition`/`remastered` and eight
+  more words, so a reissue and its original normalize identically; since
+  the `spotify_cache` PK is `artist_norm + album_norm`, they share one
+  row and whichever populated it first serves its `release_date` for 30
+  days. Owner observed this with Viagra Boys "viagr aboys" (2025)
+  surfacing under 2026 via the JP deluxe released 2026-01-09, on an
+  account that never played it.
+- The finding records why the collapse is nonetheless correct (Last.fm
+  scrobbles the same record under inconsistent album strings; keying
+  editions apart would split one album into several leaderboard rows
+  with divided playcounts), the candidate fix (decouple counting from
+  dating -- keep the collapse for aggregation, take the *earliest*
+  candidate release date when resolving the year, no schema change), the
+  rejected boolean discriminator and why, three questions answerable by
+  querying the cache, and the note that Spotify exposes no
+  original-release-date field at all.
+- Deviations: earlier in the session an agent claim that release-date
+  drift was a systemic risk was walked back. The owner has ~14 years of
+  scrobbles and one recalled instance; the claim had been reasoned from
+  a plausible mechanism rather than measured. Filed P2 with low user
+  impact stated explicitly, and `release_scope: all` already bypasses
+  date filtering. Recording the correction so the finding is not read as
+  more urgent than the evidence supports.
+- Validation: `pytest -q` -- **390 passed**. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0.
+- Forward guidance: question 2 (which other albums) is a cache query, not
+  an investigation -- run it before designing any fix. Sequenced behind
+  Batch 21, the F-B20-2 orchestrator split, and the test/docstring pass
+  per owner priority.
+
 ### 2026-07-31 - DEVELOPMENT.md: correct HANDOFF_PROMPT description (side-task)
 
 - Scope: DEVELOPMENT.md described `HANDOFF_PROMPT.md` as a condensed

--- a/scripts/testing/concurrent_users_test.py
+++ b/scripts/testing/concurrent_users_test.py
@@ -6,13 +6,16 @@ per-thread outcomes (job_id, elapsed time, completion status) plus aggregate
 results (submitted, completed, failed, elapsed range).
 
 **Observability tool, not a pass/fail test.**  Results vary by machine, network
-conditions, and server load.  The primary signal is whether threads that exceed
-``MAX_ACTIVE_JOBS`` block, queue, or fail -- and whether concurrent Postgres
-cache access produces races or corrupted results.
+conditions, and server load.  The primary signal is how submissions past the
+cap are turned away, and whether concurrent Postgres cache access produces
+races or corrupted results.
 
 ``MAX_ACTIVE_JOBS`` is configured in ``scrobblescope/config.py`` (default 5)
-and enforced via a semaphore in ``scrobblescope/worker.py``.  Set
-``--concurrency`` above 5 to observe queuing and semaphore-limit behavior.
+and enforced by a *non-blocking* semaphore in ``scrobblescope/worker.py``:
+``acquire_job_slot()`` calls ``acquire(blocking=False)``, so a submission
+past the cap is rejected immediately with "Too many requests in progress"
+-- it is never queued and never waits for a slot.  Set ``--concurrency``
+above 5 to observe those rejections.
 
 Usage example::
 
@@ -103,7 +106,7 @@ def run_thread(
     Waits at the shared ``barrier`` before submitting so that all threads
     fire their POST at the same instant (maximises the chance of exceeding
     the ``MAX_ACTIVE_JOBS`` semaphore limit in ``worker.py`` and observing
-    queuing or rejection behavior).
+    the resulting rejections).
 
     All exceptions are caught and stored in ``ConcurrentResult.error`` so
     a single failing thread (e.g. CSRF race, network timeout, server error)

--- a/scripts/testing/concurrent_users_test.py
+++ b/scripts/testing/concurrent_users_test.py
@@ -10,9 +10,9 @@ conditions, and server load.  The primary signal is whether threads that exceed
 ``MAX_ACTIVE_JOBS`` block, queue, or fail -- and whether concurrent Postgres
 cache access produces races or corrupted results.
 
-``MAX_ACTIVE_JOBS`` is configured in ``scrobblescope/config.py`` (default 10)
+``MAX_ACTIVE_JOBS`` is configured in ``scrobblescope/config.py`` (default 5)
 and enforced via a semaphore in ``scrobblescope/worker.py``.  Set
-``--concurrency`` above 10 to observe queuing and semaphore-limit behavior.
+``--concurrency`` above 5 to observe queuing and semaphore-limit behavior.
 
 Usage example::
 
@@ -243,7 +243,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     Defaults are tuned for local development (``http://localhost:5000``).
     Override ``--base-url`` for deployed instances.  Set ``--concurrency``
-    above ``MAX_ACTIVE_JOBS`` (default 10) to observe semaphore limiting.
+    above ``MAX_ACTIVE_JOBS`` (default 5) to observe semaphore limiting.
 
     Returns
     -------

--- a/scrobblescope/config.py
+++ b/scrobblescope/config.py
@@ -19,7 +19,11 @@ SPOTIFY_BATCH_RETRIES = int(os.getenv("SPOTIFY_BATCH_RETRIES", "3"))
 # Global state tracking
 REQUEST_CACHE_TIMEOUT = 3600  # Cache timeout in seconds (1 hour)
 JOB_TTL_SECONDS = 2 * 60 * 60
-MAX_ACTIVE_JOBS = int(os.getenv("MAX_ACTIVE_JOBS", "10"))
+# Default 5 (was 10 until 2026-07-31): the 2026-03-04 load test ran 2/3/5
+# concurrent users clean while the 10-user run never completed. All jobs
+# share the global 10 req/s API throttle, so a cap of 5 keeps >=2 req/s
+# per job on this single small Fly.io machine.
+MAX_ACTIVE_JOBS = int(os.getenv("MAX_ACTIVE_JOBS", "5"))
 METADATA_CACHE_TTL_DAYS = int(os.getenv("METADATA_CACHE_TTL_DAYS", "30"))
 
 spotify_token_cache = {"token": None, "expires_at": 0}

--- a/scrobblescope/config.py
+++ b/scrobblescope/config.py
@@ -21,8 +21,10 @@ REQUEST_CACHE_TIMEOUT = 3600  # Cache timeout in seconds (1 hour)
 JOB_TTL_SECONDS = 2 * 60 * 60
 # Default 5 (was 10 until 2026-07-31): the 2026-03-04 load test ran 2/3/5
 # concurrent users clean while the 10-user run never completed. All jobs
-# share the global 10 req/s API throttle, so a cap of 5 keeps >=2 req/s
-# per job on this single small Fly.io machine.
+# share one global 10 req/s API throttle that serializes callers in
+# arrival order with no per-job fairness, so a cap of 5 averages ~2 req/s
+# per job rather than guaranteeing it -- enough headroom on this single
+# small Fly.io machine.
 MAX_ACTIVE_JOBS = int(os.getenv("MAX_ACTIVE_JOBS", "5"))
 METADATA_CACHE_TTL_DAYS = int(os.getenv("METADATA_CACHE_TTL_DAYS", "30"))
 

--- a/scrobblescope/config.py
+++ b/scrobblescope/config.py
@@ -20,11 +20,13 @@ SPOTIFY_BATCH_RETRIES = int(os.getenv("SPOTIFY_BATCH_RETRIES", "3"))
 REQUEST_CACHE_TIMEOUT = 3600  # Cache timeout in seconds (1 hour)
 JOB_TTL_SECONDS = 2 * 60 * 60
 # Default 5 (was 10 until 2026-07-31): the 2026-03-04 load test ran 2/3/5
-# concurrent users clean while the 10-user run never completed. All jobs
-# share one global 10 req/s API throttle that serializes callers in
-# arrival order with no per-job fairness, so a cap of 5 averages ~2 req/s
-# per job rather than guaranteeing it -- enough headroom on this single
-# small Fly.io machine.
+# concurrent users clean while the 10-user run never completed. Each API
+# has its own global throttle (`_LASTFM_THROTTLE` and `_SPOTIFY_THROTTLE`,
+# utils.py:81-82), and both serialize callers in arrival order with no
+# per-job fairness. The binding constraint is the Last.fm scrobble-fetch
+# phase: at 10 req/s shared across jobs, a cap of 5 averages ~2 req/s per
+# job through that phase rather than guaranteeing it -- enough headroom on
+# this single small Fly.io machine.
 MAX_ACTIVE_JOBS = int(os.getenv("MAX_ACTIVE_JOBS", "5"))
 METADATA_CACHE_TTL_DAYS = int(os.getenv("METADATA_CACHE_TTL_DAYS", "30"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -17,6 +18,27 @@ from app import create_app  # noqa: E402
 # ---------------------------------------------------------------------------
 # Flask fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def fresh_job_slots():
+    """Give every test a fresh job-slot semaphore.
+
+    Route tests that mock start_job_thread acquire a real slot that is
+    never released (the release lives in the background task's finally
+    block), so leaked slots accumulate across the test session. With the
+    old MAX_ACTIVE_JOBS default of 10 the leaks never crossed the
+    threshold; the drop to 5 exposed the hidden ordering coupling (a late
+    /heatmap_loading test drew a real 429). Resetting per test removes
+    the inter-test coupling instead of relying on the cap exceeding the
+    session's leak count.
+    """
+    from scrobblescope import config, worker
+
+    original = worker._active_jobs_semaphore
+    worker._active_jobs_semaphore = threading.BoundedSemaphore(config.MAX_ACTIVE_JOBS)
+    yield
+    worker._active_jobs_semaphore = original
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

<!-- What changed and why -->

## Checklist

- [ ] `pytest -q` passes (update SESSION_CONTEXT Section 1 if test count changed)
- [ ] `pre-commit run --all-files` passes (all hooks)
- [ ] `python scripts/doc_state_sync.py --check` exits 0
- [ ] PLAYBOOK Section 3 reflects current WP/task state
- [ ] PLAYBOOK Section 4 has a dated log entry:
      - Batch WP: inside `DOCSYNC:CURRENT-BATCH-START/END` markers
      - Side task: after `DOCSYNC:CURRENT-BATCH-END` marker
- [ ] Changes are within scope of the active batch definition
      (or deviation is logged in the Section 4 entry)
