### PR TITLE
fix(batch21): clear the SWE audit gate before WP-1

### DIFF
--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -1,6 +1,6 @@
 # ScrobbleScope Session Context
 
-Last updated: 2026-08-15
+Last updated: 2026-08-20
 
 ---
 
@@ -20,7 +20,7 @@ Last updated: 2026-08-15
 | Batch 18 status | **Complete**. All 5 WPs done. Definition: `docs/history/definitions/BATCH18_DEFINITION.md`. |
 | Batch 19 status | **Complete**. All 5 WPs done plus owner-review follow-up. Definition: `docs/history/definitions/BATCH19_DEFINITION.md`. PR #152 merged to `main`. |
 | Batch 20 status | **Complete**. All 9 WPs done. Definition: `docs/history/definitions/BATCH20_DEFINITION.md`. |
-| Batch 21 status | **Active.** UI overhaul: Tailwind + daisyUI migration, warm theme propagation. WP-0 done; the repository-integrity gate and split worktree guard shipped via PR #169 (merged 2026-08-08), F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2 are resolved. PR #170 merged 2026-08-12 (`5b060a2`), remediating the four round-6 findings that had merged unaddressed. The F-SWE-1 audit ran 2026-08-20 and returned **migration blocked by F-SWE-2** (report: `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md`); the charter is retired. Next: the owner decides F-SWE-2 -- fix or waive -- then WP-1. Definition: `BATCH21_DEFINITION.md`. |
+| Batch 21 status | **Active.** UI overhaul: Tailwind + daisyUI migration, warm theme propagation. WP-0 done; the repository-integrity gate and split worktree guard shipped via PR #169 (merged 2026-08-08), F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2 are resolved. PR #170 merged 2026-08-12 (`5b060a2`), remediating the four round-6 findings that had merged unaddressed. The F-SWE-1 audit ran 2026-08-20 and returned **migration blocked by F-SWE-2** (report: `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md`); the charter is retired. Owner elected the fix 2026-08-20, so next: apply the F-SWE-2 fix as its own commit (two lines at `orchestrator.py:70-71` plus a regression test; it moves the test count), then WP-1. Definition: `BATCH21_DEFINITION.md`. |
 | Known open risk | `RotatingFileHandler` throws `PermissionError: [WinError 32]` on Windows when multiple Flask processes hold the log file open (Werkzeug debug reloader). Cosmetic -- Flask continues to serve. Linux/Fly.io unaffected. |
 
 **Key runtime facts:**

--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -9,7 +9,7 @@ Last updated: 2026-08-20
 | Item | Value |
 |------|-------|
 | Branch | `wip/batch-21` |
-| Tests | **590 passing** across 35 test modules |
+| Tests | **591 passing** across 35 test modules |
 | Coverage | 89% (2026-07-28 run, `pytest --cov=scrobblescope`) |
 | Pre-commit | All hooks pass |
 | Batch 13 status | **Complete**. All 5 WPs done. Definition: `docs/history/definitions/BATCH13_DEFINITION.md`. |
@@ -20,7 +20,7 @@ Last updated: 2026-08-20
 | Batch 18 status | **Complete**. All 5 WPs done. Definition: `docs/history/definitions/BATCH18_DEFINITION.md`. |
 | Batch 19 status | **Complete**. All 5 WPs done plus owner-review follow-up. Definition: `docs/history/definitions/BATCH19_DEFINITION.md`. PR #152 merged to `main`. |
 | Batch 20 status | **Complete**. All 9 WPs done. Definition: `docs/history/definitions/BATCH20_DEFINITION.md`. |
-| Batch 21 status | **Active.** UI overhaul: Tailwind + daisyUI migration, warm theme propagation. WP-0 done; the repository-integrity gate and split worktree guard shipped via PR #169 (merged 2026-08-08), F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2 are resolved. PR #170 merged 2026-08-12 (`5b060a2`), remediating the four round-6 findings that had merged unaddressed. The F-SWE-1 audit ran 2026-08-20 and returned **migration blocked by F-SWE-2** (report: `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md`); the charter is retired. Owner elected the fix 2026-08-20, so next: apply the F-SWE-2 fix as its own commit (two lines at `orchestrator.py:70-71` plus a regression test; it moves the test count), then WP-1. Definition: `BATCH21_DEFINITION.md`. |
+| Batch 21 status | **Active.** UI overhaul: Tailwind + daisyUI migration, warm theme propagation. WP-0 done; the repository-integrity gate and split worktree guard shipped via PR #169 (merged 2026-08-08), F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2 are resolved. PR #170 merged 2026-08-12 (`5b060a2`), remediating the four round-6 findings that had merged unaddressed. The F-SWE-1 audit ran 2026-08-20 and blocked migration on F-SWE-2 (report: `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md`); the charter is retired. F-SWE-2 was resolved 2026-08-20 in its standalone prerequisite commit. WP-1 is next. Definition: `BATCH21_DEFINITION.md`. |
 | Known open risk | `RotatingFileHandler` throws `PermissionError: [WinError 32]` on Windows when multiple Flask processes hold the log file open (Werkzeug debug reloader). Cosmetic -- Flask continues to serve. Linux/Fly.io unaffected. |
 
 **Key runtime facts:**
@@ -44,11 +44,11 @@ Last updated: 2026-08-20
 <!-- DOCSYNC:STATUS-START -->
 - Source of truth: `PLAYBOOK.md` (Section 3 and Section 4).
 - Current batch: Batch 21.
-- Current-batch entries in active log block: 1.
+- Current-batch entries in active log block: 2.
 - Completed work packages in current-batch entries: WP-0.
 - Next expected work package: WP-1.
-- Latest validated test count: **590 passed**.
-- Newest current-batch entry: 2026-07-24 - Batch 21 opened: UI overhaul definition committed (Batch 21 WP-0).
+- Latest validated test count: **591 passed**.
+- Newest current-batch entry: 2026-08-20 - F-SWE-2 UTC album-year window fixed (Batch 21 WP-0).
 <!-- DOCSYNC:STATUS-END -->
 
 ---
@@ -178,7 +178,7 @@ loading.js polls GET /progress?job_id=...
 
 ---
 
-## 6. Test structure (590 tests)
+## 6. Test structure (591 tests)
 
 | File | Count |
 |------|-------|
@@ -196,7 +196,7 @@ loading.js polls GET /progress?job_id=...
 | test_routes.py | 67 |
 | test_utils.py | 34 |
 | test_worker.py | 6 |
-| services/test_lastfm_logic.py | 7 |
+| services/test_lastfm_logic.py | 8 |
 | services/test_lastfm_service.py | 9 |
 | services/test_orchestrator_fetch_and_process.py | 10 |
 | services/test_orchestrator_fetch_spotify.py | 8 |

--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -44,11 +44,11 @@ Last updated: 2026-08-20
 <!-- DOCSYNC:STATUS-START -->
 - Source of truth: `PLAYBOOK.md` (Section 3 and Section 4).
 - Current batch: Batch 21.
-- Current-batch entries in active log block: 2.
+- Current-batch entries in active log block: 3.
 - Completed work packages in current-batch entries: WP-0.
 - Next expected work package: WP-1.
 - Latest validated test count: **591 passed**.
-- Newest current-batch entry: 2026-08-20 - F-SWE-2 UTC album-year window fixed (Batch 21 WP-0).
+- Newest current-batch entry: 2026-08-20 - PR #172 frontend-gate contract made executable (Batch 21 WP-0).
 <!-- DOCSYNC:STATUS-END -->
 
 ---

--- a/.claude/SESSION_CONTEXT.md
+++ b/.claude/SESSION_CONTEXT.md
@@ -20,7 +20,7 @@ Last updated: 2026-08-15
 | Batch 18 status | **Complete**. All 5 WPs done. Definition: `docs/history/definitions/BATCH18_DEFINITION.md`. |
 | Batch 19 status | **Complete**. All 5 WPs done plus owner-review follow-up. Definition: `docs/history/definitions/BATCH19_DEFINITION.md`. PR #152 merged to `main`. |
 | Batch 20 status | **Complete**. All 9 WPs done. Definition: `docs/history/definitions/BATCH20_DEFINITION.md`. |
-| Batch 21 status | **Active.** UI overhaul: Tailwind + daisyUI migration, warm theme propagation. WP-0 done; the repository-integrity gate and split worktree guard shipped via PR #169 (merged 2026-08-08), F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2 are resolved. PR #170 merged 2026-08-12 (`5b060a2`), remediating the four round-6 findings that had merged unaddressed. Next: the F-SWE-1 audit, then WP-1. Definition: `BATCH21_DEFINITION.md`. |
+| Batch 21 status | **Active.** UI overhaul: Tailwind + daisyUI migration, warm theme propagation. WP-0 done; the repository-integrity gate and split worktree guard shipped via PR #169 (merged 2026-08-08), F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2 are resolved. PR #170 merged 2026-08-12 (`5b060a2`), remediating the four round-6 findings that had merged unaddressed. The F-SWE-1 audit ran 2026-08-20 and returned **migration blocked by F-SWE-2** (report: `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md`); the charter is retired. Next: the owner decides F-SWE-2 -- fix or waive -- then WP-1. Definition: `BATCH21_DEFINITION.md`. |
 | Known open risk | `RotatingFileHandler` throws `PermissionError: [WinError 32]` on Windows when multiple Flask processes hold the log file open (Werkzeug debug reloader). Cosmetic -- Flask continues to serve. Linux/Fly.io unaffected. |
 
 **Key runtime facts:**

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,9 @@ docs/agents/
 # Markdown, which is what GitHub renders; a tracked .mmd would be a second
 # copy free to drift. See .github/instructions/mermaid.instructions.md.
 *.mmd
+
+# Playwright MCP scratch: console logs and page snapshots from the browser
+# tooling. The console file already matched *.log above, but the .yml page
+# dump did not, so this directory kept showing as untracked. Batch 21 makes
+# Playwright a per-WP gate, so it would otherwise resurface on every run.
+.playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ serve as external memory shared across sessions.
 | `PLAYBOOK.md` | **Work order** | What to do next, what was just done. Active batch + execution log. |
 | `README.md` | **Product docs** | User/developer setup and context. Not for agent orchestration. |
 | `docs/history/` | **Archive** | Completed batch definitions (`definitions/`), per-batch execution logs (`logs/`), audits and other dated one-off documents (`reports/`). |
+| `docs/AGENT_DOC_MAP.md` | **Orientation** | Which document owns what, how to read an audit or a finding, and the known navigation traps. Optional, and not part of the bootstrap set; written for agents new to this repository. |
 
 **Anti-duplication rule:** Each fact lives in exactly one file. If you need to
 reference a fact owned by another file, link to it -- do not copy it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -628,9 +628,13 @@ dedicated findings-cleanup WP. Nothing is deleted -- the archive preserves
 grep history.
 
 1. **F-ID format:** every item heading is `F-<context>-<N>: <title>`.
-   Context is a batch tag (`B18`, `B19`, `B20`, ...) or a source tag
-   (`MAS` for MULTI_AGENT_SWEEP, `DOCSYNC`, `AUDIT`, `LOAD` for the
-   load-testing session); `FEATURE` covers feature-prep notes. No
+   Context is a batch tag (`B18`, `B19`, `B20`, ...) or one of these
+   source tags -- the list is complete, so extend it here when you coin a
+   new tag rather than leaving it undocumented:
+   `MAS` (MULTI_AGENT_SWEEP), `DOCSYNC`, `AUDIT`, `LOAD` (the
+   load-testing session), `SWE` (the SWE-principles audit), `WORKTREE`
+   (the worktree-guard work), `DATA` (data-model items), `STYLE`
+   (writing and Python style), and `FEATURE` (feature-prep notes). No
    bare-numbered items in FINDINGS.md.
 2. **Required fields:** the F-ID heading, a one-sentence problem statement,
    a `Status:` line, and a `Source:` line when the finding came from a

--- a/AGENT_NOTES.md
+++ b/AGENT_NOTES.md
@@ -155,11 +155,11 @@ forward from an earlier note; re-verify before relying on it, because the
 skill and MCP inventory is per-machine and moves independently of this repo.
 
 **How this keys against the definition.** `BATCH21_DEFINITION.md` has no
-per-WP acceptance criteria. It carries one batch-level list of 9 criteria
-and a per-WP validation gate that every WP runs identically (`pytest -q`,
-`pre-commit run --all-files`, `doc_state_sync.py --check`, plus owner visual
-review). So the map keys on the WP and names the batch-level criteria each
-one serves. Do not go looking for per-WP criteria; there are none by design.
+per-WP acceptance criteria. It carries one batch-level list of 9 criteria;
+the three repository gates and owner visual review run at every WP, while
+the repository-owned frontend gate joins them from WP-2 onward. So the map
+keys on the WP and names the batch-level criteria each one serves. Do not go
+looking for per-WP criteria; there are none by design.
 
 ### Skills: four separate sources, and the names collide
 
@@ -206,7 +206,7 @@ Atlassian Rovo, Microsoft 365, Vercel, ZipRecruiter.
 | WP | Tooling that serves it | Batch criteria |
 |---|---|---|
 | WP-1 toolchain + themes | Bespoke Python only. No installed skill covers pinned-binary fetch with per-platform SHA-256 verification, and `frontend-design` authors UI rather than build plumbing. Treat WP-1 as unassisted work | 2, 3, 9 |
-| WP-2 base shell + `error.html` pilot | `frontend-design`; Playwright, which WP-2 now makes permanent as `scripts/dev/frontend_gate.py` -- the one-stylesheet-per-page rule becomes an enforced check rather than a stated deliverable. Gaps 2 and 3 land here, not at WP-8 | 1, 3, 4 |
+| WP-2 base shell + `error.html` pilot | `frontend-design`; repository-owned `playwright==1.62.0` + Chromium power `scripts/dev/frontend_gate.py`, independent of MCP. The one-stylesheet-per-page rule becomes an enforced check rather than a stated deliverable. The drift hook also lands here after WP-1 records its CI-fetch decision | 1, 3, 4 |
 | WP-3 index page | `frontend-design`; Playwright for decade pills, the thresholds disclosure, and the CSS-only hints that replace `bootstrap.Popover` | 1, 4, 8 |
 | WP-4 unified loading | Playwright for progress polling against a live job; the shared Jinja2 partial is exercised from both `loading.html` and the heatmap panel | 5 |
 | WP-5 results leaderboard | Playwright, driven directly -- see gap 1. The JPEG export must be checked in both themes at mobile and desktop, and the `data-export` CSV precision fix needs a real DOM walk | 5, 7 |
@@ -217,8 +217,10 @@ Atlassian Rovo, Microsoft 365, Vercel, ZipRecruiter.
 ### Verified gaps
 
 1. **No `webapp-testing` skill exists on this machine** -- not in any of the
-   four sources above. WP-5's JPEG export E2E and WP-8's owner E2E have no
-   skill support and run through Playwright MCP tools directly.
+   four sources above. That does not block the permanent automated gate:
+   WP-2 adds pinned Python Playwright + Chromium as a repository dependency.
+   WP-5's exploratory JPEG-export E2E and WP-8's owner E2E remain direct
+   Playwright MCP runs on top of that deterministic gate.
 2. **The pre-commit top-level exclude covers 13 directories**, among them
    `docs/`, `static/` and `templates/`. The `tailwind-css-drift` hook on
    `static/css/tailwind.css` would therefore never run as an ordinary
@@ -235,6 +237,9 @@ Atlassian Rovo, Microsoft 365, Vercel, ZipRecruiter.
    pinned versions and digests are chosen. WP-1 now carries an explicit
    criterion to write that decision down; before 2026-08-19 nothing did,
    which is how the hook came to be specified against an open question.
+   WP-2's Python Playwright plan does not add a Node project: CI installs
+   the pinned Python dependency and its matching Chromium build through
+   `python -m playwright`, then runs the repository gate.
 4. **No CSS, JS or HTML hooks at all.** `trailing-whitespace` and
    `end-of-file-fixer` are scoped to `py|md|yaml|yml|txt`, and `static/`
    and `templates/` are excluded by the top-level rule regardless -- so the

--- a/AGENT_NOTES.md
+++ b/AGENT_NOTES.md
@@ -206,13 +206,13 @@ Atlassian Rovo, Microsoft 365, Vercel, ZipRecruiter.
 | WP | Tooling that serves it | Batch criteria |
 |---|---|---|
 | WP-1 toolchain + themes | Bespoke Python only. No installed skill covers pinned-binary fetch with per-platform SHA-256 verification, and `frontend-design` authors UI rather than build plumbing. Treat WP-1 as unassisted work | 2, 3, 9 |
-| WP-2 base shell + `error.html` pilot | `frontend-design`; a Playwright provider to confirm the one-stylesheet-per-page rule actually holds during coexistence | 1, 3, 4 |
+| WP-2 base shell + `error.html` pilot | `frontend-design`; Playwright, which WP-2 now makes permanent as `scripts/dev/frontend_gate.py` -- the one-stylesheet-per-page rule becomes an enforced check rather than a stated deliverable. Gaps 2 and 3 land here, not at WP-8 | 1, 3, 4 |
 | WP-3 index page | `frontend-design`; Playwright for decade pills, the thresholds disclosure, and the CSS-only hints that replace `bootstrap.Popover` | 1, 4, 8 |
 | WP-4 unified loading | Playwright for progress polling against a live job; the shared Jinja2 partial is exercised from both `loading.html` and the heatmap panel | 5 |
 | WP-5 results leaderboard | Playwright, driven directly -- see gap 1. The JPEG export must be checked in both themes at mobile and desktop, and the `data-export` CSV precision fix needs a real DOM walk | 5, 7 |
 | WP-6 heatmap seam removal | Playwright plus visual review; `--bars-color` aliasing is the thing to assert in both themes | 2, 3, 8 |
 | WP-7 `reason_code` (only backend WP) | `test-driven-development` or `tdd`, and `systematic-debugging` or `diagnosing-bugs`. This is where the test count moves, so update the inventory sites listed in `AGENTS.md` in the same commit | 6, 9 |
-| WP-8 sweep + close-out | `verification-before-completion` before any done claim; `pr-bot-triage` for review rounds. Gaps 2, 3 and 4 all land here | 1, 9 |
+| WP-8 sweep + close-out | `verification-before-completion` before any done claim; `pr-bot-triage` for review rounds. Gap 4 lands here as a recorded decision, not as tooling; gaps 2 and 3 moved to WP-2 | 1, 9 |
 
 ### Verified gaps
 
@@ -220,21 +220,32 @@ Atlassian Rovo, Microsoft 365, Vercel, ZipRecruiter.
    four sources above. WP-5's JPEG export E2E and WP-8's owner E2E have no
    skill support and run through Playwright MCP tools directly.
 2. **The pre-commit top-level exclude covers 13 directories**, among them
-   `docs/`, `static/` and `templates/`. WP-8's planned `tailwind-css-drift`
-   hook on `static/css/tailwind.css` would therefore never run as an
-   ordinary file-scoped hook. It must follow the `doc-state-sync-check`
-   pattern (`always_run: true`, `pass_filenames: false`) -- the only hook
-   that currently sees excluded paths -- or the exclude must be narrowed.
+   `docs/`, `static/` and `templates/`. The `tailwind-css-drift` hook on
+   `static/css/tailwind.css` would therefore never run as an ordinary
+   file-scoped hook. It must follow the `doc-state-sync-check` pattern
+   (`always_run: true`, `pass_filenames: false`) -- the only hook that
+   currently sees excluded paths -- or the exclude must be narrowed.
+   The hook moved from WP-8 to WP-2 on 2026-08-19: WP-2 is the first WP
+   whose templates consume the compiled CSS, so waiting for WP-8 left six
+   work packages able to ship drifted output.
 3. **CI has no Node and no Tailwind binary.** `.github/workflows/test.yml`
-   is Python-only. WP-8 requires the fetch to work headless on Linux, so
-   either CI fetches and caches the pinned binary or the drift hook is
-   local-only. Decide this at WP-1, because that is where the pinned
-   versions and digests are chosen.
+   is Python-only. The drift hook (now WP-2) requires the fetch to work
+   headless on Linux, so either CI fetches and caches the pinned binary or
+   the hook is local-only. Decide this at WP-1, because that is where the
+   pinned versions and digests are chosen. WP-1 now carries an explicit
+   criterion to write that decision down; before 2026-08-19 nothing did,
+   which is how the hook came to be specified against an open question.
 4. **No CSS, JS or HTML hooks at all.** `trailing-whitespace` and
    `end-of-file-fixer` are scoped to `py|md|yaml|yml|txt`, and `static/`
    and `templates/` are excluded by the top-level rule regardless -- so the
    files eight work packages spend their time rewriting are unreachable by
    two independent mechanisms. Nothing formats or lints them.
+   **Disposition (2026-08-19):** this gap is closed by decision, not by
+   tooling. Batch 21 adds the generated-CSS drift hook (WP-2) and the
+   frontend gate (WP-2 onward), keeps owner Firefox review, and does not
+   add general CSS/JS/HTML linting unless a real regression demonstrates
+   the need. WP-8 records that decision and its reason. Do not read this
+   gap as an open commitment to add linters.
 5. **`workflow_dispatch` is now usable.** The comment in `test.yml` notes
    it only becomes usable once on the default branch; the PR #170 merge put
    it there, confirmed present on `origin/main`.

--- a/AGENT_NOTES.md
+++ b/AGENT_NOTES.md
@@ -211,7 +211,7 @@ Atlassian Rovo, Microsoft 365, Vercel, ZipRecruiter.
 | WP-4 unified loading | Playwright for progress polling against a live job; the shared Jinja2 partial is exercised from both `loading.html` and the heatmap panel | 5 |
 | WP-5 results leaderboard | Playwright, driven directly -- see gap 1. The JPEG export must be checked in both themes at mobile and desktop, and the `data-export` CSV precision fix needs a real DOM walk | 5, 7 |
 | WP-6 heatmap seam removal | Playwright plus visual review; `--bars-color` aliasing is the thing to assert in both themes | 2, 3, 8 |
-| WP-7 `reason_code` (only backend WP) | `test-driven-development` or `tdd`, and `systematic-debugging` or `diagnosing-bugs`. This is where the test count moves, so update the inventory sites listed in `AGENTS.md` in the same commit | 6, 9 |
+| WP-7 `reason_code` (only backend WP) | `test-driven-development` or `tdd`, and `systematic-debugging` or `diagnosing-bugs`. The test count moves again here, so update the inventory sites listed in `AGENTS.md` in the same commit | 6, 9 |
 | WP-8 sweep + close-out | `verification-before-completion` before any done claim; `pr-bot-triage` for review rounds. Gap 4 lands here as a recorded decision, not as tooling; gaps 2 and 3 moved to WP-2 | 1, 9 |
 
 ### Verified gaps

--- a/BATCH21_DEFINITION.md
+++ b/BATCH21_DEFINITION.md
@@ -52,7 +52,17 @@ WP-2 moves the Bootstrap CSS `<link>` out of `base.html` into a per-page
 block so migrated pages load only Tailwind while unmigrated pages keep
 Bootstrap. Theme state dual-writes `data-theme` (html) and `.dark-mode`
 (body) until every consumer (`theme.js`, `heatmap.js`, `results.js`
-html2canvas clone) is migrated, then `.dark-mode` retires.
+html2canvas clone) is migrated, then `.dark-mode` retires. **WP-8 owns
+that retirement:** dropping the `.dark-mode` write from `theme.js` and
+removing the selector from every stylesheet is a named WP-8 deliverable,
+not a side effect of the "kill dead CSS" sweep.
+
+**Browser floor:** Tailwind v4 targets Chrome 111+, Safari 16.4+ and
+Firefox 128+. It depends on native cascade layers, `@property`, and
+`color-mix()`, none of which degrade gracefully -- below those versions the
+compiled stylesheet does not look different, it fails to work. WP-8 records
+the floor in the README tech-stack section. No polyfill and no fallback
+stylesheet is in scope for this batch.
 
 ---
 
@@ -94,9 +104,12 @@ html2canvas clone) is migrated, then `.dark-mode` retires.
    heatmap headlines (`white-space: nowrap` dropped on mobile headline).
 8. Mode pills have equal width (closes F-B18-12); toggle meets tap-target
    size (closes F-AUDIT-1).
-9. `pytest -q` green and all pre-commit hooks pass at every WP; docs
-   (README tech stack + structure, SESSION_CONTEXT, DEVELOPMENT.md build
-   step) updated by close-out.
+9. `pytest -q` green, all pre-commit hooks pass, and the frontend gate
+   passes at every WP. `doc_state_sync.py --check` also runs at every WP,
+   so the documents it governs (PLAYBOOK Section 4, SESSION_CONTEXT) must
+   be correct at every WP -- not at close-out. Only the narrative docs it
+   does not govern (README tech stack and structure, the DEVELOPMENT.md
+   build step) may land by close-out.
 
 ---
 
@@ -146,6 +159,18 @@ kickoff log entry.
   cards), 999 (pills); `--bars-color` aliased in both themes.
 - Compiled `static/css/tailwind.css` committed; build/watch commands
   documented in DEVELOPMENT.md; CI unaffected (no Node).
+- **Record the CI fetch decision in this file, in the WP-1 commit.**
+  `AGENT_NOTES.md` assigns the choice to WP-1 because WP-1 is where
+  versions and digests are pinned: either CI fetches and caches the pinned
+  binary, or the drift hook is local-only. Nothing currently requires that
+  decision to be written down, which is how the drift hook came to be
+  specified against an unresolved dependency.
+- **Measure reproducibility before anything depends on it.** Build once on
+  the owner machine and once on headless Linux (the CI image) and confirm
+  the two `tailwind.css` outputs are byte-identical. This WP asserts
+  byte-identical output as a requirement; until it is measured it is an
+  assumption, and the drift hook converts that assumption into a gate that
+  fails for everyone at once.
 `feat(ui): add tailwind + daisyui toolchain and theme tokens`
 
 ### WP-2 -- base.html shell + strangler enabler
@@ -173,6 +198,19 @@ kickoff log entry.
   their theme tokens from it; migrated pages get tokens from the
   daisyUI themes, and the wordmark recolor plus shared-shell styling
   move to `shell.css`.
+- **Add the `tailwind-css-drift` pre-commit hook here, not at WP-8.** This
+  is the first WP where a template consumes the compiled CSS, so it is the
+  first WP where drift can ship; deferring to WP-8 leaves WP-2 through
+  WP-7 -- six work packages -- unprotected. The hook must set
+  `always_run: true` and `pass_filenames: false`: `.pre-commit-config.yaml`
+  excludes `static/`, so a filename-driven hook would silently never run on
+  the one file it exists to check. Rebuild via `tailwind_build.py`, then
+  fail if `git diff --exit-code -- static/css/tailwind.css` reports the
+  committed output dirty. The pathspec scopes the check to the generated
+  file so unrelated dirty files, or rewrites left by earlier hooks in the
+  same run, cannot produce false drift failures.
+- **Add `scripts/dev/frontend_gate.py`** (see the validation gate section).
+  It starts with the migrated `error.html` pilot and grows one page per WP.
 `feat(ui): tailwind base shell, header bar, error page pilot`
 
 ### WP-3 -- Index page
@@ -187,6 +225,17 @@ kickoff log entry.
 - Thresholds disclosure with +/- steppers over real number inputs,
   "reset to 10 - 3" affordance, expands in place pushing the CTA down.
 - Decisions 2 and 3 land here (welcome modal, limit_results placement).
+- **The CSS-only hints must open on keyboard focus and on tap, not on
+  hover alone.** A hover-only disclosure is unreachable by keyboard and on
+  touch, which is how "removes the `bootstrap.Popover` dependency" quietly
+  becomes "removes the explanation for some users". Verify on a touch
+  viewport and by tab traversal.
+- Every input keeps a programmatic label association, and focus stays
+  visible on every interactive element in both themes.
+- **Validation parity:** the rebuilt form rejects exactly what the current
+  form rejects and accepts exactly what it accepts. The server contract
+  does not change in this WP, so any behavioural difference is a
+  regression, not a redesign.
 `feat(ui): rebuild index page on tailwind`
 
 ### WP-4 -- Unified loading experience
@@ -204,6 +253,14 @@ kickoff log entry.
   slot and keeps writing into the same job id afterward, so invoking it
   is misleading and racy. True server-side cancellation stays a
   Batch 22+ candidate.
+- **Exercise both pipelines, not just the shared markup.** Top Albums and
+  the heatmap run independent state machines against different endpoints;
+  a shared partial proves shared appearance and nothing about shared
+  behaviour. Cover for each: normal progress to 100%; a retryable failure
+  (Retry offered, page holds, no `results_complete` post); and a
+  non-retryable failure (three-second wait, posts `results_complete`,
+  lands on the processing-error page). The two failure paths differ and
+  are drawn in `docs/architecture/top-albums-sequence.md`.
 `feat(ui): unified pinwheel loading screen for both pipelines`
 
 ### WP-5 -- Results leaderboard
@@ -249,21 +306,47 @@ kickoff log entry.
 - Two reason cards with human copy, top offenders + expander; same row
   component as the leaderboard; welcome + unmatched modals now gone so
   `bootstrap.bundle.min.js` is removed from all templates.
-`feat(unmatched): stable reason codes + card layout`
+- **Ship as two commits, backend first.** A single commit mixing a
+  route/orchestrator contract change with a full page rebuild is hard to
+  review and impossible to roll back independently, and "tests updated in
+  lockstep" does not order the tests ahead of the code they cover:
+  1. `feat(unmatched): add stable reason_code to the unmatched contract`
+     -- orchestrator, routes, and tests only. No template change. The
+     contract is verifiable and revertible on its own.
+  2. `feat(ui): rebuild unmatched page on tailwind`
+     -- cards, expander, modal removal, Bootstrap JS drop.
 
 ### WP-8 -- Sweep + close-out
 
 - Remove every remaining Bootstrap reference (closes F-B20-3 by
-  elimination); radius/spacing ladder sweep; kill dead CSS.
-- Add a `tailwind-css-drift` pre-commit hook: rebuild via
-  `tailwind_build.py`, then fail if
-  `git diff --exit-code -- static/css/tailwind.css` reports the
-  committed compiled CSS dirty. The pathspec scopes the check to the
-  generated file so unrelated dirty tracked files (or rewrites left by
-  earlier hooks in the same run) cannot produce false drift failures.
-  Catches source/output drift without anyone remembering to rebuild.
-  Caveat: the hook also runs in CI, so the fetch step must work headless
-  on Linux (pinned version; consider caching the binary between runs).
+  elimination); radius/spacing ladder sweep; kill dead CSS. Retire
+  `.dark-mode`: drop the dual-write from `theme.js` and remove the
+  selector from every stylesheet.
+- The `tailwind-css-drift` hook is added at WP-2, not here. WP-8 only
+  confirms it still passes on the final tree.
+- **Deterministic Bootstrap-removal check, not a manual sweep.** This
+  command must return nothing:
+  `git grep -nE "bootstrap|data-bs-|bs-(toggle|target|dismiss)" -- templates static`
+  Criterion 1 claims no Bootstrap loads anywhere; until a command proves
+  it, it is an assertion by the person who did the removing.
+- **Frontend quality and accessibility audit -- required, not optional.**
+  `docs/SWE_AUDIT_CHARTER.md` excludes `static/js/`, templates and CSS
+  because this batch rewrites them. That exclusion is only honest if the
+  rewritten frontend then gets an equivalent pass, otherwise the code with
+  the most churn in Batch 21 is the only code never audited. Charter a
+  follow-up audit over the migrated `static/js/`, templates and
+  `tailwind.src.css`: the same ten principles where they apply, plus an
+  accessibility sweep (keyboard traversal of every page, focus visibility,
+  label associations, contrast in both themes, tap-target size). File
+  results as F-SWE-N or F-AUDIT-N. **Batch 21 does not close until this
+  has run.**
+- **Record an explicit disposition for HTML/CSS/JS linting.**
+  `AGENT_NOTES.md` assigns that tooling gap to this WP. The decision is:
+  add only the generated-CSS drift enforcement (now WP-2), keep the
+  per-WP frontend gate and owner Firefox review, and do not add general
+  CSS/JS CI unless a real regression demonstrates the need. Write that
+  decision and its reason here and amend the AGENT_NOTES gap entry to
+  point at it. A gap closed by silence reads as a gap forgotten.
 - Docs: README (tech stack, structure, screenshots note), DEVELOPMENT.md
   (build step), SESSION_CONTEXT Sections 1/3.
 - Owner E2E pass in Firefox + Responsive Design Mode -- explicitly
@@ -280,18 +363,45 @@ kickoff log entry.
 pytest -q
 pre-commit run --all-files
 python scripts/doc_state_sync.py --check
+python scripts/dev/frontend_gate.py        # added at WP-2
 ```
 
 Plus per-WP: owner visual review in both themes before the next WP.
 
-Any WP that changes templates or `tailwind.src.css` (WP-2 through WP-7)
-must run `tailwind_build.py` and commit the refreshed `tailwind.css` in
-the same commit: production serves the committed file with no runtime
-build, and the drift hook only arrives at WP-8, so an intermediate page
-could otherwise ship without its generated utilities while every listed
-command still passes. (The hook stays in WP-8 rather than moving to
-WP-1: that would front-load the headless-CI fetch problem before any
-template exists to protect.)
+**Why the fourth command exists.** The first three cannot fail on frontend
+work. `pre-commit` excludes `static/` and `templates/`, and its whitespace
+hooks are scoped to `py|md|yaml|yml|txt`; `pytest` covers no template and no
+stylesheet. A work package in this batch can therefore rewrite every
+template and every stylesheet with all three green. For a batch that is
+nothing but template and stylesheet rewriting, that is the gate failing at
+its only job.
+
+WP-2 adds `scripts/dev/frontend_gate.py`, a headless Playwright run over the
+migrated pages. It grows one page at a time as the strangler migration
+proceeds, and it must be able to fail. Checks:
+
+1. **Stylesheet isolation** -- each page loads exactly one framework
+   stylesheet. WP-2 states this as a deliverable with nothing enforcing it.
+2. **Theme tokens** -- computed `--bars-color` equals the theme primary in
+   both themes on every migrated page, and no cool-grey surface (`#f8f9fa`,
+   `#121212`) is computed anywhere. Criteria 2 and 3 are otherwise eye-only.
+3. **Theme persistence** -- toggling then reloading keeps the theme.
+4. **Fonts** -- the self-hosted faces load and no request leaves for a font
+   CDN (decision 4 is otherwise unverified).
+5. **Exports** (from WP-5) -- the exported CSV date cell equals its
+   `data-export` ISO value, and the JPEG export is non-blank and correctly
+   sized in both themes at mobile and desktop widths. These are the two
+   silent regression surfaces this batch already identified; owner review
+   stays, on top of the assertion rather than instead of it.
+6. **Headline wrapping** (from WP-6) -- a 15-character username does not
+   clip at mobile widths.
+
+Each check lands in the WP that creates what it checks. None is deferred to
+WP-8.
+
+Any WP that changes templates or `tailwind.src.css` (WP-2 through WP-7) must
+run `tailwind_build.py` and commit the refreshed `tailwind.css` in the same
+commit: production serves the committed file with no runtime build.
 
 ---
 

--- a/BATCH21_DEFINITION.md
+++ b/BATCH21_DEFINITION.md
@@ -104,12 +104,13 @@ stylesheet is in scope for this batch.
    heatmap headlines (`white-space: nowrap` dropped on mobile headline).
 8. Mode pills have equal width (closes F-B18-12); toggle meets tap-target
    size (closes F-AUDIT-1).
-9. `pytest -q` green, all pre-commit hooks pass, and the frontend gate
-   passes at every WP. `doc_state_sync.py --check` also runs at every WP,
-   so the documents it governs (PLAYBOOK Section 4, SESSION_CONTEXT) must
-   be correct at every WP -- not at close-out. Only the narrative docs it
-   does not govern (README tech stack and structure, the DEVELOPMENT.md
-   build step) may land by close-out.
+9. `pytest -q`, all pre-commit hooks, and `doc_state_sync.py --check` pass
+   at every WP. The frontend gate joins them from WP-2 onward, when the
+   gate and its first migrated page exist. Documents governed by docsync
+   (PLAYBOOK Section 4, SESSION_CONTEXT) must be correct at every WP -- not
+   at close-out. Only the narrative docs it does not govern (README tech
+   stack and structure, the DEVELOPMENT.md build step) may land by
+   close-out.
 
 ---
 
@@ -158,7 +159,8 @@ kickoff log entry.
   (4/8/12/16/24/32/48 only); radius 8 (inputs/small cards), 14 (large
   cards), 999 (pills); `--bars-color` aliased in both themes.
 - Compiled `static/css/tailwind.css` committed; build/watch commands
-  documented in DEVELOPMENT.md; CI unaffected (no Node).
+  documented in DEVELOPMENT.md. The Tailwind toolchain introduces no Node
+  project; WP-2 provisions its separate Python browser-test dependency.
 - **Record the CI fetch decision in this file, in the WP-1 commit.**
   `AGENT_NOTES.md` assigns the choice to WP-1 because WP-1 is where
   versions and digests are pinned: either CI fetches and caches the pinned
@@ -209,8 +211,12 @@ kickoff log entry.
   committed output dirty. The pathspec scopes the check to the generated
   file so unrelated dirty files, or rewrites left by earlier hooks in the
   same run, cannot produce false drift failures.
-- **Add `scripts/dev/frontend_gate.py`** (see the validation gate section).
-  It starts with the migrated `error.html` pilot and grows one page per WP.
+- **Add the repository-owned frontend gate and its runtime** (see the
+  validation-gate section). This same commit pins `playwright==1.62.0` in
+  `requirements-dev.txt`, provisions Chromium locally and in CI, adds
+  `scripts/dev/frontend_gate.py`, and runs it in the Quality Gate. It starts
+  with the migrated `error.html` pilot and grows one page per WP. README and
+  DEVELOPMENT document setup when the runtime actually lands, not before.
 `feat(ui): tailwind base shell, header bar, error page pilot`
 
 ### WP-3 -- Index page
@@ -357,13 +363,20 @@ kickoff log entry.
 
 ---
 
-## Validation gate (every WP)
+## Validation gates
+
+Every WP:
 
 ```
 pytest -q
 pre-commit run --all-files
 python scripts/doc_state_sync.py --check
-python scripts/dev/frontend_gate.py        # added at WP-2
+```
+
+From WP-2 onward:
+
+```
+python scripts/dev/frontend_gate.py
 ```
 
 Plus per-WP: owner visual review in both themes before the next WP.
@@ -376,9 +389,34 @@ template and every stylesheet with all three green. For a batch that is
 nothing but template and stylesheet rewriting, that is the gate failing at
 its only job.
 
-WP-2 adds `scripts/dev/frontend_gate.py`, a headless Playwright run over the
-migrated pages. It grows one page at a time as the strangler migration
-proceeds, and it must be able to fail. Checks:
+**Executable runtime, owner-approved 2026-08-20.** WP-2 adds
+`playwright==1.62.0` to `requirements-dev.txt` and uses the Python library
+directly; it adds no `package.json`, Node project, pytest plugin, or MCP
+dependency. The Playwright pin selects its matching browser build. Local
+setup uses the qualified-worktree form of:
+
+```
+python -m playwright install chromium
+```
+
+The Quality Gate installs the Linux dependencies and the same browser after
+the Python dependency step, then runs the frontend gate:
+
+```
+python -m playwright install --with-deps chromium
+python scripts/dev/frontend_gate.py
+```
+
+The script never downloads tooling implicitly. A missing package or browser
+fails immediately with the exact setup command. It starts the Flask app on an
+ephemeral loopback port, owns that server's lifecycle, and shuts it down in a
+`finally` block, so the gate needs neither a separately running app nor an
+external MCP service. Unit tests cover missing-runtime diagnostics, assertion
+failure, and server cleanup; the real headless Chromium run is the integration
+gate. Owner Firefox review remains the cross-browser visual check.
+
+`scripts/dev/frontend_gate.py` grows one migrated page at a time as the
+strangler migration proceeds, and it must be able to fail. Checks:
 
 1. **Stylesheet isolation** -- each page loads exactly one framework
    stylesheet. WP-2 states this as a deliverable with nothing enforcing it.

--- a/BATCH21_DEFINITION.md
+++ b/BATCH21_DEFINITION.md
@@ -1,6 +1,6 @@
 # BATCH21: UI overhaul -- Tailwind + daisyUI migration
 
-**Status:** Active. Owner-approved 2026-07-24 (expanded from the Claude Design audit, ScrobbleScope UI Audit v3). WP-0 committed; PR #170 merged 2026-08-12, so the F-SWE-1 audit comes next, then WP-1 (toolchain).
+**Status:** Active. Owner-approved 2026-07-24 (expanded from the Claude Design audit, ScrobbleScope UI Audit v3). WP-0 committed; PR #170 merged 2026-08-12. The F-SWE-1 audit ran 2026-08-20 and blocked WP-1 on F-SWE-2; the owner elected the fix, so that fix comes next, then WP-1 (toolchain).
 **Branch:** `wip/batch-21` (linked worktree; lineage changes are recorded
 in PLAYBOOK Section 4 rather than pinned here).
 **Baseline:** 390 tests passing at batch open (2026-07-24). This batch touches production templates, static assets, and (WP-7 only) `routes.py`/`orchestrator.py`; the count may move and each WP records its own validated count. For the current count see SESSION_CONTEXT Section 1.

--- a/BATCH21_DEFINITION.md
+++ b/BATCH21_DEFINITION.md
@@ -335,7 +335,7 @@ kickoff log entry.
   rewritten frontend then gets an equivalent pass, otherwise the code with
   the most churn in Batch 21 is the only code never audited. Charter a
   follow-up audit over the migrated `static/js/`, templates and
-  `tailwind.src.css`: the same ten principles where they apply, plus an
+  `tailwind.src.css`: the same mandated principles where they apply, plus an
   accessibility sweep (keyboard traversal of every page, focus visibility,
   label associations, contrast in both themes, tap-target size). File
   results as F-SWE-N or F-AUDIT-N. **Batch 21 does not close until this

--- a/BATCH21_DEFINITION.md
+++ b/BATCH21_DEFINITION.md
@@ -1,6 +1,6 @@
 # BATCH21: UI overhaul -- Tailwind + daisyUI migration
 
-**Status:** Active. Owner-approved 2026-07-24 (expanded from the Claude Design audit, ScrobbleScope UI Audit v3). WP-0 committed; PR #170 merged 2026-08-12. The F-SWE-1 audit ran 2026-08-20 and blocked WP-1 on F-SWE-2; the owner elected the fix, so that fix comes next, then WP-1 (toolchain).
+**Status:** Active. Owner-approved 2026-07-24 (expanded from the Claude Design audit, ScrobbleScope UI Audit v3). WP-0 committed; PR #170 merged 2026-08-12. The F-SWE-1 audit blocked WP-1 on F-SWE-2; the owner elected the fix, and the standalone prerequisite was resolved 2026-08-20. WP-1 (toolchain) is next.
 **Branch:** `wip/batch-21` (linked worktree; lineage changes are recorded
 in PLAYBOOK Section 4 rather than pinned here).
 **Baseline:** 390 tests passing at batch open (2026-07-24). This batch touches production templates, static assets, and (WP-7 only) `routes.py`/`orchestrator.py`; the count may move and each WP records its own validated count. For the current count see SESSION_CONTEXT Section 1.
@@ -297,8 +297,8 @@ kickoff log entry.
 - `orchestrator.py`: stable `reason_code` (release_scope /
   no_spotify_match) stored alongside the prose reason; `routes.py`
   groups on the code, keeps the sentence as per-row detail. Fixes the
-  verified grouping bug; unit tests updated in lockstep (this is where
-  the test count moves). `below_min_plays` / `below_min_tracks` are
+  verified grouping bug; unit tests updated in lockstep (the test count
+  moves again here). `below_min_plays` / `below_min_tracks` are
   deliberately not introduced here: `fetch_top_albums_async` drops
   threshold failures before the pipeline sees them
   (`orchestrator.py:112-116`), so those codes only become producible

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,9 +1,10 @@
 # ScrobbleScope Findings & Open Issues
 
-Last updated: 2026-08-15
+Last updated: 2026-08-20
 Status: Batch 21 (UI overhaul -- Tailwind + daisyUI migration) is ACTIVE;
-WP-0 done; PR #170 merged 2026-08-12, then the F-SWE-1 audit, then WP-1.
-590 tests across 35 test modules.
+WP-0 done. PR #171 merged 2026-08-19 (`bb187ae`). The F-SWE-1 audit ran
+2026-08-20 and blocked WP-1 on F-SWE-2; the owner elected the fix, which
+lands as its own commit before WP-1. 590 tests across 35 test modules.
 
 **Rotation policy:** resolved and no-action findings rotate to
 `docs/history/findings/FINDINGS_ARCHIVE.md` at batch close-out or during
@@ -412,29 +413,16 @@ local verification of album results runs against a shifted window. Fix: add
 on `test_utc_decode_invariant_against_local_tz_drift`.
 
 **Blocks Batch 21 WP-1** under SWE_AUDIT_CHARTER Section 6: a correctness
-defect in `orchestrator.py`, which WP-7 modifies. Fix or waive.
-Status: open (P1). Source: SWE_PRINCIPLES_AUDIT.
+defect in `orchestrator.py`, which WP-7 modifies. The charter offered a fix
+or an owner waiver. **Owner decided 2026-08-20: fix, do not waive.**
 
-### F-SWE-3: a Spotify HTTP error is reported as a missing album
-
-`spotify.py:67-68` returns `(None, None, True)` for every non-200,
-non-429 response. The `True` marks the attempt terminal, so
-`retry_with_semaphore` stops immediately -- verified: a simulated HTTP 500
-returns `None` after 1 of 3 permitted attempts. A genuine empty result
-(`spotify.py:75`) returns the identical value, so the caller cannot tell a
-Spotify outage from an album Spotify does not have.
-
-`orchestrator.py:250-262` then records the album with the reason
-`No Spotify match`, which the unmatched page shows the user as fact.
-`_detect_spotify_total_failure` (`orchestrator.py:671-686`) raises
-`spotify_unavailable` only when *every* album failed, so a partial Spotify
-outage silently drops albums from the results with a wrong explanation.
-
-Filed against `spotify.py` because that is where the distinction is
-discarded; `orchestrator.py` cannot recover information it never receives.
-Read the other way this would block WP-1, so the choice is stated in the
-report rather than left implicit.
-Status: open (P1). Source: SWE_PRINCIPLES_AUDIT.
+The fix is its own commit and lands before WP-1 starts. It is a code change,
+not a docs change, so it moves the test count: two lines in
+`orchestrator.py` plus a regression test modelled on
+`test_utc_decode_invariant_against_local_tz_drift`, which must fail against
+the current naive window before it passes against the fixed one.
+Status: open (P1), owner elected the fix 2026-08-20.
+Source: SWE_PRINCIPLES_AUDIT.
 
 ### F-SWE-4: the production entrypoint never validates API keys
 
@@ -598,6 +586,35 @@ Status: open (P2). Source: MULTI_AGENT_SWEEP.
 
 Cleanup is opportunistic (at job start); TTL mitigates, does not cap.
 Status: open (P2). Source: MULTI_AGENT_SWEEP.
+
+### F-SWE-3: a Spotify server error bypasses the configured retries
+
+`spotify.py:67-68` returns `(None, None, True)` for every non-200, non-429
+response, and `is_done=lambda t: t[2]` treats that `True` as terminal. A 500
+or 503 therefore ends the attempt loop after one try, while
+`SPOTIFY_SEARCH_RETRIES` is set to 3 -- verified by running it. The retries
+only ever fire for 429. `fetch_spotify_album_details_batch` has the same
+shape at `spotify.py:129-132`.
+
+The consequence is narrow: an album that _is_ on Spotify can be recorded as
+unmatched when a second attempt would have found it.
+
+**Rescoped by the owner, 2026-08-20, and the correction is worth keeping.**
+The audit first filed this as a user-facing mislabelling -- `spotify.py:75`
+returns the same value for a genuine empty result, so
+`orchestrator.py:250-262` records the album with the reason
+`No Spotify match`, and the report treated that label as wrong. It is not.
+Thousands of Last.fm-scrobbled albums genuinely have no Spotify release, so
+the label is accurate for the ordinary case and what the user sees is
+correct. What survives is the defect above -- configured retries that never
+run -- which is a smaller thing than the audit claimed. Severity drops from
+P1 to P2 and the finding moved from the P1 section to this one.
+
+The related UI need -- the unmatched modal and page should say plainly that
+an album had no Spotify match -- is already Batch 21 WP-7 scope
+(`BATCH21_DEFINITION.md:297-308`: the `no_spotify_match` reason code and two
+reason cards with human copy). It is not extra work and is not tracked here.
+Status: open (P2). Source: SWE_PRINCIPLES_AUDIT, rescoped by owner review.
 
 ### F-SWE-6: reading a job renews its TTL, so a polled job never expires
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -308,12 +308,23 @@ Status: open. Source: MULTI_AGENT_SWEEP.
 
 No differential check of the ten mandated software principles
 (AGENT_NOTES.md Owner Preferences) has run since the 2026-02 audits.
-`docs/SWE_AUDIT_CHARTER.md` defines scope (Python only until Batch 21
-ships), the do-not-re-report baseline, method, and output contract; any
-dedicated single-purpose agent session (Claude or Codex) can execute it
-cold. Report lands as `docs/history/reports/SWE_PRINCIPLES_AUDIT_<date>.md` with
+`docs/SWE_AUDIT_CHARTER.md` defines the scope, the do-not-re-report
+baseline, the method, and the output contract; any dedicated
+single-purpose agent session (Claude or Codex) can execute it cold.
+
+The charter was amended 2026-08-19, after a preflight review found it could
+not work as the gate its position implies. It now names the 13 graded
+modules explicitly (130 cells), excludes `scripts/docsync/` and
+`scripts/dev/` with stated reasons rather than leaving them ambiguous,
+defines the A/B/C/D rubric and the Boy Scout history window, reads the whole
+finding corpus including the archive instead of a closed ID list, requires a
+provenance block naming the audited SHA, and states which findings block
+Batch 21 WP-1. The permission to cut modules to fit the budget is withdrawn.
+
+Report lands as `docs/history/reports/SWE_PRINCIPLES_AUDIT_<date>.md` with
 net-new findings as F-SWE-2 onward; this entry closes by pointing at the
-report. Status: open (chartered 2026-07-31, execution pending).
+report, and the charter is retired in the same commit.
+Status: open (chartered 2026-07-31, amended 2026-08-19, execution pending).
 Source: owner request 2026-07-31.
 
 ### F-MAS-4: broad `except Exception` catches
@@ -321,6 +332,57 @@ Source: owner request 2026-07-31.
 17 instances across `scrobblescope/*.py` (recounted 2026-07-24; 14 at
 the original sweep); narrow or add structured logging per exception
 class. Status: open. Source: MULTI_AGENT_SWEEP.
+
+### F-STYLE-1: repository prose is denser than it needs to be
+
+The goal is writing that is easier to read, not conformance to a standard.
+ASD-STE100 Simplified Technical English names the target well: short
+sentences, active voice, one idea per sentence, lean docstrings that say what
+a function does and why, and no coined compound terms where a plain phrase
+exists. It is an example of the goal, not a standard this repository adopts.
+
+**This is not a gate and cannot become one.** The ASD-STE100 dictionary is
+licensed and unavailable here, so no agent can check anything against it, and
+no automated check scores prose quality. Declaring it a rule would also
+trigger anti-pattern 11 in `AGENTS.md`, which requires a claim to be applied
+across the corpus in the commit that states it -- a sweep far larger than the
+benefit. Treat this as standing guidance for text you are already editing.
+
+Concrete instance: `AGENTS.md` uses the coined term "blast-radius" in three
+places (currently around lines 254, 262 and 550 -- locate by the term, not
+the number). Later agent sessions copy it from there. Replace it with the
+plain phrase, such as "search the repo for other copies of the same claim",
+when those lines are next edited for another reason.
+Status: open (guidance, never a gate). Source: owner style direction,
+2026-08-19.
+
+### F-STYLE-2: Python style settings disagree, and Ruff is planned but unwritten
+
+Three separate problems that one decision settles.
+
+**Docstring convention.** Measured 2026-08-19 across tracked Python outside
+`tests/` (38 files, via `git ls-files "*.py"` plus an `ast` walk of every
+function, async function and class): 204 definitions, 171 carrying a
+docstring (84%), and 4 using Google sections such as `Args:` or `Returns:`
+(2%). Adopting Google sections everywhere is a 167-definition sweep across
+the documented ones, plus 33 that carry no docstring at all. That size is why
+this is a finding and not a rule. Re-measure before quoting these numbers.
+
+**Line length.** `black` has no `[tool.black]` section in `pyproject.toml`,
+so it wraps at its default 88. `.flake8` sets `max-line-length = 120`.
+Nothing reconciles the two.
+
+**A stale note.** `.flake8` still describes its five ignored codes as
+temporary, for an incremental cleanup that has since finished.
+
+Ruff is the planned replacement for black, isort, autoflake and flake8, as
+part of a CI modernization, and it also settles the line-length
+disagreement -- so do not open that as a separate question. The plan is not
+written down anywhere it would be found: the only tracked traces are
+`.ruff_cache/` in `.dockerignore` and one line in
+`docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`. Defer the sweep; record
+the decision.
+Status: open. Source: root-hygiene side task, 2026-08-19.
 
 ---
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -2,9 +2,9 @@
 
 Last updated: 2026-08-20
 Status: Batch 21 (UI overhaul -- Tailwind + daisyUI migration) is ACTIVE;
-WP-0 done. PR #171 merged 2026-08-19 (`bb187ae`). The F-SWE-1 audit ran
-2026-08-20 and blocked WP-1 on F-SWE-2; the owner elected the fix, which
-lands as its own commit before WP-1. 590 tests across 35 test modules.
+WP-0 done. PR #171 merged 2026-08-19 (`bb187ae`). F-SWE-2 was resolved
+2026-08-20, clearing the F-SWE-1 migration block; WP-1 is next. 591 tests
+across 35 test modules.
 
 **Rotation policy:** resolved and no-action findings rotate to
 `docs/history/findings/FINDINGS_ARCHIVE.md` at batch close-out or during
@@ -146,6 +146,22 @@ The charter was retired in the same commit, per its own output contract.
 Status: resolved 2026-08-20; rotates to the archive at Batch 21 close-out.
 Report at `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md`.
 Source: owner request 2026-07-31.
+
+### F-SWE-2: the album year window is built from naive datetimes
+
+`orchestrator.py:70-71` built the Last.fm fetch window with naive datetimes,
+so `.timestamp()` applied the host's local zone. The same shifted timestamps
+were reused to filter individual scrobbles. On a UTC-5 host, each boundary
+moved five hours into the requested year.
+
+This was the twin of F-B19-6 in `heatmap.py`. The standalone pre-WP-1 fix
+adds explicit UTC to both constructors. A deterministic regression drives
+`fetch_top_albums_async` through a simulated UTC-5 time boundary and asserts
+the literal UTC epochs passed to Last.fm; it failed against the naive window
+before passing against the corrected one.
+
+Status: resolved 2026-08-20; rotates to the archive at Batch 21 close-out.
+Source: SWE_PRINCIPLES_AUDIT.
 
 ---
 
@@ -388,41 +404,6 @@ written down anywhere it would be found: the only tracked traces are
 `docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`. Defer the sweep; record
 the decision.
 Status: open. Source: root-hygiene side task, 2026-08-19.
-
-### F-SWE-2: the album year window is built from naive datetimes
-
-`orchestrator.py:70-71` builds the Last.fm fetch window with naive
-`datetime(year, 1, 1)` and `datetime(year, 12, 31, 23, 59, 59)`, so
-`.timestamp()` applies the local zone of the host and the window shifts by
-that offset. `orchestrator.py:100` reuses those timestamps to filter
-individual scrobbles, applying the shift a second time. Measured on the
-UTC-5 development host, the window starts at 05:00 UTC on 1 January instead
-of 00:00, so five hours of scrobbles land in the wrong year at each
-boundary.
-
-This is the defect F-B19-6 fixed in `heatmap.py`. `git show --stat ccb000f`
-confirms that fix touched `scrobblescope/heatmap.py` and
-`tests/test_heatmap.py` only; `orchestrator.py` was never revisited, and
-`heatmap.py:116-122` has used explicit UTC ever since. `AGENTS.md`
-anti-pattern 6 now registers the naive-timezone pattern repository-wide.
-
-Production is unaffected because the Fly.io container runs UTC. Every
-non-UTC host is affected, including the Windows development machine, so
-local verification of album results runs against a shifted window. Fix: add
-`tzinfo=timezone.utc` to both constructors and pin it with a test modelled
-on `test_utc_decode_invariant_against_local_tz_drift`.
-
-**Blocks Batch 21 WP-1** under SWE_AUDIT_CHARTER Section 6: a correctness
-defect in `orchestrator.py`, which WP-7 modifies. The charter offered a fix
-or an owner waiver. **Owner decided 2026-08-20: fix, do not waive.**
-
-The fix is its own commit and lands before WP-1 starts. It is a code change,
-not a docs change, so it moves the test count: two lines in
-`orchestrator.py` plus a regression test modelled on
-`test_utc_decode_invariant_against_local_tz_drift`, which must fail against
-the current naive window before it passes against the fixed one.
-Status: open (P1), owner elected the fix 2026-08-20.
-Source: SWE_PRINCIPLES_AUDIT.
 
 ### F-SWE-4: the production entrypoint never validates API keys
 

--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -119,6 +119,33 @@ for backward references -- not cruft, do not delete.
 Status: resolved 2026-07-31; rotates to the archive at Batch 21
 close-out. Source: PR #163 doc-hygiene pass.
 
+### F-SWE-1: SWE-principles audit -- executed 2026-08-20
+
+No differential check of the ten mandated software principles
+(AGENT_NOTES.md Owner Preferences) had run since the 2026-02 audits.
+`docs/SWE_AUDIT_CHARTER.md` chartered one on 2026-07-31 and was amended
+2026-08-19, after a preflight review found it could not work as the gate its
+position implies. The amendment named the 13 graded modules explicitly (130
+cells), excluded `scripts/docsync/` and `scripts/dev/` with stated reasons,
+defined the A/B/C/D rubric and the Boy Scout history window, read the whole
+finding corpus including the archive instead of a closed ID list, required a
+provenance block naming the audited SHA, and stated which findings block
+Batch 21 WP-1. The permission to cut modules to fit the budget was withdrawn.
+
+Executed 2026-08-20 against `1994673`, whose runtime code is identical to
+`bb187ae`. All 130 cells filled in one session: 74 A, 28 B, 8 C, 2 D,
+18 N/A. Six net-new findings, F-SWE-2 to F-SWE-7. The weakest principle is
+Fail Fast, holding five of the eight C grades. Mutation testing deleted all
+81 top-level functions in the graded modules one at a time and the suite
+caught every one, so there is no net-new test-vacuity finding. The audit
+returned **migration blocked by F-SWE-2** under charter Section 6, which is
+an owner decision: fix the two lines, or waive.
+
+The charter was retired in the same commit, per its own output contract.
+Status: resolved 2026-08-20; rotates to the archive at Batch 21 close-out.
+Report at `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md`.
+Source: owner request 2026-07-31.
+
 ---
 
 ## P1 -- Next batch candidates
@@ -304,29 +331,6 @@ defect. Compare against the largest peer in the directory when deciding
 whether the split is due.
 Status: open. Source: MULTI_AGENT_SWEEP.
 
-### F-SWE-1: SWE-principles audit chartered, pending execution
-
-No differential check of the ten mandated software principles
-(AGENT_NOTES.md Owner Preferences) has run since the 2026-02 audits.
-`docs/SWE_AUDIT_CHARTER.md` defines the scope, the do-not-re-report
-baseline, the method, and the output contract; any dedicated
-single-purpose agent session (Claude or Codex) can execute it cold.
-
-The charter was amended 2026-08-19, after a preflight review found it could
-not work as the gate its position implies. It now names the 13 graded
-modules explicitly (130 cells), excludes `scripts/docsync/` and
-`scripts/dev/` with stated reasons rather than leaving them ambiguous,
-defines the A/B/C/D rubric and the Boy Scout history window, reads the whole
-finding corpus including the archive instead of a closed ID list, requires a
-provenance block naming the audited SHA, and states which findings block
-Batch 21 WP-1. The permission to cut modules to fit the budget is withdrawn.
-
-Report lands as `docs/history/reports/SWE_PRINCIPLES_AUDIT_<date>.md` with
-net-new findings as F-SWE-2 onward; this entry closes by pointing at the
-report, and the charter is retired in the same commit.
-Status: open (chartered 2026-07-31, amended 2026-08-19, execution pending).
-Source: owner request 2026-07-31.
-
 ### F-MAS-4: broad `except Exception` catches
 
 17 instances across `scrobblescope/*.py` (recounted 2026-07-24; 14 at
@@ -383,6 +387,100 @@ written down anywhere it would be found: the only tracked traces are
 `docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`. Defer the sweep; record
 the decision.
 Status: open. Source: root-hygiene side task, 2026-08-19.
+
+### F-SWE-2: the album year window is built from naive datetimes
+
+`orchestrator.py:70-71` builds the Last.fm fetch window with naive
+`datetime(year, 1, 1)` and `datetime(year, 12, 31, 23, 59, 59)`, so
+`.timestamp()` applies the local zone of the host and the window shifts by
+that offset. `orchestrator.py:100` reuses those timestamps to filter
+individual scrobbles, applying the shift a second time. Measured on the
+UTC-5 development host, the window starts at 05:00 UTC on 1 January instead
+of 00:00, so five hours of scrobbles land in the wrong year at each
+boundary.
+
+This is the defect F-B19-6 fixed in `heatmap.py`. `git show --stat ccb000f`
+confirms that fix touched `scrobblescope/heatmap.py` and
+`tests/test_heatmap.py` only; `orchestrator.py` was never revisited, and
+`heatmap.py:116-122` has used explicit UTC ever since. `AGENTS.md`
+anti-pattern 6 now registers the naive-timezone pattern repository-wide.
+
+Production is unaffected because the Fly.io container runs UTC. Every
+non-UTC host is affected, including the Windows development machine, so
+local verification of album results runs against a shifted window. Fix: add
+`tzinfo=timezone.utc` to both constructors and pin it with a test modelled
+on `test_utc_decode_invariant_against_local_tz_drift`.
+
+**Blocks Batch 21 WP-1** under SWE_AUDIT_CHARTER Section 6: a correctness
+defect in `orchestrator.py`, which WP-7 modifies. Fix or waive.
+Status: open (P1). Source: SWE_PRINCIPLES_AUDIT.
+
+### F-SWE-3: a Spotify HTTP error is reported as a missing album
+
+`spotify.py:67-68` returns `(None, None, True)` for every non-200,
+non-429 response. The `True` marks the attempt terminal, so
+`retry_with_semaphore` stops immediately -- verified: a simulated HTTP 500
+returns `None` after 1 of 3 permitted attempts. A genuine empty result
+(`spotify.py:75`) returns the identical value, so the caller cannot tell a
+Spotify outage from an album Spotify does not have.
+
+`orchestrator.py:250-262` then records the album with the reason
+`No Spotify match`, which the unmatched page shows the user as fact.
+`_detect_spotify_total_failure` (`orchestrator.py:671-686`) raises
+`spotify_unavailable` only when *every* album failed, so a partial Spotify
+outage silently drops albums from the results with a wrong explanation.
+
+Filed against `spotify.py` because that is where the distinction is
+discarded; `orchestrator.py` cannot recover information it never receives.
+Read the other way this would block WP-1, so the choice is stated in the
+report rather than left implicit.
+Status: open (P1). Source: SWE_PRINCIPLES_AUDIT.
+
+### F-SWE-4: the production entrypoint never validates API keys
+
+`config.ensure_api_keys()` (`config.py:37-40`) raises when any of the three
+API keys is missing, and it is called only inside the `__main__` guard at
+`app.py:140-145`. Production starts with `gunicorn app:app`
+(`Dockerfile:15`), which imports the module rather than running it, so the
+check never fires. Verified: with all three keys unset, `import app`
+succeeds and serves, while `ensure_api_keys()` would have raised.
+
+The same file gets the neighbouring case right. `_validate_secret_key` is
+called from `create_app()` (`app.py:111`) and refuses to start in
+production. One secret is checked at startup and three are not.
+
+`spotify.py:26-27` is the only remaining guard for two of them, and it uses
+`assert`, which `python -O` strips. Without the startup check a missing key
+surfaces as a per-request failure, classified as an upstream outage.
+
+Fix: call `ensure_api_keys()` from `create_app()`. One line, and it closes
+two C cells in the audit matrix.
+Status: open (P1). Source: SWE_PRINCIPLES_AUDIT.
+
+### F-SWE-5: the two background entry points disagree about terminal job state
+
+`heatmap_task` and `background_task` answer the same question two different
+ways, and both answers are wrong.
+
+`heatmap.py:218-221` catches every exception and reports
+`lastfm_unavailable`. `_fetch_and_process_heatmap` has no inner handler, so
+this is the only handler on the path and it fires for any failure at all.
+Verified: a `ZeroDivisionError` raised inside the aggregation step reaches
+the user as a Last.fm outage message, with `error_source: lastfm` and
+`retryable: True`. The app blames a third party for its own bug and invites
+a retry that will fail the same way.
+
+`orchestrator.py:912-913` has the mirror-image gap: it logs and sets no job
+state, so the job never reaches progress 100 and the loading page polls
+forever. This half needs the inner handler at `orchestrator.py:851` to fail
+first, which nothing observed can cause, so the finding is recorded rather
+than treated as blocking. F-SWE-6 compounds it -- a polled job never
+expires.
+
+Fix: give each entry point a terminal state that names what actually
+failed, using an `ERROR_CODES` entry for an unclassified internal error
+rather than borrowing an upstream one.
+Status: open (P1). Source: SWE_PRINCIPLES_AUDIT.
 
 ---
 
@@ -500,6 +598,44 @@ Status: open (P2). Source: MULTI_AGENT_SWEEP.
 
 Cleanup is opportunistic (at job start); TTL mitigates, does not cap.
 Status: open (P2). Source: MULTI_AGENT_SWEEP.
+
+### F-SWE-6: reading a job renews its TTL, so a polled job never expires
+
+`get_job_progress`, `get_job_unmatched` and `get_job_context` each write
+`updated_at` (`repositories.py:163`, `:175`, `:199`) while their docstrings
+promise only to return a copy. `cleanup_expired_jobs` reaps on that same
+field, so every `/progress` poll renews the lease.
+
+Verified: a job backdated to three hours old, against a two-hour
+`JOB_TTL_SECONDS`, survives `cleanup_expired_jobs` after a single read,
+while an identical job that was never read is reaped. A browser sitting on
+the loading page therefore keeps its `JOBS` entry alive indefinitely, which
+matters most for a job whose thread died without setting a terminal state
+(F-SWE-5).
+
+Touch-on-access may well be intended -- results should not vanish while a
+user is reading them. Nothing says so. Either document the side effect in
+the three docstrings and in the `JOB_TTL_SECONDS` comment, or stop writing
+from a getter and refresh the lease explicitly where it is wanted.
+Status: open (P2). Source: SWE_PRINCIPLES_AUDIT.
+
+### F-SWE-7: utils.py holds five unrelated concerns
+
+One 346-line module carries API rate limiting (`utils.py:29-121`), aiohttp
+session construction (`:155-188`), an in-memory response cache
+(`:192-242`), duration formatting for display (`:245-283`) and a generic
+async retry loop (`:286-346`). Nothing binds them together except the file
+name, and `utils` is the name that accretes.
+
+Each function is individually clean, which is why SRP grades B while SoC
+grades C. The cost is discoverability: the response cache that F-MAS-8
+tracks lives in the same file as `format_seconds`, and a reader looking for
+either has no reason to look here.
+
+A split into rate limiting, HTTP and caching, and formatting is a sibling
+of the F-B20-2 orchestrator decomposition and belongs in the same batch as
+it, not before Batch 21.
+Status: open (P2). Source: SWE_PRINCIPLES_AUDIT.
 
 ---
 

--- a/HANDOFF_PROMPT.md
+++ b/HANDOFF_PROMPT.md
@@ -4,14 +4,16 @@ You are continuing work on ScrobbleScope. Follow the comment-job fast-paths
 in `AGENTS.md` (Session Bootstrap) when the task is a PR comment or
 review-comment fix. Otherwise bootstrap first.
 
+Every rule lives in `AGENTS.md`: the canonical read order, document roles,
+token discipline, the sufficiency gate, bootstrap-conflict handling, the
+validation gates, commit discipline, side-task handling, and the
+Anti-Pattern Registry. Follow them there; this file restates none of them.
+It carries only the two things that belong to no other file -- the check
+that repository reality matches the documents, and the handoff checklist.
+
 ---
 
-## 1) Bootstrap
-
-The canonical read order, document roles, token discipline, sufficiency
-gate, and bootstrap-conflict handling are defined once in `AGENTS.md`
-("Document Roles" and "Session Bootstrap") -- follow them exactly; they
-are not restated here.
+## Bootstrap verification
 
 After reading the bootstrap files, complete the canonical worktree gate in
 `AGENTS.md` ("Session Bootstrap"), then retain this human-readable evidence
@@ -29,29 +31,7 @@ before doing any work.
 
 ---
 
-## 2) Validation gates (run before every commit)
-
-Owned by `AGENTS.md` (Commit Rules "Procedure before every commit", and
-Doc Sync Rules for the `--fix` step). Do not restate or re-derive them
-here -- read them there.
-
----
-
-## 3) Commit discipline
-
-Owned by `AGENTS.md` (Commit Rules and Side-Task Handling). Do not restate
-or re-derive it here -- read it there.
-
----
-
-## 4) Anti-patterns
-
-Owned by `AGENTS.md` (Anti-Pattern Registry). Check your work against that
-list before every commit.
-
----
-
-## 5) Handoff when you are done or interrupted
+## Handoff when you are done or interrupted
 
 Documentation lands *in* the commit, not after it: the documentation step
 of AGENTS.md Commit Rules, plus "Missing log entries" in the Anti-Pattern

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -82,17 +82,13 @@ See FINDINGS F-DOCSYNC-3.
   page-by-page strangler migration. Expanded from the owner's Claude
   Design audit (UI Audit v3); four owner decisions locked in the
   definition. Branch: `wip/batch-21` (worktree off `main`).
-- **Next action:** apply the F-SWE-2 fix, then Batch 21 WP-1. The F-SWE-1
-  audit ran 2026-08-20 and returned **migration blocked by F-SWE-2** -- see
-  `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md` and the Section 4
-  entry of the same date. Charter Section 6 offered a fix or an owner waiver;
-  **the owner elected the fix on 2026-08-20.** It is a code change, not a
-  docs change, so it ships as its own commit before WP-1 and moves the test
-  count: add `tzinfo=timezone.utc` to both constructors at
-  `orchestrator.py:70-71`, plus a regression test modelled on
-  `test_utc_decode_invariant_against_local_tz_drift` that must fail against
-  the naive window before it passes against the fixed one. Nothing else in
-  the audit blocks; the other five net-new findings are record-and-continue.
+- **Next action:** Batch 21 WP-1. **F-SWE-2 was resolved 2026-08-20** in its
+  owner-approved standalone prerequisite commit: both album-year boundary
+  constructors now use explicit UTC, and a deterministic UTC-5 regression
+  pins the Last.fm request window. This clears the F-SWE-1 migration block;
+  see `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md` and the
+  Section 4 entry of the same date. Nothing else in the audit blocks; the
+  other five net-new findings are record-and-continue.
   `docs/SWE_AUDIT_CHARTER.md` is retired and kept only as the record of what
   the audit was asked to do.
   Earlier context, still true: **PR #171 merged to `main` on 2026-08-19**
@@ -171,6 +167,44 @@ non-current operational logs. Older dated entries live in
   daisyUI v5 bundled plugin, defines both themes from the audit token
   sheet, and commits the compiled CSS. No template changes until WP-2.
 
+### 2026-08-20 - F-SWE-2 UTC album-year window fixed (Batch 21 WP-0)
+
+- Scope: cleared the only F-SWE-1 migration blocker in the standalone
+  prerequisite after WP-0 and before WP-1. No Tailwind or WP-1 work started.
+- Plan vs implementation: as planned. `orchestrator.py` now imports
+  `timezone` and passes `tzinfo=timezone.utc` to both listening-year boundary
+  constructors. The regression drives the public `fetch_top_albums_async`
+  workflow, simulates UTC-5 semantics only for naive constructors, and checks
+  the literal UTC epoch values sent to the mocked Last.fm boundary. Existing
+  mock track fixtures now construct their UTS values in explicit UTC too.
+- TDD red evidence: before the production fix,
+  `pytest -q tests/services/test_lastfm_logic.py::test_fetch_top_albums_uses_utc_year_window_on_non_utc_host`
+  failed twice with the same boundary shift:
+
+  ```text
+  AssertionError: expected await not found.
+  Expected: mock('testuser', 1704067200, 1735689599, progress_cb=None)
+    Actual: mock('testuser', 1704085200, 1735707599, progress_cb=None)
+  ```
+
+  After the fix, the targeted test passed, and the complete test module passed
+  with 8 tests.
+- Deviations: no implementation deviation. Pre-push whole-file review corrected
+  the README test badge and module inventory plus two forward-looking WP-7
+  claims that still described WP-7 as the first test-count change. The same-day
+  docsync source order gives live side-task entries precedence over
+  current-batch entries, so the document-map entry below carries a later-count
+  addendum that points back to this entry. Its original 590-test completion
+  result stays unchanged.
+  F-SWE-3 remains P2, F-B21-1 remains P1 without blocking WP-1, and root
+  hygiene remains deferred until after WP-1.
+- Validation: `pytest -q` -- **591 passed**, 3 warnings.
+  `pre-commit run --all-files` -- all hooks pass; all tracked Markdown hashes
+  match before and after the hook. `doc_state_sync.py --check` -- exit 0 with
+  the expected active-root `BATCH21_DEFINITION.md` warning.
+- Forward guidance: F-SWE-2 is resolved. WP-1 is next; pause for owner review
+  of this commit before starting it.
+
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
 ### 2026-08-20 - Agent document map added; HANDOFF_PROMPT trimmed (side-task)
@@ -232,6 +266,11 @@ non-current operational logs. Older dated entries live in
   that hook has twice reverted files nobody edited, once into a commit.
 - Forward guidance: unchanged. The F-SWE-2 fix is still the next action. It
   is a code commit and it moves the test count off 590.
+- **Later same-day test-count addendum:** the F-SWE-2 current-batch entry above
+  records the subsequent code change and owns its implementation details. Its
+  full-suite result was `pytest -q` -- **591 passed**. The earlier 590 result
+  in this entry remains point-in-time evidence; this pointer supplies the
+  later same-date count to docsync's live-side-first authority order.
 
 ### 2026-08-20 - F-SWE-1 SWE principles audit executed (side-task)
 

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -82,19 +82,29 @@ See FINDINGS F-DOCSYNC-3.
   page-by-page strangler migration. Expanded from the owner's Claude
   Design audit (UI Audit v3); four owner decisions locked in the
   definition. Branch: `wip/batch-21` (worktree off `main`).
-- **Next action:** execute the full F-SWE-1 principles audit, then proceed to
-  Batch 21 WP-1. PR #169 merged to `main` on 2026-08-08 and the Quality Gate
-  is green for `5bc6294`, so the canonical repository-integrity gate and
-  read-only worktree guard are shipped and
-  F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2 are resolved. Three guard files
-  exceed their directory peer caps after review remediation -- accepted as a
-  deviation and tracked as F-WORKTREE-4 in FINDINGS.md, not silently. Review
-  remediation ran to round 6: rounds 2 through 5 landed before the merge, and
-  round 6 was reviewed after the final push, so its four findings reached
-  `main` unaddressed. **PR #170 remediated them and merged 2026-08-12**
-  (`5b060a2`), so the guard and docsync sources the audit reads are settled.
-  Three of its review threads remain open, two of them independent reports of
-  F-WORKTREE-5.
+- **Next action:** apply the F-SWE-2 fix, then Batch 21 WP-1. The F-SWE-1
+  audit ran 2026-08-20 and returned **migration blocked by F-SWE-2** -- see
+  `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md` and the Section 4
+  entry of the same date. Charter Section 6 offered a fix or an owner waiver;
+  **the owner elected the fix on 2026-08-20.** It is a code change, not a
+  docs change, so it ships as its own commit before WP-1 and moves the test
+  count: add `tzinfo=timezone.utc` to both constructors at
+  `orchestrator.py:70-71`, plus a regression test modelled on
+  `test_utc_decode_invariant_against_local_tz_drift` that must fail against
+  the naive window before it passes against the fixed one. Nothing else in
+  the audit blocks; the other five net-new findings are record-and-continue.
+  `docs/SWE_AUDIT_CHARTER.md` is retired and kept only as the record of what
+  the audit was asked to do.
+  Earlier context, still true: **PR #171 merged to `main` on 2026-08-19**
+  (`bb187ae`, rebase merge) with zero unresolved review threads after eight
+  rounds; `wip/batch-21` was realigned to it. `BATCH21_DEFINITION.md` was
+  amended the same day so the batch gate can fail on frontend work.
+  PR #169 merged 2026-08-08 shipping the
+  repository-integrity gate and read-only worktree guard, resolving
+  F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2; three guard files exceed their
+  directory peer caps, accepted as a deviation and tracked as F-WORKTREE-4,
+  not silently. PR #170 merged 2026-08-12 (`5b060a2`), settling the guard and
+  docsync sources the audit reads.
 - Batch 21 WP status: WP-0 done. WP-1 through WP-8 not yet started.
 - **Perf note:** heatmap fetch speed is rate-limit bound; measurement and
   rationale live in FINDINGS.md F-B18-11 (single source).
@@ -163,164 +173,233 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
-### 2026-08-15 - PR #171 round-6 threads fixed and all five diagrams audited (side-task)
+### 2026-08-20 - F-SWE-1 SWE principles audit executed (side-task)
 
-- Scope: the two unresolved Codex threads on `00c0adb`, both on the Top Albums
-  sequence. A prior GLM-5.2 session had left uncommitted diagram edits and a
-  list of findings, then stopped before it finished. I checked the two threads
-  and every edit that session made against the code, then audited all five
-  diagrams with three independent verification agents.
-- Verification of the two threads: both are correct. `fetch_top_albums_async`
-  groups, normalizes, and thresholds the albums before it returns
-  (`orchestrator.py:112-116`), so all of that runs before the empty-result
-  check at `orchestrator.py:784`. `process_albums` writes to the cache only
-  under `if conn and new_metadata_rows` (`orchestrator.py:591`).
-- Verification of the prior session: three of its six edits were wrong. It put
-  the hit/miss partition inside the DB-connected branch, but the code
-  partitions with or without a connection (`orchestrator.py:567`). It drew
-  `cleanup_expired_cache()` as a call to `repositories.py`, but that helper
-  comes from `utils.py` (`orchestrator.py:40`). It put the total Spotify match
-  failure after the store step, but the check runs first
-  (`orchestrator.py:824` before `orchestrator.py:842`).
-- Plan vs implementation:
-  - Top Albums sequence: rewrote the background-task block and the browser
-    block. Grouping now sits before every downstream branch. Persistence is
-    conditional and records `db_cache_persisted`. The partition sits outside
-    the DB branch. New: the connection close and its `finally` ordering
-    against `SpotifyUnavailableError`, the `get_job_context` read behind the
-    total-match-failure check, the six `results_complete` outcomes, the
-    `/progress` 404, and the two unhandled-exception states.
-  - Heatmap sequence: added the housekeeping calls, the page-count stats, the
-    5% and 80% progress writes, and the unhandled-exception path. Rebuilt the
-    render block: the client requests `/heatmap_data` only at 100%, so the 202
-    is a narrow race that restarts polling, not a peer alternative.
-  - Development cycle: split the merged fast path so the actionability stop
-    applies to comment jobs only, added the push-authorization gate that
-    `AGENTS.md` requires between commit and PR, and dropped the E2E claim that
-    no rule file makes.
-  - Runtime diagram and `docs/ARCHITECTURE.md`: named the eight nodes that
-    import `config.py`, corrected the arrow-semantics paragraph, and repointed
-    the module-graph reference to SESSION_CONTEXT Section 4 alone.
-  - Both structural diagrams passed their audit with no change to the graphs.
-- Deviations: the prior session said the fix needed a full rewrite of the
-  parallel block. It did not. The corrections are local, but they reach more
-  branches than that session touched. The audit also found a real code gap and
-  it is recorded as F-B21-1 rather than fixed here: `background_task` and
-  `heatmap_task` build the event loop outside the `try`, so a failure there
-  leaks a job slot. No production code changed in this commit.
-- Validation: all four changed diagrams pass Mermaid validation, checked
-  against the exact text now in the files. `pytest -q` -- **590 passed**, 3
-  known warnings. `pre-commit run --all-files` -- all hooks pass.
-  `doc_state_sync.py --check` -- exit 0 with the expected active-root
-  `BATCH21_DEFINITION.md` warning.
-- Forward guidance: push, then reply to the two threads and resolve them.
-  PR #171 stays open until the owner says otherwise.
-
-### 2026-08-15 - PR #171 round-5 review threads remediated (side-task)
-
-- Scope: three new Codex threads on `37ca4a9` -- one on the development-cycle
-  diagram and two on the Top Albums sequence. All three were verified against
-  the code before any edit and all three were valid.
-- Verification:
-  - `AGENTS.md` L29-44 defines the review-comment fast path (fetch the thread
-    first, stop if not actionable, else read only the scoped files), but the
-    development-cycle diagram routed every review finding through the full
-    bootstrap gates. The diagram and the rules it documents were written in
-    the same PR and disagreed.
-  - `_fetch_and_process()` stores an empty result, marks progress 100%, and
-    returns before pre-slicing, cache access, or Spotify enrichment when
-    `filtered_albums` is empty. The Top Albums sequence sent every successful
-    page fetch into those stages.
-  - `process_albums()` catches `_batch_lookup_metadata()` exceptions, records
-    `db_cache_warning`, treats every album as a miss, and continues to Spotify
-    (possibly persisting via the open connection). The diagram's connected
-    path presented lookup as unconditional and its unavailable path said
-    persistence was skipped.
-- Plan vs implementation: the development-cycle diagram now branches on
-  review-finding/comment-job before full bootstrap (fetch thread, stop if not
-  actionable, else read scoped files); the Top Albums sequence now stops after
-  an empty filtered set and adds a fail-open cache-lookup-error continuation.
-- Deviations: none. No production behavior changed and no tests were added;
-  existing tests already cover the empty-filtered-set and fail-open lookup
-  paths.
-- Validation: both updated diagrams pass Mermaid validation and open in
-  preview. `pytest -q` -- **590 passed**, 3 known warnings. `pre-commit run
-  --all-files` -- all hooks pass. `doc_state_sync.py --check` -- exit 0 with
-  the expected active-root `BATCH21_DEFINITION.md` warning.
-- Forward guidance: commit and push this remediation, then resolve the three
-  threads. PR #171 remains unmerged pending separate owner instruction.
-
-### 2026-08-15 - PR #171 final four review threads remediated (side-task)
-
-- Scope: the four remaining unresolved review threads on `e73540d` -- two
-  Codex path-repointing reports and two Codex Top Albums sequence reports.
-  All four were verified against the code and the moved files before any
-  edit and all four were valid.
-- Verification:
-  - `docs/superpowers/plans/2026-08-11-pr-170-remediation.md` still cited
-    `docs/history/GUARD_HARDENING_2026-08-11.md` and
-    `docs/history/REPOSITORY_SYNTHESIS_2026-08-11.md`, both moved to
-    `docs/history/reports/` by commit `5865c55`. The links resolved to
-    nonexistent files.
-  - `docs/history/definitions/BATCH9_DEFINITION.md` pointed twice to
-    `docs/history/BATCH9_AUDIT_REMEDIATION_PLAN_2026-02-20.md`, and
-    `BATCH10_DEFINITION_2026-02-21.md` pointed to the old
-    `docs/history/ROUTES_SOC_AUDIT_2026-02-21.md` and
-    `docs/history/TEST_QUALITY_AUDIT_2026-02-21.md` paths. All three reports
-    now live under `docs/history/reports/`. These are definition-to-report
-    references, not exempt point-in-time citations, so they must be repointed.
-  - `_fetch_and_process()` returns immediately after `set_job_error` when
-    `fetch_metadata["status"] == "error"`, while a `partial` status records
-    `partial_data_warning` and continues. The diagram drew an unconditional
-    transition from page fetching into grouping.
-  - `_fetch_spotify_misses()` raises `SpotifyUnavailableError` when token
-    acquisition fails with no cache hits, caught in `_fetch_and_process` as
-    `set_job_error("spotify_unavailable"); return []` -- no merge or store.
-    The diagram's no-cache-hits branch rejoined the unconditional merge/store
-    steps.
-- Plan vs implementation: repointed the four report paths in the remediation
-  plan and the two batch definitions; the Top Albums sequence now branches on
-  Last.fm status (terminal error vs partial-success-with-warning) and
-  terminates after the no-cache-hits token failure while retaining the
-  cached-success continuation.
-- Deviations: none. No production behavior changed and no tests were added;
-  existing tests already cover the Last.fm error/partial paths and the
-  no-cache-hits token failure.
-- Validation: the updated diagram passes Mermaid validation and opens in
-  preview. `pytest -q` -- **590 passed**, 3 known warnings. `pre-commit run
-  --all-files` -- all hooks pass. `doc_state_sync.py --check` -- exit 0 with
-  the expected active-root `BATCH21_DEFINITION.md` warning.
-- Forward guidance: commit and push this final remediation, then resolve the
-  four threads. PR #171 remains unmerged pending separate owner instruction.
-
-### 2026-08-15 - PR #171 final two Codex threads remediated (side-task)
-
-- Scope: the two remaining unresolved Codex threads on `3508c48`, both on the
-  Top Albums sequence diagram. Both were verified against the code before any
-  edit and both were valid.
-- Verification:
-  - `_get_db_connection()` returns `None` when `DATABASE_URL` is unset,
-    asyncpg is unavailable, or connection attempts fail; `process_albums`
-    then sets a `db_cache_warning` stat and skips lookup, cleanup, and
-    persistence, so every album becomes a miss. The diagram presented those
-    three cache operations as unconditional.
-  - `_fetch_spotify_misses()` sets `partial_data_warning` and returns without
-    searching when Spotify token acquisition fails and cache hits exist, so
-    the pipeline completes successfully with cached albums only; it raises
-    `SpotifyUnavailableError` only when no cache hits exist. The diagram sent
-    every miss through search and grouped the token failure with the terminal
-    path.
-- Plan vs implementation: the Top Albums sequence now branches on DB
-  availability before the cache lookup and branches the Spotify token-fetch
-  failure into a success-with-warning path (cached albums only) versus the
-  terminal `spotify_unavailable` path.
-- Deviations: none. No production behavior changed and no tests were added;
-  existing tests already cover the DB-disabled fallback and the partial-cache
-  continuation.
-- Validation: the updated diagram passes Mermaid validation and opens in
-  preview; the tracked block exactly matches its ignored `.mmd` source.
-  `pytest -q` -- **590 passed**, 3 known warnings. `pre-commit run --all-files`
-  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0 with the expected
+- Scope: executed `docs/SWE_AUDIT_CHARTER.md` against `1994673`, whose
+  runtime code is byte-identical to `main` at `bb187ae` -- the five commits
+  between them are documentation only. Read-only audit; all 130 cells
+  (13 graded modules x 10 principles) filled in one session. Report:
+  `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md`.
+- **Verdict: migration blocked by F-SWE-2**, per charter Section 6 -- a
+  net-new correctness defect in `orchestrator.py`, which WP-7 modifies.
+  `orchestrator.py:70-71` builds the listening-year window from naive
+  datetimes, so the window shifts by the local offset of the host: measured
+  at five hours on this machine. It is the same defect F-B19-6 fixed in
+  `heatmap.py`; `git show --stat ccb000f` confirms that fix touched heatmap
+  and its tests only, and the twin was never revisited. Production is
+  unaffected because the Fly.io container runs UTC. Every non-UTC host is
+  affected, including local dev, so local checks of album results have been
+  running against a shifted window.
+- **Owner decisions, same day.** F-SWE-2: fix, do not waive -- it lands as
+  its own commit before WP-1 and moves the test count. F-SWE-3: rescoped
+  from P1 to P2, and the audit was partly wrong. It filed the
+  `No Spotify match` reason as a user-facing mislabelling; that framing does
+  not hold, because thousands of Last.fm-scrobbled albums genuinely have no
+  Spotify release, so the label is accurate for the ordinary case. What
+  survives is narrower and independent of labelling: `spotify.py:67-68`
+  marks every non-200, non-429 response terminal, so a 500 ends the attempt
+  loop after one try while `SPOTIFY_SEARCH_RETRIES` is 3. The related UI
+  need -- the unmatched modal and page should say plainly that an album had
+  no Spotify match -- is already WP-7 scope
+  (`BATCH21_DEFINITION.md:297-308`), not new work.
+- Grades: 74 A, 28 B, 8 C, 2 D, 18 N/A. The weakest principle is Fail Fast,
+  holding five of the eight C grades and only two A grades across 13
+  modules. The failures share one shape: the code catches a problem and
+  discards what the problem was.
+- Six net-new findings, F-SWE-2 to F-SWE-7. Every one of the ten C and D
+  cells carries a disposition; two map to open F-B20-2 rather than becoming
+  new entries. Each finding was verified by running the code, not by reading
+  it -- the TTL renewal, the Spotify retry bypass, the unreachable API-key
+  check and the heatmap misattribution were each reproduced.
+- Test vacuity: measured, not judged. Each of the 81 top-level functions in
+  the graded modules was replaced in turn with a raise, in a copy of the
+  tree outside the repository, and the 237 runtime tests were run against
+  each mutation. Every deletion was caught, so there is no vacuity finding.
+- Broad catches: all 17 were read in context and judged, which F-MAS-4 never
+  did. Fifteen are justified. The two that are not are both in F-SWE-5, and
+  both are catches that report a cause they never established.
+- F-B21-1 keeps its recorded P1 disposition. The gate covers net-new
+  findings only, so the audit did not re-triage it and it does not block
+  WP-1.
+- Deviations: F-SWE-1 moved from the P1 section to Resolved this batch, and
+  F-SWE-3 from P1 to P2 -- the charter asked for neither move, but leaving
+  either where it was would have made the section heading false.
+- **Tooling hazard hit twice, worth recording.** `pre-commit run --all-files`
+  stashes unstaged changes and restores them afterwards. That cycle reverted
+  files nobody had edited: first `docs/architecture/development-cycle.md`
+  and `top-albums-sequence.md` back to a pre-PR-#171 state, then `PLAYBOOK.md`
+  itself back to a pre-PR-#170 state, dropping this very entry. Every hook
+  reported `Passed`. The first was caught at staging because AGENTS.md
+  requires staging by name; the second reached commit `a34c57f` and was
+  repaired in the follow-up commit. Check `git status` before and against
+  after every `--all-files` run, and compare file mtimes against the files
+  you actually edited.
+- Validation: `pytest -q` -- 590 passed, unchanged, as expected for a
+  docs-only change. `pre-commit run --all-files` and
+  `doc_state_sync.py --check` both pass, the latter with the expected
   active-root `BATCH21_DEFINITION.md` warning.
-- Forward guidance: commit and push this final remediation, then resolve both
-  threads. PR #171 remains unmerged pending separate owner instruction.
+- Forward guidance: apply the F-SWE-2 fix as its own commit, then WP-1. Root
+  hygiene stays deferred until after WP-1.
+
+### 2026-08-19 - Batch 21 preflight: F-SWE-1 charter and WP gates amended (side-task)
+
+- Scope: owner preflight review before WP-1, raised as six criticisms of
+  `docs/SWE_AUDIT_CHARTER.md` and an eight-row table of weak WP gates. Two
+  verification agents checked every claim against the files before any edit.
+  All six charter criticisms held. Two of the batch claims did not.
+- Verification of the owner report:
+  - Confirmed: the charter named five docsync modules when the directory has
+    seven (`integrity.py`, 474 lines, unnamed) and its LOC figure was stale
+    for the five it did name; the differential baseline was a closed ID list
+    omitting F-B21-1, F-DATA-1, F-WORKTREE-3/4/5, F-DOCSYNC-6/7 and never
+    referenced `FINDINGS_ARCHIVE.md`; A/B/C/D was defined nowhere in the
+    repository; the matrix was 190-210 cells with explicit permission to cut
+    modules; no severity or stop condition existed anywhere, so finishing the
+    audit was the same as passing it; and the post-Batch-21 frontend audit
+    was permissive ("can"), not required.
+  - Corrected: the excluded set is a proper subset of what Batch 21 rewrites,
+    not equal to it -- WP-7 modifies `routes.py` and `orchestrator.py`, which
+    are in scope, so those grades also expire at WP-7. The charter never
+    addressed that; it now does.
+  - Refuted: the claimed AGENT_NOTES-versus-definition contradiction over the
+    drift hook. `AGENT_NOTES.md` requires the CI-fetch *decision* at WP-1;
+    the definition deferred the *hook* to WP-8. Both could hold. The real
+    defect was quieter -- no WP-1 criterion required the decision to be
+    recorded, so nothing enforced it.
+- Root cause neither side had named: the batch validation gate is three
+  Python commands, and pre-commit excludes `static/` and `templates/`. A work
+  package could rewrite every template and stylesheet with a fully green
+  gate, in a batch that is nothing but template and stylesheet rewriting.
+- Plan vs implementation:
+  - Charter: 13 graded modules enumerated by name (130 cells, `__init__.py`
+    excluded by a stated empty-module rule); docsync and `scripts/dev/`
+    excluded with reasons rather than left ambiguous; provenance block
+    naming branch, SHA and clean state; symbol-based hotspot discovery
+    replacing hardcoded line numbers and counts; baseline widened to the
+    whole finding corpus plus the archive and every report from 2026-02 on;
+    A/B/C/D rubric with the B/C line defined as exception-versus-pattern;
+    Boy Scout window fixed at commits since the February audits; a
+    resolved-finding branch for C/D cells; a migration-blocking severity
+    policy with a one-line verdict required in the report; an instruction to
+    retire the charter at close. The budget escape hatch is withdrawn.
+  - Batch 21: new `scripts/dev/frontend_gate.py` added as a fourth gate
+    command at WP-2 and grown one page per WP, covering stylesheet
+    isolation, computed theme tokens in both themes, theme persistence,
+    self-hosted font loading, CSV/JPEG export assertions, and headline
+    wrapping. The `tailwind-css-drift` hook moved from WP-8 to WP-2, with
+    the `always_run` / `pass_filenames` requirement that AGENT_NOTES gap 2
+    had already identified and the definition had not carried. Targeted
+    criteria added to WP-3 (keyboard and touch reachability for the CSS-only
+    hints, label associations, validation parity), WP-4 (both state machines
+    including retryable and non-retryable failures), WP-7 (split into a
+    backend contract commit and a UI commit), and WP-8 (required frontend
+    and accessibility audit, deterministic Bootstrap-removal grep, recorded
+    lint disposition). Browser floor documented; `.dark-mode` retirement
+    given an owner; criterion 9 reconciled with the per-WP docsync check.
+  - FINDINGS.md: F-STYLE-1 (prose legibility, explicitly never a gate) and
+    F-STYLE-2 (docstring convention, the black/flake8 line-length
+    disagreement, and the unwritten Ruff plan) added. F-SWE-1 corrected --
+    it claimed the charter scoped "Python only until Batch 21 ships", a
+    commitment the charter never made.
+  - AGENTS.md: the F-ID source-tag list named five tags while nine are in
+    use. `SWE`, `WORKTREE`, `DATA` and `STYLE` added, and the list is now
+    declared complete so the next coined tag gets documented.
+- Deviations: the drift hook landed at WP-2 rather than the WP-1 the owner
+  proposed. WP-1 changes no template, so nothing consumes the compiled CSS
+  until WP-2; WP-2 is the first point where drift can ship.
+- Independent review of the amended charter, same day, and the fixes it drove:
+  - The migration gate did not say whether it covered existing findings. Read
+    the wide way, F-B21-1 blocks WP-1 today -- a resource-release defect in
+    `orchestrator.py`, which WP-7 modifies. The gate is now scoped to net-new
+    findings in terms, F-B21-1 is named as the case that forces the
+    distinction, and an audit that thinks an existing finding should block
+    must recommend rather than act.
+  - The A/B/C/D rubric graded by frequency ("one place is B, several is C")
+    while its own table graded by cost. One leak can be C; five contained
+    exceptions can stay B. Rewritten to grade cost, not count. The
+    "when torn, over-raise" instruction is deleted -- it contradicted
+    Section 4's rule that the audit's value is not volume.
+  - Resolved and no-action findings shared one rule. Split: a recurred
+    resolved defect earns a new finding; an unchanged no-action rationale
+    does not; materially changed assumptions do, explaining the delta.
+  - Provenance permitted grading a dirty tree, which no SHA can reproduce.
+    A clean worktree is now required before grading starts.
+  - The hotspot command was `awk '...{...}'` -- a placeholder that could not
+    run, and a poor Python parser besides. Replaced with a tested `ast`
+    script in a new Section 5c, deliberately at the left margin: a heredoc
+    terminator indented inside the numbered list fails with
+    `IndentationError`, which was verified rather than assumed.
+  - Boy Scout used `git log`, which lists commits without showing what they
+    left behind. Now `git log -p`, with an instruction to read the patches.
+  - "Weakest principle repo-wide" overclaimed: the audit excludes the
+    frontend, both script directories, and tests as graded subjects. Scoped
+    to the audited runtime modules.
+  - Cell arithmetic hardcoded 130 in three places while Section 3 allowed the
+    principle count to change. All three now derive from the live count.
+  - One review point was stale, not wrong: the claim that WP-8 defines no
+    frontend principles audit. It does, in this commit's parent -- the
+    reviewer was reading `origin/main`, because the amendment is committed
+    locally and deliberately unpushed.
+- Validation: `pytest -q` -- **590 passed**. `pre-commit run --all-files` --
+  all hooks pass. `doc_state_sync.py --check` -- exit 0 with the expected
+  root BATCH warning.
+- Forward guidance: execute the amended charter against current `main` and
+  publish the migration verdict before WP-1 starts. The verified root-hygiene
+  plan (audience banners, README tree, DEPLOY.md) is deferred until after
+  WP-1 by owner decision; its line numbers will need re-checking.
+
+### 2026-08-19 - PR #171 round-8 thread fixed: push authorization in the cycle diagram (side-task)
+
+- Scope: one unresolved Codex thread on `docs/architecture/development-cycle.md`,
+  raised again by an owner-side human peer on the grounds that this diagram
+  purports to govern agents. Checked against the ruleset before editing. Valid.
+- Verification: the diagram had a single unconditional edge,
+  `Authorize -->|Review-fix commit on an open PR| PR`. `AGENTS.md:234-242`
+  grants that standing exception to Claude Code and Codex sessions only and
+  says in terms that it does not extend to GitHub Copilot task sessions or
+  their subagents, Jules, or any other agent. An agent reading the canonical
+  diagram would therefore push a review-fix commit that the ruleset requires
+  it to pause on.
+- Plan vs implementation: the decision node now carries three edges instead of
+  two. WP and batch commits pause in any session; the direct path is labelled
+  Claude Code or Codex only; every other agent routes to the same pause. Added
+  prose naming `AGENTS.md` as the owner of the rule, and recording the three
+  actions that always need explicit instruction whatever the session --
+  force-pushes, history rewrites, and anything targeting `main` -- plus the
+  Copilot platform-tool requirement at `AGENTS.md:243-244`, neither of which
+  the diagram had carried.
+- Deviations: none. No code changed.
+- Validation: the edited diagram was validated before it was written --
+  `valid = true`, type `flowchart`. `pytest -q` -- **590 passed**.
+  `doc_state_sync.py --check` -- exit 0 with the expected root BATCH warning.
+- Forward guidance: next action unchanged -- the F-SWE-1 audit, then WP-1. A
+  preflight amendment to the charter and the Batch 21 WP gates is agreed and
+  pending; see the owner decisions recorded with it.
+
+### 2026-08-19 - PR #171 round-7 threads fixed (side-task)
+
+- Scope: the three unresolved Codex threads left on `3d15849` after the
+  diagram audit. All three are P2 and all three were checked against the
+  source before any edit. All three are correct.
+- Verification and fixes:
+  - `top-albums-sequence.md` drew `Close connection` unconditionally, but
+    `process_albums` closes inside `if conn` (`orchestrator.py:603-604`), so
+    the no-connection branch never closes anything. Wrapped in an `opt DB
+    connected` block.
+  - The same diagram claimed the browser never posts `results_complete` on an
+    error payload. `loading.js:209-229` shows only the retryable branch stays
+    on the page; a non-retryable error waits three seconds and calls
+    `redirectToResults()`, which does post. Split the branch by `retryable`
+    and routed the non-retryable case to the processing-error page.
+  - `FINDINGS.md` F-B21-1 stated `MAX_ACTIVE_JOBS` is 5 as an absolute.
+    `config.py:31` reads it from the environment with 5 as the default, and
+    the literal contradicted F-LOAD-1 in the same file. Reworded to name 5 as
+    the default and tie the failure count to configured capacity.
+- Deviations: none. No code changed; F-B21-1 stays open and unfixed, because
+  it is a code change for a code batch.
+- Validation: `pytest -q` -- **590 passed**. `pre-commit run --files` on both
+  edited files -- all hooks pass. `doc_state_sync.py --check` -- exit 0 with
+  the expected root BATCH warning. The edited Mermaid diagram was validated
+  through the Mermaid Chart validator: `valid = true`, type `sequence`.
+- Forward guidance: the next action is unchanged -- the F-SWE-1 audit, then
+  Batch 21 WP-1.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -232,6 +232,39 @@ non-current operational logs. Older dated entries live in
 - Deviations: the drift hook landed at WP-2 rather than the WP-1 the owner
   proposed. WP-1 changes no template, so nothing consumes the compiled CSS
   until WP-2; WP-2 is the first point where drift can ship.
+- Independent review of the amended charter, same day, and the fixes it drove:
+  - The migration gate did not say whether it covered existing findings. Read
+    the wide way, F-B21-1 blocks WP-1 today -- a resource-release defect in
+    `orchestrator.py`, which WP-7 modifies. The gate is now scoped to net-new
+    findings in terms, F-B21-1 is named as the case that forces the
+    distinction, and an audit that thinks an existing finding should block
+    must recommend rather than act.
+  - The A/B/C/D rubric graded by frequency ("one place is B, several is C")
+    while its own table graded by cost. One leak can be C; five contained
+    exceptions can stay B. Rewritten to grade cost, not count. The
+    "when torn, over-raise" instruction is deleted -- it contradicted
+    Section 4's rule that the audit's value is not volume.
+  - Resolved and no-action findings shared one rule. Split: a recurred
+    resolved defect earns a new finding; an unchanged no-action rationale
+    does not; materially changed assumptions do, explaining the delta.
+  - Provenance permitted grading a dirty tree, which no SHA can reproduce.
+    A clean worktree is now required before grading starts.
+  - The hotspot command was `awk '...{...}'` -- a placeholder that could not
+    run, and a poor Python parser besides. Replaced with a tested `ast`
+    script in a new Section 5c, deliberately at the left margin: a heredoc
+    terminator indented inside the numbered list fails with
+    `IndentationError`, which was verified rather than assumed.
+  - Boy Scout used `git log`, which lists commits without showing what they
+    left behind. Now `git log -p`, with an instruction to read the patches.
+  - "Weakest principle repo-wide" overclaimed: the audit excludes the
+    frontend, both script directories, and tests as graded subjects. Scoped
+    to the audited runtime modules.
+  - Cell arithmetic hardcoded 130 in three places while Section 3 allowed the
+    principle count to change. All three now derive from the live count.
+  - One review point was stale, not wrong: the claim that WP-8 defines no
+    frontend principles audit. It does, in this commit's parent -- the
+    reviewer was reading `origin/main`, because the amendment is committed
+    locally and deliberately unpushed.
 - Validation: `pytest -q` -- **590 passed**. `pre-commit run --all-files` --
   all hooks pass. `doc_state_sync.py --check` -- exit 0 with the expected
   root BATCH warning.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -82,19 +82,22 @@ See FINDINGS F-DOCSYNC-3.
   page-by-page strangler migration. Expanded from the owner's Claude
   Design audit (UI Audit v3); four owner decisions locked in the
   definition. Branch: `wip/batch-21` (worktree off `main`).
-- **Next action:** execute the full F-SWE-1 principles audit, then proceed to
-  Batch 21 WP-1. PR #169 merged to `main` on 2026-08-08 and the Quality Gate
-  is green for `5bc6294`, so the canonical repository-integrity gate and
-  read-only worktree guard are shipped and
-  F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2 are resolved. Three guard files
-  exceed their directory peer caps after review remediation -- accepted as a
-  deviation and tracked as F-WORKTREE-4 in FINDINGS.md, not silently. Review
-  remediation ran to round 6: rounds 2 through 5 landed before the merge, and
-  round 6 was reviewed after the final push, so its four findings reached
-  `main` unaddressed. **PR #170 remediated them and merged 2026-08-12**
-  (`5b060a2`), so the guard and docsync sources the audit reads are settled.
-  Three of its review threads remain open, two of them independent reports of
-  F-WORKTREE-5.
+- **Next action:** execute the amended F-SWE-1 principles audit against the
+  current `main`, then proceed to Batch 21 WP-1. **PR #171 merged to `main`
+  on 2026-08-19** (`bb187ae`, rebase merge) with zero unresolved review
+  threads after eight rounds; `wip/batch-21` was realigned to it.
+  `docs/SWE_AUDIT_CHARTER.md` and `BATCH21_DEFINITION.md` were both amended
+  the same day by a preflight review -- the charter could not work as the
+  gate its position implies, and the batch gate could not fail on frontend
+  work. Read the charter before executing: the audit now blocks WP-1 on P0
+  findings and on correctness defects in modules Batch 21 modifies, and the
+  report must state that verdict explicitly.
+  Earlier context, still true: PR #169 merged 2026-08-08 shipping the
+  repository-integrity gate and read-only worktree guard, resolving
+  F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2; three guard files exceed their
+  directory peer caps, accepted as a deviation and tracked as F-WORKTREE-4,
+  not silently. PR #170 merged 2026-08-12 (`5b060a2`), settling the guard and
+  docsync sources the audit reads.
 - Batch 21 WP status: WP-0 done. WP-1 through WP-8 not yet started.
 - **Perf note:** heatmap fetch speed is rate-limit bound; measurement and
   rationale live in FINDINGS.md F-B18-11 (single source).
@@ -162,6 +165,80 @@ non-current operational logs. Older dated entries live in
   sheet, and commits the compiled CSS. No template changes until WP-2.
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
+
+### 2026-08-19 - Batch 21 preflight: F-SWE-1 charter and WP gates amended (side-task)
+
+- Scope: owner preflight review before WP-1, raised as six criticisms of
+  `docs/SWE_AUDIT_CHARTER.md` and an eight-row table of weak WP gates. Two
+  verification agents checked every claim against the files before any edit.
+  All six charter criticisms held. Two of the batch claims did not.
+- Verification of the owner report:
+  - Confirmed: the charter named five docsync modules when the directory has
+    seven (`integrity.py`, 474 lines, unnamed) and its LOC figure was stale
+    for the five it did name; the differential baseline was a closed ID list
+    omitting F-B21-1, F-DATA-1, F-WORKTREE-3/4/5, F-DOCSYNC-6/7 and never
+    referenced `FINDINGS_ARCHIVE.md`; A/B/C/D was defined nowhere in the
+    repository; the matrix was 190-210 cells with explicit permission to cut
+    modules; no severity or stop condition existed anywhere, so finishing the
+    audit was the same as passing it; and the post-Batch-21 frontend audit
+    was permissive ("can"), not required.
+  - Corrected: the excluded set is a proper subset of what Batch 21 rewrites,
+    not equal to it -- WP-7 modifies `routes.py` and `orchestrator.py`, which
+    are in scope, so those grades also expire at WP-7. The charter never
+    addressed that; it now does.
+  - Refuted: the claimed AGENT_NOTES-versus-definition contradiction over the
+    drift hook. `AGENT_NOTES.md` requires the CI-fetch *decision* at WP-1;
+    the definition deferred the *hook* to WP-8. Both could hold. The real
+    defect was quieter -- no WP-1 criterion required the decision to be
+    recorded, so nothing enforced it.
+- Root cause neither side had named: the batch validation gate is three
+  Python commands, and pre-commit excludes `static/` and `templates/`. A work
+  package could rewrite every template and stylesheet with a fully green
+  gate, in a batch that is nothing but template and stylesheet rewriting.
+- Plan vs implementation:
+  - Charter: 13 graded modules enumerated by name (130 cells, `__init__.py`
+    excluded by a stated empty-module rule); docsync and `scripts/dev/`
+    excluded with reasons rather than left ambiguous; provenance block
+    naming branch, SHA and clean state; symbol-based hotspot discovery
+    replacing hardcoded line numbers and counts; baseline widened to the
+    whole finding corpus plus the archive and every report from 2026-02 on;
+    A/B/C/D rubric with the B/C line defined as exception-versus-pattern;
+    Boy Scout window fixed at commits since the February audits; a
+    resolved-finding branch for C/D cells; a migration-blocking severity
+    policy with a one-line verdict required in the report; an instruction to
+    retire the charter at close. The budget escape hatch is withdrawn.
+  - Batch 21: new `scripts/dev/frontend_gate.py` added as a fourth gate
+    command at WP-2 and grown one page per WP, covering stylesheet
+    isolation, computed theme tokens in both themes, theme persistence,
+    self-hosted font loading, CSV/JPEG export assertions, and headline
+    wrapping. The `tailwind-css-drift` hook moved from WP-8 to WP-2, with
+    the `always_run` / `pass_filenames` requirement that AGENT_NOTES gap 2
+    had already identified and the definition had not carried. Targeted
+    criteria added to WP-3 (keyboard and touch reachability for the CSS-only
+    hints, label associations, validation parity), WP-4 (both state machines
+    including retryable and non-retryable failures), WP-7 (split into a
+    backend contract commit and a UI commit), and WP-8 (required frontend
+    and accessibility audit, deterministic Bootstrap-removal grep, recorded
+    lint disposition). Browser floor documented; `.dark-mode` retirement
+    given an owner; criterion 9 reconciled with the per-WP docsync check.
+  - FINDINGS.md: F-STYLE-1 (prose legibility, explicitly never a gate) and
+    F-STYLE-2 (docstring convention, the black/flake8 line-length
+    disagreement, and the unwritten Ruff plan) added. F-SWE-1 corrected --
+    it claimed the charter scoped "Python only until Batch 21 ships", a
+    commitment the charter never made.
+  - AGENTS.md: the F-ID source-tag list named five tags while nine are in
+    use. `SWE`, `WORKTREE`, `DATA` and `STYLE` added, and the list is now
+    declared complete so the next coined tag gets documented.
+- Deviations: the drift hook landed at WP-2 rather than the WP-1 the owner
+  proposed. WP-1 changes no template, so nothing consumes the compiled CSS
+  until WP-2; WP-2 is the first point where drift can ship.
+- Validation: `pytest -q` -- **590 passed**. `pre-commit run --all-files` --
+  all hooks pass. `doc_state_sync.py --check` -- exit 0 with the expected
+  root BATCH warning.
+- Forward guidance: execute the amended charter against current `main` and
+  publish the migration verdict before WP-1 starts. The verified root-hygiene
+  plan (audience banners, README tree, DEPLOY.md) is deferred until after
+  WP-1 by owner decision; its line numbers will need re-checking.
 
 ### 2026-08-19 - PR #171 round-8 thread fixed: push authorization in the cycle diagram (side-task)
 
@@ -271,37 +348,3 @@ non-current operational logs. Older dated entries live in
   `BATCH21_DEFINITION.md` warning.
 - Forward guidance: push, then reply to the two threads and resolve them.
   PR #171 stays open until the owner says otherwise.
-
-### 2026-08-15 - PR #171 round-5 review threads remediated (side-task)
-
-- Scope: three new Codex threads on `37ca4a9` -- one on the development-cycle
-  diagram and two on the Top Albums sequence. All three were verified against
-  the code before any edit and all three were valid.
-- Verification:
-  - `AGENTS.md` L29-44 defines the review-comment fast path (fetch the thread
-    first, stop if not actionable, else read only the scoped files), but the
-    development-cycle diagram routed every review finding through the full
-    bootstrap gates. The diagram and the rules it documents were written in
-    the same PR and disagreed.
-  - `_fetch_and_process()` stores an empty result, marks progress 100%, and
-    returns before pre-slicing, cache access, or Spotify enrichment when
-    `filtered_albums` is empty. The Top Albums sequence sent every successful
-    page fetch into those stages.
-  - `process_albums()` catches `_batch_lookup_metadata()` exceptions, records
-    `db_cache_warning`, treats every album as a miss, and continues to Spotify
-    (possibly persisting via the open connection). The diagram's connected
-    path presented lookup as unconditional and its unavailable path said
-    persistence was skipped.
-- Plan vs implementation: the development-cycle diagram now branches on
-  review-finding/comment-job before full bootstrap (fetch thread, stop if not
-  actionable, else read scoped files); the Top Albums sequence now stops after
-  an empty filtered set and adds a fail-open cache-lookup-error continuation.
-- Deviations: none. No production behavior changed and no tests were added;
-  existing tests already cover the empty-filtered-set and fail-open lookup
-  paths.
-- Validation: both updated diagrams pass Mermaid validation and open in
-  preview. `pytest -q` -- **590 passed**, 3 known warnings. `pre-commit run
-  --all-files` -- all hooks pass. `doc_state_sync.py --check` -- exit 0 with
-  the expected active-root `BATCH21_DEFINITION.md` warning.
-- Forward guidance: commit and push this remediation, then resolve the three
-  threads. PR #171 remains unmerged pending separate owner instruction.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -173,6 +173,66 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
+### 2026-08-20 - Agent document map added; HANDOFF_PROMPT trimmed (side-task)
+
+- Scope: the owner asked for an instructional that lets an agent other than
+  Claude navigate the documentation set -- including the audit and SWE
+  documents -- and understand why each document exists. Added
+  `docs/AGENT_DOC_MAP.md` and registered it in the `AGENTS.md` Document Roles
+  table. Documentation only; no runtime code changed.
+- Plan vs implementation: as planned. The map routes rather than summarises.
+  It names the owner of each fact and links to it, so it adds no copy that a
+  later edit can contradict (`AGENTS.md` Anti-duplication rule). Sections:
+  the one-owner rule and why it exists, where to start, the document groups,
+  the human-facing documents, how to read an audit, how to read a finding,
+  seven navigation traps, the pre-change gates, and the tie-break order when
+  two documents disagree. It sits under `docs/` rather than the repository
+  root, because a twelfth root Markdown file would worsen the problem the map
+  exists to solve, and it is marked optional and outside the bootstrap set so
+  it does not inflate the cold-start read. 264 lines, under the 370-line
+  largest peer in `docs/`.
+- Audit guidance is the part with no prior owner: the charter to report to
+  findings to log-entry lifecycle, why a retired charter is kept, why a dated
+  report is never edited in place, and that a report is a measurement of one
+  day rather than current truth. The SWE report's own "Owner review" section
+  is cited as the worked example of an appended correction.
+- Owner request mid-task, and the reason it changed shape: delete
+  `HANDOFF_PROMPT.md`. That is not a documentation-only delete. The file is
+  pinned into the commit gate at `scripts/docsync/cli.py:26` and
+  `scripts/docsync/integrity.py:51`. `cli.py:88` loads every
+  `LIVE_DOCUMENT_PATHS` entry through `_read_lines`, which raises `SyncError`
+  on a missing file and maps to exit 2, and the `doc-state-sync-check` hook
+  runs `--check` with `always_run: true`. Deleting the file alone would fail
+  every commit in the repository until `cli.py`, `integrity.py`,
+  `tests/conftest.py:149` and four assertions in
+  `tests/test_docsync_integrity.py` changed with it. The owner chose to trim
+  the file instead of deleting it.
+- Trim: `HANDOFF_PROMPT.md` went from 66 to 46 lines. Removed three sections
+  that carried no requirement of their own and only named an `AGENTS.md`
+  section: validation gates, commit discipline, and anti-patterns. Every
+  subject those sections named survives in the new opening paragraph, checked
+  against the removed text one item at a time per Anti-Pattern 12. The two
+  unique parts are untouched: the post-read verification and the handoff
+  checklist. Section numbers were replaced with names, so no later edit can
+  leave a stale "Section 4)" citation behind. `DEVELOPMENT.md:74-78` already
+  claimed the file held only those two things, so the trim closes an existing
+  drift rather than creating one.
+- Deviations: two stale claims corrected in the same commit, both left behind
+  by the 2026-08-20 audit commits. `BATCH21_DEFINITION.md:3` still read that
+  the F-SWE-1 audit "comes next" after PR #170; the audit ran on 2026-08-20.
+  The `README.md` documentation tree still described
+  `docs/SWE_AUDIT_CHARTER.md` as "Standing audit scope and method"; the
+  charter is retired. The same tree gained a row for the new map, because it
+  enumerates the contents of `docs/`.
+- Validation: `pytest -q` **590 passed** (unchanged; no code touched);
+  `pre-commit run --all-files` all hooks passed;
+  `python scripts/doc_state_sync.py --check` exit 0 with the expected
+  active-root `BATCH21_DEFINITION.md` warning. Every tracked Markdown file
+  was checksummed before and after the pre-commit run and compared, because
+  that hook has twice reverted files nobody edited, once into a commit.
+- Forward guidance: unchanged. The F-SWE-2 fix is still the next action. It
+  is a code commit and it moves the test count off 590.
+
 ### 2026-08-20 - F-SWE-1 SWE principles audit executed (side-task)
 
 - Scope: executed `docs/SWE_AUDIT_CHARTER.md` against `1994673`, whose
@@ -375,31 +435,3 @@ non-current operational logs. Older dated entries live in
 - Forward guidance: next action unchanged -- the F-SWE-1 audit, then WP-1. A
   preflight amendment to the charter and the Batch 21 WP gates is agreed and
   pending; see the owner decisions recorded with it.
-
-### 2026-08-19 - PR #171 round-7 threads fixed (side-task)
-
-- Scope: the three unresolved Codex threads left on `3d15849` after the
-  diagram audit. All three are P2 and all three were checked against the
-  source before any edit. All three are correct.
-- Verification and fixes:
-  - `top-albums-sequence.md` drew `Close connection` unconditionally, but
-    `process_albums` closes inside `if conn` (`orchestrator.py:603-604`), so
-    the no-connection branch never closes anything. Wrapped in an `opt DB
-    connected` block.
-  - The same diagram claimed the browser never posts `results_complete` on an
-    error payload. `loading.js:209-229` shows only the retryable branch stays
-    on the page; a non-retryable error waits three seconds and calls
-    `redirectToResults()`, which does post. Split the branch by `retryable`
-    and routed the non-retryable case to the processing-error page.
-  - `FINDINGS.md` F-B21-1 stated `MAX_ACTIVE_JOBS` is 5 as an absolute.
-    `config.py:31` reads it from the environment with 5 as the default, and
-    the literal contradicted F-LOAD-1 in the same file. Reworded to name 5 as
-    the default and tie the failure count to configured capacity.
-- Deviations: none. No code changed; F-B21-1 stays open and unfixed, because
-  it is a code change for a code batch.
-- Validation: `pytest -q` -- **590 passed**. `pre-commit run --files` on both
-  edited files -- all hooks pass. `doc_state_sync.py --check` -- exit 0 with
-  the expected root BATCH warning. The edited Mermaid diagram was validated
-  through the Mermaid Chart validator: `valid = true`, type `sequence`.
-- Forward guidance: the next action is unchanged -- the F-SWE-1 audit, then
-  Batch 21 WP-1.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -82,13 +82,17 @@ See FINDINGS F-DOCSYNC-3.
   page-by-page strangler migration. Expanded from the owner's Claude
   Design audit (UI Audit v3); four owner decisions locked in the
   definition. Branch: `wip/batch-21` (worktree off `main`).
-- **Next action:** Batch 21 WP-1. **F-SWE-2 was resolved 2026-08-20** in its
+- **Next action:** land PR #172 after its review-fix validation, then begin
+  Batch 21 WP-1. **F-SWE-2 was resolved 2026-08-20** in its
   owner-approved standalone prerequisite commit: both album-year boundary
   constructors now use explicit UTC, and a deterministic UTC-5 regression
   pins the Last.fm request window. This clears the F-SWE-1 migration block;
   see `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md` and the
   Section 4 entry of the same date. Nothing else in the audit blocks; the
-  other five net-new findings are record-and-continue.
+  other five net-new findings are record-and-continue. PR review also
+  corrected the frontend-gate contract: the three repository gates run at
+  every WP; pinned Python Playwright + Chromium and the frontend gate begin
+  together at WP-2. No WP-1 work has started.
   `docs/SWE_AUDIT_CHARTER.md` is retired and kept only as the record of what
   the audit was asked to do.
   Earlier context, still true: **PR #171 merged to `main` on 2026-08-19**
@@ -204,6 +208,39 @@ non-current operational logs. Older dated entries live in
   the expected active-root `BATCH21_DEFINITION.md` warning.
 - Forward guidance: F-SWE-2 is resolved. WP-1 is next; pause for owner review
   of this commit before starting it.
+
+### 2026-08-20 - PR #172 frontend-gate contract made executable (Batch 21 WP-0)
+
+- Scope: addressed the two actionable P1 review threads on the active Batch 21
+  definition before WP-1. This is design and state documentation only; no
+  frontend runtime or WP-1 work started.
+- Verification of the review findings: criterion 9 required the frontend gate
+  at every WP while the validation section created it at WP-2, making WP-1
+  impossible to complete. The planned Python script also had no declared
+  Playwright package, browser provisioning, CI setup, or callable bridge to
+  the machine-local MCP providers.
+- Plan vs implementation: owner-approved as designed. The three existing
+  repository gates remain mandatory at every WP and the frontend gate starts
+  at WP-2. That WP pins `playwright==1.62.0` in `requirements-dev.txt`, installs
+  its matching Chromium build explicitly on the developer machine and Linux
+  CI, runs the repository gate in the Quality Gate, and documents setup in
+  README and DEVELOPMENT when the runtime lands. The script owns an ephemeral
+  loopback Flask server and always tears it down; missing tooling fails with an
+  actionable command rather than downloading silently. No Node project,
+  pytest plugin, or MCP dependency is introduced.
+- Review disposition outside this commit: the nuanced F-SWE-3 thread received
+  the owner-approved ROI explanation and was resolved without expanding WP-7.
+  F-SWE-3 remains open at P2; operational Spotify failures do not become an
+  unmatched-page `reason_code`.
+- Deviations: none. The active definition is the canonical design document, so
+  no duplicate `docs/superpowers/specs/` file was created.
+- Validation: qualified `pytest -q` -- **591 passed**, 3 warnings; all
+  pre-commit hooks passed; tracked-Markdown MD5 manifests were identical
+  before and after the hook run; `doc_state_sync.py --check` passed with only
+  the expected active-batch root-definition warning.
+- Forward guidance: land PR #172, then start WP-1. The Playwright dependency,
+  browser download, workflow change, gate implementation, tests, README, and
+  DEVELOPMENT updates all land together at WP-2.
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -82,22 +82,19 @@ See FINDINGS F-DOCSYNC-3.
   page-by-page strangler migration. Expanded from the owner's Claude
   Design audit (UI Audit v3); four owner decisions locked in the
   definition. Branch: `wip/batch-21` (worktree off `main`).
-- **Next action:** execute the amended F-SWE-1 principles audit against the
-  current `main`, then proceed to Batch 21 WP-1. **PR #171 merged to `main`
-  on 2026-08-19** (`bb187ae`, rebase merge) with zero unresolved review
-  threads after eight rounds; `wip/batch-21` was realigned to it.
-  `docs/SWE_AUDIT_CHARTER.md` and `BATCH21_DEFINITION.md` were both amended
-  the same day by a preflight review -- the charter could not work as the
-  gate its position implies, and the batch gate could not fail on frontend
-  work. Read the charter before executing: the audit now blocks WP-1 on P0
-  findings and on correctness defects in modules Batch 21 modifies, and the
-  report must state that verdict explicitly.
-  Earlier context, still true: PR #169 merged 2026-08-08 shipping the
-  repository-integrity gate and read-only worktree guard, resolving
-  F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2; three guard files exceed their
-  directory peer caps, accepted as a deviation and tracked as F-WORKTREE-4,
-  not silently. PR #170 merged 2026-08-12 (`5b060a2`), settling the guard and
-  docsync sources the audit reads.
+- **Next action:** execute the full F-SWE-1 principles audit, then proceed to
+  Batch 21 WP-1. PR #169 merged to `main` on 2026-08-08 and the Quality Gate
+  is green for `5bc6294`, so the canonical repository-integrity gate and
+  read-only worktree guard are shipped and
+  F-DOCSYNC-5/F-WORKTREE-1/F-WORKTREE-2 are resolved. Three guard files
+  exceed their directory peer caps after review remediation -- accepted as a
+  deviation and tracked as F-WORKTREE-4 in FINDINGS.md, not silently. Review
+  remediation ran to round 6: rounds 2 through 5 landed before the merge, and
+  round 6 was reviewed after the final push, so its four findings reached
+  `main` unaddressed. **PR #170 remediated them and merged 2026-08-12**
+  (`5b060a2`), so the guard and docsync sources the audit reads are settled.
+  Three of its review threads remain open, two of them independent reports of
+  F-WORKTREE-5.
 - Batch 21 WP status: WP-0 done. WP-1 through WP-8 not yet started.
 - **Perf note:** heatmap fetch speed is rate-limit bound; measurement and
   rationale live in FINDINGS.md F-B18-11 (single source).
@@ -166,169 +163,6 @@ non-current operational logs. Older dated entries live in
 
 <!-- DOCSYNC:CURRENT-BATCH-END -->
 
-### 2026-08-19 - Batch 21 preflight: F-SWE-1 charter and WP gates amended (side-task)
-
-- Scope: owner preflight review before WP-1, raised as six criticisms of
-  `docs/SWE_AUDIT_CHARTER.md` and an eight-row table of weak WP gates. Two
-  verification agents checked every claim against the files before any edit.
-  All six charter criticisms held. Two of the batch claims did not.
-- Verification of the owner report:
-  - Confirmed: the charter named five docsync modules when the directory has
-    seven (`integrity.py`, 474 lines, unnamed) and its LOC figure was stale
-    for the five it did name; the differential baseline was a closed ID list
-    omitting F-B21-1, F-DATA-1, F-WORKTREE-3/4/5, F-DOCSYNC-6/7 and never
-    referenced `FINDINGS_ARCHIVE.md`; A/B/C/D was defined nowhere in the
-    repository; the matrix was 190-210 cells with explicit permission to cut
-    modules; no severity or stop condition existed anywhere, so finishing the
-    audit was the same as passing it; and the post-Batch-21 frontend audit
-    was permissive ("can"), not required.
-  - Corrected: the excluded set is a proper subset of what Batch 21 rewrites,
-    not equal to it -- WP-7 modifies `routes.py` and `orchestrator.py`, which
-    are in scope, so those grades also expire at WP-7. The charter never
-    addressed that; it now does.
-  - Refuted: the claimed AGENT_NOTES-versus-definition contradiction over the
-    drift hook. `AGENT_NOTES.md` requires the CI-fetch *decision* at WP-1;
-    the definition deferred the *hook* to WP-8. Both could hold. The real
-    defect was quieter -- no WP-1 criterion required the decision to be
-    recorded, so nothing enforced it.
-- Root cause neither side had named: the batch validation gate is three
-  Python commands, and pre-commit excludes `static/` and `templates/`. A work
-  package could rewrite every template and stylesheet with a fully green
-  gate, in a batch that is nothing but template and stylesheet rewriting.
-- Plan vs implementation:
-  - Charter: 13 graded modules enumerated by name (130 cells, `__init__.py`
-    excluded by a stated empty-module rule); docsync and `scripts/dev/`
-    excluded with reasons rather than left ambiguous; provenance block
-    naming branch, SHA and clean state; symbol-based hotspot discovery
-    replacing hardcoded line numbers and counts; baseline widened to the
-    whole finding corpus plus the archive and every report from 2026-02 on;
-    A/B/C/D rubric with the B/C line defined as exception-versus-pattern;
-    Boy Scout window fixed at commits since the February audits; a
-    resolved-finding branch for C/D cells; a migration-blocking severity
-    policy with a one-line verdict required in the report; an instruction to
-    retire the charter at close. The budget escape hatch is withdrawn.
-  - Batch 21: new `scripts/dev/frontend_gate.py` added as a fourth gate
-    command at WP-2 and grown one page per WP, covering stylesheet
-    isolation, computed theme tokens in both themes, theme persistence,
-    self-hosted font loading, CSV/JPEG export assertions, and headline
-    wrapping. The `tailwind-css-drift` hook moved from WP-8 to WP-2, with
-    the `always_run` / `pass_filenames` requirement that AGENT_NOTES gap 2
-    had already identified and the definition had not carried. Targeted
-    criteria added to WP-3 (keyboard and touch reachability for the CSS-only
-    hints, label associations, validation parity), WP-4 (both state machines
-    including retryable and non-retryable failures), WP-7 (split into a
-    backend contract commit and a UI commit), and WP-8 (required frontend
-    and accessibility audit, deterministic Bootstrap-removal grep, recorded
-    lint disposition). Browser floor documented; `.dark-mode` retirement
-    given an owner; criterion 9 reconciled with the per-WP docsync check.
-  - FINDINGS.md: F-STYLE-1 (prose legibility, explicitly never a gate) and
-    F-STYLE-2 (docstring convention, the black/flake8 line-length
-    disagreement, and the unwritten Ruff plan) added. F-SWE-1 corrected --
-    it claimed the charter scoped "Python only until Batch 21 ships", a
-    commitment the charter never made.
-  - AGENTS.md: the F-ID source-tag list named five tags while nine are in
-    use. `SWE`, `WORKTREE`, `DATA` and `STYLE` added, and the list is now
-    declared complete so the next coined tag gets documented.
-- Deviations: the drift hook landed at WP-2 rather than the WP-1 the owner
-  proposed. WP-1 changes no template, so nothing consumes the compiled CSS
-  until WP-2; WP-2 is the first point where drift can ship.
-- Independent review of the amended charter, same day, and the fixes it drove:
-  - The migration gate did not say whether it covered existing findings. Read
-    the wide way, F-B21-1 blocks WP-1 today -- a resource-release defect in
-    `orchestrator.py`, which WP-7 modifies. The gate is now scoped to net-new
-    findings in terms, F-B21-1 is named as the case that forces the
-    distinction, and an audit that thinks an existing finding should block
-    must recommend rather than act.
-  - The A/B/C/D rubric graded by frequency ("one place is B, several is C")
-    while its own table graded by cost. One leak can be C; five contained
-    exceptions can stay B. Rewritten to grade cost, not count. The
-    "when torn, over-raise" instruction is deleted -- it contradicted
-    Section 4's rule that the audit's value is not volume.
-  - Resolved and no-action findings shared one rule. Split: a recurred
-    resolved defect earns a new finding; an unchanged no-action rationale
-    does not; materially changed assumptions do, explaining the delta.
-  - Provenance permitted grading a dirty tree, which no SHA can reproduce.
-    A clean worktree is now required before grading starts.
-  - The hotspot command was `awk '...{...}'` -- a placeholder that could not
-    run, and a poor Python parser besides. Replaced with a tested `ast`
-    script in a new Section 5c, deliberately at the left margin: a heredoc
-    terminator indented inside the numbered list fails with
-    `IndentationError`, which was verified rather than assumed.
-  - Boy Scout used `git log`, which lists commits without showing what they
-    left behind. Now `git log -p`, with an instruction to read the patches.
-  - "Weakest principle repo-wide" overclaimed: the audit excludes the
-    frontend, both script directories, and tests as graded subjects. Scoped
-    to the audited runtime modules.
-  - Cell arithmetic hardcoded 130 in three places while Section 3 allowed the
-    principle count to change. All three now derive from the live count.
-  - One review point was stale, not wrong: the claim that WP-8 defines no
-    frontend principles audit. It does, in this commit's parent -- the
-    reviewer was reading `origin/main`, because the amendment is committed
-    locally and deliberately unpushed.
-- Validation: `pytest -q` -- **590 passed**. `pre-commit run --all-files` --
-  all hooks pass. `doc_state_sync.py --check` -- exit 0 with the expected
-  root BATCH warning.
-- Forward guidance: execute the amended charter against current `main` and
-  publish the migration verdict before WP-1 starts. The verified root-hygiene
-  plan (audience banners, README tree, DEPLOY.md) is deferred until after
-  WP-1 by owner decision; its line numbers will need re-checking.
-
-### 2026-08-19 - PR #171 round-8 thread fixed: push authorization in the cycle diagram (side-task)
-
-- Scope: one unresolved Codex thread on `docs/architecture/development-cycle.md`,
-  raised again by an owner-side human peer on the grounds that this diagram
-  purports to govern agents. Checked against the ruleset before editing. Valid.
-- Verification: the diagram had a single unconditional edge,
-  `Authorize -->|Review-fix commit on an open PR| PR`. `AGENTS.md:234-242`
-  grants that standing exception to Claude Code and Codex sessions only and
-  says in terms that it does not extend to GitHub Copilot task sessions or
-  their subagents, Jules, or any other agent. An agent reading the canonical
-  diagram would therefore push a review-fix commit that the ruleset requires
-  it to pause on.
-- Plan vs implementation: the decision node now carries three edges instead of
-  two. WP and batch commits pause in any session; the direct path is labelled
-  Claude Code or Codex only; every other agent routes to the same pause. Added
-  prose naming `AGENTS.md` as the owner of the rule, and recording the three
-  actions that always need explicit instruction whatever the session --
-  force-pushes, history rewrites, and anything targeting `main` -- plus the
-  Copilot platform-tool requirement at `AGENTS.md:243-244`, neither of which
-  the diagram had carried.
-- Deviations: none. No code changed.
-- Validation: the edited diagram was validated before it was written --
-  `valid = true`, type `flowchart`. `pytest -q` -- **590 passed**.
-  `doc_state_sync.py --check` -- exit 0 with the expected root BATCH warning.
-- Forward guidance: next action unchanged -- the F-SWE-1 audit, then WP-1. A
-  preflight amendment to the charter and the Batch 21 WP gates is agreed and
-  pending; see the owner decisions recorded with it.
-
-### 2026-08-19 - PR #171 round-7 threads fixed (side-task)
-
-- Scope: the three unresolved Codex threads left on `3d15849` after the
-  diagram audit. All three are P2 and all three were checked against the
-  source before any edit. All three are correct.
-- Verification and fixes:
-  - `top-albums-sequence.md` drew `Close connection` unconditionally, but
-    `process_albums` closes inside `if conn` (`orchestrator.py:603-604`), so
-    the no-connection branch never closes anything. Wrapped in an `opt DB
-    connected` block.
-  - The same diagram claimed the browser never posts `results_complete` on an
-    error payload. `loading.js:209-229` shows only the retryable branch stays
-    on the page; a non-retryable error waits three seconds and calls
-    `redirectToResults()`, which does post. Split the branch by `retryable`
-    and routed the non-retryable case to the processing-error page.
-  - `FINDINGS.md` F-B21-1 stated `MAX_ACTIVE_JOBS` is 5 as an absolute.
-    `config.py:31` reads it from the environment with 5 as the default, and
-    the literal contradicted F-LOAD-1 in the same file. Reworded to name 5 as
-    the default and tie the failure count to configured capacity.
-- Deviations: none. No code changed; F-B21-1 stays open and unfixed, because
-  it is a code change for a code batch.
-- Validation: `pytest -q` -- **590 passed**. `pre-commit run --files` on both
-  edited files -- all hooks pass. `doc_state_sync.py --check` -- exit 0 with
-  the expected root BATCH warning. The edited Mermaid diagram was validated
-  through the Mermaid Chart validator: `valid = true`, type `sequence`.
-- Forward guidance: the next action is unchanged -- the F-SWE-1 audit, then
-  Batch 21 WP-1.
-
 ### 2026-08-15 - PR #171 round-6 threads fixed and all five diagrams audited (side-task)
 
 - Scope: the two unresolved Codex threads on `00c0adb`, both on the Top Albums
@@ -381,3 +215,112 @@ non-current operational logs. Older dated entries live in
   `BATCH21_DEFINITION.md` warning.
 - Forward guidance: push, then reply to the two threads and resolve them.
   PR #171 stays open until the owner says otherwise.
+
+### 2026-08-15 - PR #171 round-5 review threads remediated (side-task)
+
+- Scope: three new Codex threads on `37ca4a9` -- one on the development-cycle
+  diagram and two on the Top Albums sequence. All three were verified against
+  the code before any edit and all three were valid.
+- Verification:
+  - `AGENTS.md` L29-44 defines the review-comment fast path (fetch the thread
+    first, stop if not actionable, else read only the scoped files), but the
+    development-cycle diagram routed every review finding through the full
+    bootstrap gates. The diagram and the rules it documents were written in
+    the same PR and disagreed.
+  - `_fetch_and_process()` stores an empty result, marks progress 100%, and
+    returns before pre-slicing, cache access, or Spotify enrichment when
+    `filtered_albums` is empty. The Top Albums sequence sent every successful
+    page fetch into those stages.
+  - `process_albums()` catches `_batch_lookup_metadata()` exceptions, records
+    `db_cache_warning`, treats every album as a miss, and continues to Spotify
+    (possibly persisting via the open connection). The diagram's connected
+    path presented lookup as unconditional and its unavailable path said
+    persistence was skipped.
+- Plan vs implementation: the development-cycle diagram now branches on
+  review-finding/comment-job before full bootstrap (fetch thread, stop if not
+  actionable, else read scoped files); the Top Albums sequence now stops after
+  an empty filtered set and adds a fail-open cache-lookup-error continuation.
+- Deviations: none. No production behavior changed and no tests were added;
+  existing tests already cover the empty-filtered-set and fail-open lookup
+  paths.
+- Validation: both updated diagrams pass Mermaid validation and open in
+  preview. `pytest -q` -- **590 passed**, 3 known warnings. `pre-commit run
+  --all-files` -- all hooks pass. `doc_state_sync.py --check` -- exit 0 with
+  the expected active-root `BATCH21_DEFINITION.md` warning.
+- Forward guidance: commit and push this remediation, then resolve the three
+  threads. PR #171 remains unmerged pending separate owner instruction.
+
+### 2026-08-15 - PR #171 final four review threads remediated (side-task)
+
+- Scope: the four remaining unresolved review threads on `e73540d` -- two
+  Codex path-repointing reports and two Codex Top Albums sequence reports.
+  All four were verified against the code and the moved files before any
+  edit and all four were valid.
+- Verification:
+  - `docs/superpowers/plans/2026-08-11-pr-170-remediation.md` still cited
+    `docs/history/GUARD_HARDENING_2026-08-11.md` and
+    `docs/history/REPOSITORY_SYNTHESIS_2026-08-11.md`, both moved to
+    `docs/history/reports/` by commit `5865c55`. The links resolved to
+    nonexistent files.
+  - `docs/history/definitions/BATCH9_DEFINITION.md` pointed twice to
+    `docs/history/BATCH9_AUDIT_REMEDIATION_PLAN_2026-02-20.md`, and
+    `BATCH10_DEFINITION_2026-02-21.md` pointed to the old
+    `docs/history/ROUTES_SOC_AUDIT_2026-02-21.md` and
+    `docs/history/TEST_QUALITY_AUDIT_2026-02-21.md` paths. All three reports
+    now live under `docs/history/reports/`. These are definition-to-report
+    references, not exempt point-in-time citations, so they must be repointed.
+  - `_fetch_and_process()` returns immediately after `set_job_error` when
+    `fetch_metadata["status"] == "error"`, while a `partial` status records
+    `partial_data_warning` and continues. The diagram drew an unconditional
+    transition from page fetching into grouping.
+  - `_fetch_spotify_misses()` raises `SpotifyUnavailableError` when token
+    acquisition fails with no cache hits, caught in `_fetch_and_process` as
+    `set_job_error("spotify_unavailable"); return []` -- no merge or store.
+    The diagram's no-cache-hits branch rejoined the unconditional merge/store
+    steps.
+- Plan vs implementation: repointed the four report paths in the remediation
+  plan and the two batch definitions; the Top Albums sequence now branches on
+  Last.fm status (terminal error vs partial-success-with-warning) and
+  terminates after the no-cache-hits token failure while retaining the
+  cached-success continuation.
+- Deviations: none. No production behavior changed and no tests were added;
+  existing tests already cover the Last.fm error/partial paths and the
+  no-cache-hits token failure.
+- Validation: the updated diagram passes Mermaid validation and opens in
+  preview. `pytest -q` -- **590 passed**, 3 known warnings. `pre-commit run
+  --all-files` -- all hooks pass. `doc_state_sync.py --check` -- exit 0 with
+  the expected active-root `BATCH21_DEFINITION.md` warning.
+- Forward guidance: commit and push this final remediation, then resolve the
+  four threads. PR #171 remains unmerged pending separate owner instruction.
+
+### 2026-08-15 - PR #171 final two Codex threads remediated (side-task)
+
+- Scope: the two remaining unresolved Codex threads on `3508c48`, both on the
+  Top Albums sequence diagram. Both were verified against the code before any
+  edit and both were valid.
+- Verification:
+  - `_get_db_connection()` returns `None` when `DATABASE_URL` is unset,
+    asyncpg is unavailable, or connection attempts fail; `process_albums`
+    then sets a `db_cache_warning` stat and skips lookup, cleanup, and
+    persistence, so every album becomes a miss. The diagram presented those
+    three cache operations as unconditional.
+  - `_fetch_spotify_misses()` sets `partial_data_warning` and returns without
+    searching when Spotify token acquisition fails and cache hits exist, so
+    the pipeline completes successfully with cached albums only; it raises
+    `SpotifyUnavailableError` only when no cache hits exist. The diagram sent
+    every miss through search and grouped the token failure with the terminal
+    path.
+- Plan vs implementation: the Top Albums sequence now branches on DB
+  availability before the cache lookup and branches the Spotify token-fetch
+  failure into a success-with-warning path (cached albums only) versus the
+  terminal `spotify_unavailable` path.
+- Deviations: none. No production behavior changed and no tests were added;
+  existing tests already cover the DB-disabled fallback and the partial-cache
+  continuation.
+- Validation: the updated diagram passes Mermaid validation and opens in
+  preview; the tracked block exactly matches its ignored `.mmd` source.
+  `pytest -q` -- **590 passed**, 3 known warnings. `pre-commit run --all-files`
+  -- all 10 hooks pass. `doc_state_sync.py --check` -- exit 0 with the expected
+  active-root `BATCH21_DEFINITION.md` warning.
+- Forward guidance: commit and push this final remediation, then resolve both
+  threads. PR #171 remains unmerged pending separate owner instruction.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Status](https://img.shields.io/badge/status-active-brightgreen.svg)](https://github.com/pterw/ScrobbleScope)
 [![Python Version](https://img.shields.io/badge/python-3.13%2B-blue.svg)](https://www.python.org/downloads/)
-[![Tests](https://img.shields.io/badge/tests-590_passing-brightgreen.svg)](tests/)
+[![Tests](https://img.shields.io/badge/tests-591_passing-brightgreen.svg)](tests/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 **[Try it live ->](https://scrobblescope.fly.dev)**
@@ -81,7 +81,7 @@ This project was initially built to identify top albums released in a specific y
 | Async HTTP | `aiohttp`, `aiolimiter` (per-loop rate limiters with jitter retry) |
 | Database | PostgreSQL via `asyncpg` (optional -- Spotify metadata cache) |
 | Security | Flask-WTF `CSRFProtect`, `\|tojson` XSS bridge, `escapeHtml()`, startup secret guard |
-| Testing | pytest (590 tests across 35 files), 89% coverage |
+| Testing | pytest (591 tests across 35 files), 89% coverage |
 | CI/CD | GitHub Actions Quality Gate (pre-commit, pytest + coverage gate, pip-audit) |
 | Deployment | Fly.io (shared-cpu-2x @ 512 MB, Postgres add-on) |
 | Code Quality | pre-commit (black, isort, autoflake, flake8, trailing whitespace, fix end-of-files, check yaml, check-merge-conflict, detect-private-key, doc-state-sync) |
@@ -455,7 +455,7 @@ pre-commit run --all-files
 |   |   |-- test_smoke_cache_check.py       # HTTP client + smoke test unit tests (13)
 |   |   `-- test_concurrent_users_test.py   # Concurrency script unit tests (6)
 |   `-- services/
-|       |-- test_lastfm_logic.py       # Album aggregation logic (7)
+|       |-- test_lastfm_logic.py       # Album aggregation logic (8)
 |       |-- test_lastfm_service.py     # Last.fm client + progress (9)
 |       |-- test_orchestrator_fetch_and_process.py  # Fetch pipeline (10)
 |       |-- test_orchestrator_fetch_spotify.py      # Spotify fetch (8)

--- a/README.md
+++ b/README.md
@@ -463,9 +463,10 @@ pre-commit run --all-files
 |       |-- test_orchestrator_process_albums.py     # Album processing (7)
 |       `-- test_spotify_service.py    # Spotify client + token mgmt (10)
 |-- docs/
+|   |-- AGENT_DOC_MAP.md           # Which document owns what, for AI agents
 |   |-- ARCHITECTURE.md            # Canonical architecture index
 |   |-- architecture/              # One canonical detailed diagram per file
-|   |-- SWE_AUDIT_CHARTER.md       # Standing audit scope and method
+|   |-- SWE_AUDIT_CHARTER.md       # Retired 2026-08-20; record of audit scope
 |   |-- images/                    # Screenshots for README
 |   |-- history/                   # Archived batch defs, audits, changelogs
 |   |-- logarchive/                # Rotated PLAYBOOK Section 4 entries

--- a/docs/AGENT_DOC_MAP.md
+++ b/docs/AGENT_DOC_MAP.md
@@ -1,0 +1,265 @@
+# Document map for agents
+
+This document is for AI agents that work on ScrobbleScope. It is written for
+agents that are new to the repository, in particular agents other than the
+one that wrote most of these documents.
+
+This document is a map. It tells you which document to open, and it tells you
+why the document exists. It does not repeat the rules. `AGENTS.md` owns the
+rules.
+
+Language note: this document uses short sentences and the active voice, in
+the style of ASD-STE100 Simplified Technical English. The STE dictionary is
+licensed, and the writer of this document could not read it. Do not read this
+note as a claim of STE compliance.
+
+---
+
+## 1. The rule that shapes every document
+
+Each fact has one owner. One document holds the fact. Every other document
+links to it.
+
+`AGENTS.md` calls this the anti-duplication rule.
+
+The reason is cost. This repository is written by many agents across long
+gaps of time. A copied fact does not stay a copy. One agent corrects the
+first copy, and the second copy becomes a lie. The repository has paid for
+this many times. `AGENTS.md` records the largest cases in its Anti-Pattern
+Registry.
+
+Three consequences apply to you:
+
+1. Do not copy a fact into a second document. Link to the owner instead.
+2. If two documents disagree, find the owner. The owner wins.
+3. If a document tells you that another document owns a subject, stop reading
+   and open that document. The pointer is deliberate. It is not laziness.
+
+---
+
+## 2. Where to start
+
+`AGENTS.md` owns the read order. Follow the "Session Bootstrap" section of
+that document. Do not build your own order.
+
+The order puts the rules first and the state last. The reason is that state
+changes every day and rules almost never change. An agent that reads the
+state first will apply it with the wrong rules.
+
+`AGENTS.md` also gives two fast paths. Use them when your task is a single
+pull-request comment. A full bootstrap for a one-line comment wastes tokens.
+
+`HANDOFF_PROMPT.md` holds two things. It holds the checks that you run after
+you read the bootstrap files. It holds the checklist that you follow when you
+stop work. It holds no rules, and it points to `AGENTS.md` for all of them.
+
+---
+
+## 3. The document groups
+
+| Group | Documents | Open it when |
+|-------|-----------|--------------|
+| Rules | `AGENTS.md` | Always. First. |
+| Session procedure | `HANDOFF_PROMPT.md` | You start or end a session. |
+| Work order | `PLAYBOOK.md` | You need the next action or the recent history. |
+| Batch scope | `BATCH21_DEFINITION.md` | You work inside the active batch. |
+| State | `.claude/SESSION_CONTEXT.md` | You need the test count, the module list, or the dependency graph. |
+| Owner context | `AGENT_NOTES.md` | You need a preference, the local setup, or a known constraint. |
+| Findings | `FINDINGS.md` | Your task names an `F-` identifier, or a P0 or P1 item. |
+| Architecture | `docs/ARCHITECTURE.md` | You need a diagram of the system or the pipelines. |
+| History | `docs/history/` | A log entry or a task sends you to a dated document. |
+
+Two notes on this table.
+
+`FINDINGS.md` is not part of the bootstrap set. Open it on demand. The file
+is long, and most tasks do not need it.
+
+The batch definition moves. A definition file at the repository root belongs
+to an open batch. A definition file under `docs/history/definitions/` belongs
+to a closed batch. Use the location to tell the two apart. `PLAYBOOK.md`
+Section 3 is the authority when you are not sure.
+
+---
+
+## 4. Documents for humans
+
+Some documents at the repository root are for people, not for agents. They
+give you no authority. Do not quote them as a rule.
+
+| Document | Audience |
+|----------|----------|
+| `README.md` | The user and the developer. Product and setup. |
+| `DEVELOPMENT.md` | The reader who wants the reasoning behind the project. |
+| `DEPLOY.md` | The person who deploys the application. |
+| `CONTRIBUTING.md` | The outside contributor. |
+| `CODE_OF_CONDUCT.md` | The community. |
+
+`DEVELOPMENT.md` states this limit in its own opening. It explains how the
+project was built. It grants no agent authority.
+
+`README.md` is the one exception to the "do not edit" instinct. `AGENTS.md`
+requires you to update it when your change affects setup or visible
+behaviour. Read the exception in `AGENTS.md` first, because an active batch
+can defer README work to a dedicated work package.
+
+---
+
+## 5. How to read an audit
+
+An audit in this repository moves through six steps. The SWE principles
+audit is the worked example.
+
+1. **The charter.** The owner writes what to audit, how to grade, and what
+   result stops the work. Example: `docs/SWE_AUDIT_CHARTER.md`.
+2. **The execution.** One agent runs the charter in a dedicated session.
+3. **The report.** The agent writes a dated report under
+   `docs/history/reports/`. Example:
+   `docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md`.
+4. **The findings.** New problems become items in `FINDINGS.md`. Each item
+   gets an `F-` identifier.
+5. **The log entry.** A dated entry goes into `PLAYBOOK.md` Section 4, in the
+   same commit as the report.
+6. **The retirement.** The charter stays in the repository. Its status line
+   says that it is retired, and it names the report.
+
+### Why the charter stays after the audit ends
+
+The report tells you what the agent found. The charter tells you what the
+agent was asked to find. You need both to judge the report. A finding that
+is absent from a report can mean that the code is clean, or it can mean that
+the charter put that code out of scope. Only the charter answers that.
+
+### Why a dated report is never edited
+
+A dated report records what was true on that date. If you edit the body, the
+record disappears, and no one can tell what the audit concluded.
+
+Corrections go into a new section at the top of the report. The body stays as
+written.
+
+`docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md` shows the pattern.
+It has an "Owner review" section. That section states that one finding in the
+body is partly wrong. The wrong text is still there, below it. Read the
+correction section before you trust the body.
+
+### An audit report is not current truth
+
+An audit report is a measurement of one day. Three things can make it stale:
+
+- The code changed after the audit ran.
+- The owner overruled a finding.
+- The audit was wrong.
+
+The third case is real. The SWE report filed one finding on a false premise.
+The owner corrected it.
+
+When a report and the source code disagree, the code wins. `docs/ARCHITECTURE.md`
+states the same rule for the diagrams.
+
+### Where the other audits are
+
+`docs/history/reports/` holds every dated report. The names carry the date.
+`FINDINGS.md` lists the important ones under "Source documents".
+
+---
+
+## 6. How to read the findings
+
+`FINDINGS.md` holds the open items. `docs/history/findings/FINDINGS_ARCHIVE.md`
+holds the closed items. Nothing is deleted. The archive keeps the search
+history.
+
+Read the identifier first. The format is `F-<context>-<number>`. The context
+is a batch tag, such as `B21`, or a source tag, such as `SWE` or `DOCSYNC`.
+`AGENTS.md` owns the list of valid tags and the rules for writing a finding.
+
+Three properties matter when you navigate:
+
+- **The identifier never changes.** It stays with the item when the item
+  moves to the archive. Old documents that cite the identifier stay correct.
+  Do not renumber a finding.
+- **The severity sets the order, not the truth.** P0, P1, P2, and Info tell
+  you when the owner plans to act. A P2 item is still a real defect.
+- **The section tells you the state.** An item under "Resolved this batch" is
+  closed but not yet archived. Rotation moves it later.
+
+Do not add a finding as a side effect of another task. `AGENTS.md` owns the
+rules for writing one, and a finding that skips them costs a review round.
+
+---
+
+## 7. Traps in this repository
+
+These are navigation hazards. Each one has caught an agent before.
+
+**Three paths hold the same archive name.** Only one holds content:
+`docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`. The two paths under
+`docs/history/` are pointer stubs. They exist so that old references still
+resolve. Read `docs/logarchive/README.md` for the lookup map.
+
+**Dated entries are records.** A dated entry in `PLAYBOOK.md` Section 4, and
+a dated report under `docs/history/`, both describe one moment. Do not
+correct them when the facts change. Correct the live document instead.
+`AGENTS.md` states this exception inside its Anti-Pattern Registry.
+
+**Part of the state document is machine-written.** `.claude/SESSION_CONTEXT.md`
+contains a managed block. `scripts/doc_state_sync.py` writes it from
+`PLAYBOOK.md`. Do not edit the block by hand. Do not move an entry across a
+`DOCSYNC` marker by hand.
+
+**Numbers in documents go stale.** Test counts, module counts, and coverage
+figures are copies. Run the measuring command before you repeat a number. A
+coverage figure in this repository was wrong for five months because agents
+copied it forward.
+
+**A green tool run is not proof.** `pre-commit run --all-files` saves and
+restores your unstaged changes. That cycle has reverted files that nobody
+edited, while every hook reported a pass. Compare the files before and after
+the run. After you commit, read the file back out of the commit.
+
+**`.github/agents/` is off limits.** `AGENTS.md` forbids it. The directory
+does not exist today, so the rule is a guard against a future conflict of
+rule sources.
+
+**Copilot loads two files of its own.** `.github/copilot-instructions.md` and
+`.github/instructions/mermaid.instructions.md` cover diagram work only.
+`AGENTS.md` is still the ruleset.
+
+---
+
+## 8. Before you change a document
+
+`AGENTS.md` owns the gates. Its "Commit Rules" section gives the order, and
+its "Doc Sync Rules" section gives the sync step. Follow them there.
+
+Two points of that procedure surprise new agents, so they are named here with
+their reasons:
+
+- **You write the documentation first, then run the gates.** One gate checks
+  the documentation. A gate that runs before the update cannot check it.
+- **You stage files by name.** Bulk staging is forbidden, even when every
+  changed file belongs to your work. The command is the hazard, because it
+  collects whatever else sits in the tree.
+
+`scripts/doc_state_sync.py` validates the live documents and returns numbered
+`DOC` diagnostics. `scripts/docsync/integrity.py` defines each code and the
+rule it enforces. Read the diagnostic text; it names the repair.
+
+---
+
+## 9. If two documents disagree
+
+Work through this order:
+
+1. Find the owner of the fact in the "Document Roles" table in `AGENTS.md`.
+   The owner wins.
+2. If neither document owns the fact, prefer the source code. Code is not a
+   copy.
+3. If the disagreement is about the next action, prefer `PLAYBOOK.md`
+   Section 3.
+4. If the disagreement changes what you are about to do, and the steps above
+   do not settle it, stop and ask the owner. Do not merge two rule sources
+   yourself.
+
+Then repair the loser in the same commit as your work. A disagreement that
+you leave behind becomes the next agent's review round.

--- a/docs/SWE_AUDIT_CHARTER.md
+++ b/docs/SWE_AUDIT_CHARTER.md
@@ -1,7 +1,7 @@
 # SWE Principles Audit Charter
 
-**Status:** Chartered 2026-07-31, execution pending. Tracked as FINDINGS.md
-F-SWE-1.
+**Status:** Chartered 2026-07-31. Amended 2026-08-19 (preflight review before
+Batch 21 WP-1). Execution pending. Tracked as FINDINGS.md F-SWE-1.
 **Executor contract:** any dedicated, single-purpose agent session (Claude,
 Codex, or equivalent) can run this cold. The judgment is front-loaded into
 this charter; the executor's job is careful reading, evidence gathering,
@@ -17,89 +17,226 @@ status does not change while the audit runs (it is a read-only side-task).
 
 ## 2. Scope
 
-**In scope (Python only):**
+**In scope.** Exactly these 13 modules. The list is closed. Do not add to it,
+and do not drop from it.
 
-- `scrobblescope/` -- all 13 modules (~3,100 LOC)
-- `app.py` (~150 LOC)
-- `scripts/docsync/` -- parser/renderer/logic/cli/models (~1,000 LOC)
+| Module | Graded |
+|---|---|
+| `app.py` | yes |
+| `scrobblescope/cache.py` | yes |
+| `scrobblescope/config.py` | yes |
+| `scrobblescope/domain.py` | yes |
+| `scrobblescope/errors.py` | yes |
+| `scrobblescope/heatmap.py` | yes |
+| `scrobblescope/lastfm.py` | yes |
+| `scrobblescope/orchestrator.py` | yes |
+| `scrobblescope/repositories.py` | yes |
+| `scrobblescope/routes.py` | yes |
+| `scrobblescope/spotify.py` | yes |
+| `scrobblescope/utils.py` | yes |
+| `scrobblescope/worker.py` | yes |
+| `scrobblescope/__init__.py` | **no -- empty file, see rule below** |
 
-**Explicitly OUT of scope:**
+**Empty-module rule:** a module with no statements other than a docstring gets
+no matrix row. It is listed above so its absence from the matrix is a recorded
+decision, not an oversight. Confirm it is still empty at audit time; if it has
+gained content, grade it and say so in the report.
 
-- `static/js/` (~1,860 LOC) and all templates/CSS -- Batch 21 rewrites
-  them; auditing them before it ships wastes the work. A follow-up
-  charter can add them post-Batch-21.
-- Tests are read for evidence (vacuity, coverage) but are not graded
-  cells in the matrix.
-- **No code changes of any kind.** This is a read-only audit. Findings
-  become F-SWE-N entries; fixes are future batch work.
+**Explicitly OUT of scope, each for a stated reason:**
+
+- `static/js/` and all templates and CSS -- Batch 21 rewrites them. Auditing
+  them now wastes the work. This exclusion is paid for by the WP-8 frontend
+  audit that `BATCH21_DEFINITION.md` now requires; it is no longer optional.
+- `scripts/docsync/` -- carries the freshest dedicated audits and is not on the
+  Batch 21 migration path. Its known boundaries are already tracked as
+  F-DOCSYNC-6 and F-DOCSYNC-7 in `FINDINGS.md`.
+- `scripts/dev/` -- the worktree-guard family, shipped and reviewed through
+  PR #169 and PR #170. Its size problems are already tracked as F-WORKTREE-3
+  and F-WORKTREE-4. Named here because the earlier charter left it neither in
+  nor out.
+- Tests are read for evidence (vacuity, coverage) but are not graded cells.
+  Section 5 says where that evidence lands.
+- **No code changes of any kind.** This is a read-only audit. Findings become
+  F-SWE-N entries; fixes are future batch work.
+
+**Matrix size:** 13 modules x 10 principles = **130 cells**. There is no
+permission to cut coverage. If the audit cannot fit a single session, split it
+across sessions and say so in the report -- do not drop modules. A report that
+silently covers less than 130 cells implies coverage it does not have.
+
+## 2a. Provenance (record before grading, publish in the report)
+
+The report must open with a provenance block. Fill it from live commands, not
+from this charter:
+
+```bash
+git rev-parse --abbrev-ref HEAD          # audited branch
+git rev-parse HEAD                       # exact SHA graded
+git status --porcelain                   # must be empty, or list what is dirty
+git ls-files 'scrobblescope/*.py' app.py # confirm the module list above
+```
+
+A grade is a claim about one tree. Without the SHA the matrix cannot be
+rechecked, and every cell becomes unfalsifiable.
+
+**Staleness warning:** Batch 21 WP-7 modifies `routes.py` and `orchestrator.py`.
+Grades for those two modules expire when WP-7 lands. Say so in the report next
+to their rows rather than leaving a reader to discover it.
 
 ## 3. The ten principles (grade each)
 
 The canonical list and its definitions live in `AGENT_NOTES.md` Owner
 Preferences. Grade every principle named there, using that wording --
-do not keep a second copy in this file. Two need audit-specific method:
+do not keep a second copy in this file.
+
+**Count check:** that list currently names ten principles, and this charter's
+cell arithmetic assumes ten. Count them at audit time. If the count has
+changed, the matrix width changes with it -- report the new count and the new
+cell total rather than forcing ten.
+
+Two need audit-specific method:
 
 - **Clean Architecture:** check dependencies against the acyclic graph
   in SESSION_CONTEXT Section 4.
-- **Boy Scout Rule:** assess via git history of the files each change
-  touched.
+- **Boy Scout Rule:** assess over a fixed window -- commits to each module
+  since the 2026-02 audits, that is `git log --since=2026-03-01 -- <module>`.
+  Judge whether touched code was left cleaner, not whether the module is
+  clean in absolute terms. Without a window this principle grades the whole
+  history of the file, which is not what it means.
 
 ## 4. Differential baseline (do NOT re-report)
 
-These are already found, tracked, or deliberately declined. Re-reporting
-any of them is audit failure, not thoroughness:
+Re-reporting a known item is audit failure, not thoroughness. The baseline is
+not a list to memorise -- it is a corpus to read:
 
-- Already-tracked findings, whatever their current status: F-MAS-1
-  through F-MAS-8, F-B20-2 (orchestrator decomposition -- the single
-  biggest known SoC/SRP item), the F-DOCSYNC items in FINDINGS.md,
-  F-B18-2/3/4/5/10 (deferred block), and F-LOAD-1/2. Check each ID's
-  `Status:` line in FINDINGS.md rather than assuming from this list;
-  resolved items remain part of the baseline and must not be re-raised.
-- `docs/history/reports/AUDIT_2026-02-27_MULTI_AGENT_SWEEP.md` (lines 113-136
-  list the prior runtime SoC/DRY/code-smell findings).
-- `docs/history/reports/ROUTES_SOC_AUDIT_2026-02-21.md` -- Section 4 "What was
-  NOT changed" documents deliberate declines; respect them.
-- `docs/history/reports/TEST_QUALITY_AUDIT_2026-02-21.md`.
-- Standing design decisions (F-LOAD-3/4/5, AGENT_NOTES.md Architectural
-  Constraints): in-memory REQUEST_CACHE, single-worker JOBS dict,
-  TTL-on-write cache, ProactorEventLoop guard. These are choices, not
-  findings.
+1. **All of `FINDINGS.md`.** Every open item, whatever its severity.
+2. **All of `docs/history/findings/FINDINGS_ARCHIVE.md`.** Resolved and
+   no-action items stay part of the baseline and must not be re-raised.
+3. **Every report under `docs/history/reports/`** dated 2026-02 or later.
+   As of this amendment that includes `AUDIT_2026-02-27_MULTI_AGENT_SWEEP.md`
+   (lines 113-136 list prior runtime SoC/DRY/code-smell findings),
+   `ROUTES_SOC_AUDIT_2026-02-21.md` (Section 4 "What was NOT changed"
+   documents deliberate declines -- respect them),
+   `TEST_QUALITY_AUDIT_2026-02-21.md`, `GUARD_HARDENING_2026-08-11.md`, and
+   `REPOSITORY_SYNTHESIS_2026-08-11.md`. List the directory rather than
+   trusting this sentence to stay current.
+
+Read the corpus by listing those locations, not by matching the ID list an
+earlier version of this charter carried. That list was closed and had already
+gone stale: it omitted F-B21-1, F-DATA-1, F-WORKTREE-3/4/5, F-DOCSYNC-6/7 and
+F-AUDIT-1, several of which sit in modules this audit grades.
+
+**Standing design decisions are choices, not findings:** F-LOAD-3/4/5 and the
+`AGENT_NOTES.md` Architectural Constraints -- in-memory REQUEST_CACHE,
+single-worker JOBS dict, TTL-on-write cache, ProactorEventLoop guard.
 
 The audit's value is NET-NEW findings and a defensible per-module grade,
 not volume.
 
 ## 5. Method
 
-1. Read the baseline documents in Section 4 first.
-2. Examine pre-identified hotspots before anything else:
-   - `orchestrator.py:719` `_fetch_and_process` (~153 lines)
-   - `routes.py:405` `results_loading` (~115 lines)
-   - `heatmap.py:89` `_fetch_and_process_heatmap` (~111 lines)
-   - the 17 `except Exception` sites (routes 5, orchestrator 4, cache 2,
-     lastfm 2, utils 2, heatmap 1, worker 1) -- F-MAS-4 tracks the
-     count; the audit grades whether each catch is justified, which
-     F-MAS-4 never did.
-3. Fill a 10-principle x module grading matrix. Grade A/B/C/D per cell
-   with a one-line evidence citation (`file:line`). "Not applicable"
-   is a valid cell value (e.g., Composition over Inheritance in a
-   module with no classes) -- grade what exists.
-4. For every C or D cell, either map it to an existing finding (cite the
-   F-ID, no new entry) or write a net-new F-SWE-N finding per AGENTS.md
-   Finding-Writing Rules (heading, one-sentence problem, Status, Source:
-   `SWE_PRINCIPLES_AUDIT`).
-5. Answer two summary questions in prose: (a) which principle is weakest
-   repo-wide and what single change would most improve it; (b) has code
-   quality drifted since the 2026-02 audits, held, or improved --
-   with evidence.
+1. Read the baseline corpus in Section 4 first.
+2. Record the provenance block from Section 2a.
+3. Discover hotspots live rather than trusting written counts. The previous
+   version of this charter hardcoded line numbers and an exception count that
+   had already drifted; `AGENTS.md` anti-pattern 10 forbids repeating a number
+   without re-measuring it. Use symbol-based discovery:
 
-## 6. Output contract
+   ```bash
+   # longest functions, by definition, across the in-scope set
+   git ls-files 'scrobblescope/*.py' app.py | xargs awk '/^(async )?def |^class /{...}'
+   # broad catches, with their real locations
+   git grep -n "except Exception" -- 'scrobblescope/*.py' app.py
+   ```
+
+   Record the command and its output in the report. The known-largest
+   functions are `_fetch_and_process` in `orchestrator.py`, `results_loading`
+   in `routes.py`, and `_fetch_and_process_heatmap` in `heatmap.py` -- locate
+   them by name, not by line number. F-MAS-4 tracks the broad-catch count; the
+   audit grades whether each catch is justified, which F-MAS-4 never did.
+4. Fill the 13-module x 10-principle matrix. Grade A/B/C/D per cell with a
+   one-line evidence citation (`file:line`). "Not applicable" is a valid cell
+   value (for example, Composition over Inheritance in a module with no
+   classes) -- grade what exists, and say why it does not apply.
+5. Apply the rubric in Section 5a. Every C or D cell either maps to an
+   existing finding or becomes a net-new one, per Section 5b.
+6. Answer two summary questions in prose: (a) which principle is weakest
+   repo-wide and what single change would most improve it; (b) has code
+   quality drifted since the 2026-02 audits, held, or improved -- with
+   evidence, and reckoning with `REPOSITORY_SYNTHESIS_2026-08-11.md` rather
+   than treating February as the last word.
+7. Collect test-vacuity evidence while reading. Tests are not graded cells,
+   but `AGENT_NOTES.md` mandates that every test must fail if the function
+   under test is deleted. Any test that would survive deletion of its subject
+   is a net-new finding in its own right, filed against the module it covers.
+
+## 5a. Grading rubric
+
+Grades are not vibes. A cell's grade is determined by what the evidence shows,
+and the C boundary matters most because it is the finding threshold.
+
+| Grade | Meaning | Test to apply |
+|---|---|---|
+| **A** | The principle is upheld throughout the module. | No counter-example found after reading the module whole. |
+| **B** | Upheld, with a local exception that is deliberate or harmless. | A counter-example exists, but it is contained, documented, or cheaper than the fix. State it; do not raise a finding. |
+| **C** | Violated in a way that costs real maintainability now. | A counter-example a maintainer would have to work around. **Becomes a finding.** |
+| **D** | Violated structurally; the module is organised against the principle. | The violation is the module's shape, not an instance in it. **Becomes a finding.** |
+| **N/A** | The principle has no purchase on this module. | Say why in one line (for example: no classes, so Composition over Inheritance cannot apply). |
+
+The B/C line is the judgment call this rubric exists to constrain: **B is an
+exception, C is a pattern.** If you can point at one place, it is B. If you
+would have to point at several, or at the way the module is laid out, it is C.
+When genuinely torn, grade C and let the finding be closed as no-action --
+an over-raised finding is cheap to decline, an under-raised one is invisible.
+
+## 5b. What happens to a C or D cell
+
+Each C or D cell resolves exactly one of three ways:
+
+1. **Maps to an open finding.** Cite the F-ID. No new entry.
+2. **Maps to a finding that is resolved or no-action.** Do **not** cite it as
+   live evidence, and do **not** re-raise it. Instead write a net-new finding
+   that says the earlier fix did not hold, and cite the old F-ID as history.
+   A `Status: resolved` finding cannot be the standing explanation for a
+   present-tense defect.
+3. **Nothing covers it.** Write a net-new F-SWE-N finding per `AGENTS.md`
+   Finding-Writing Rules (heading, one-sentence problem, `Status:`, and
+   `Source: SWE_PRINCIPLES_AUDIT`).
+
+## 6. What blocks the migration
+
+This audit is read-only, but it is not consequence-free. It runs immediately
+before Batch 21 WP-1, and finishing it is not the same as passing it.
+
+Classify every net-new finding, then apply this policy:
+
+| Finding | Effect on WP-1 |
+|---|---|
+| **P0** by the FINDINGS.md severity key | **Stop.** Fix before WP-1 begins. |
+| Correctness defect in a module any Batch 21 WP modifies -- currently `routes.py` and `orchestrator.py` via WP-7 | **Stop.** Fix or get an explicit owner waiver before WP-1 begins. |
+| P1 in a module Batch 21 does not touch | Record and continue. |
+| P2 and below | Backlog. |
+
+"Correctness defect" means the module can produce a wrong result, lose data,
+leak a resource, or fail to release one -- not that it is untidy. The test is
+mechanical on purpose: severity, plus whether the module appears in a WP's
+file list. Neither half requires interpretation.
+
+The report must state the verdict in one line near the top: **migration may
+proceed**, or **migration is blocked by `<F-IDs>`**. A report that finds blocking
+defects and does not say so has failed its main job.
+
+## 7. Output contract
 
 - Report: `docs/history/reports/SWE_PRINCIPLES_AUDIT_<YYYY-MM-DD>.md` -- the
-  matrix, per-cell evidence, the two prose answers, and a net-new
-  findings list.
+  provenance block, the migration verdict, the matrix, per-cell evidence, the
+  two prose answers, and a net-new findings list.
 - FINDINGS.md: append net-new F-SWE-N entries (start at F-SWE-2;
   F-SWE-1 is this charter's tracking entry). Update F-SWE-1 to
   `Status: resolved -- report at <path>`.
+- **Retire this charter in the same commit.** Change the Status line at the
+  top of this file to `Executed <date>, report at <path>`. Leaving it as
+  "execution pending" makes this file false the moment F-SWE-1 closes.
 - PLAYBOOK Section 4: one dated side-task entry, placed and tagged per
   AGENTS.md Side-Task Handling.
 - Validation gates per AGENTS.md Commit Rules (docs-only change; all
@@ -108,10 +245,13 @@ not volume.
   F-SWE findings` (imperative mood per AGENTS.md Commit Rules).
   Do not push without owner instruction.
 
-## 7. Budget guidance
+## 8. Budget guidance
 
-Target a single focused session. If module coverage must be cut to fit,
-cut `scripts/docsync/` first (it has the freshest dedicated audit) and
-name every skipped module in the report's scope section. A report that
-does not list what it skipped implies coverage it does not have, which
-defeats the purpose of the audit.
+Target a single focused session. If the work does not fit, **split it across
+sessions and complete all 130 cells** -- record in the report which session
+covered which modules. Coverage is not negotiable; session count is.
+
+The earlier version of this charter permitted cutting modules to fit. That
+permission is withdrawn: it let a "comprehensive" audit ship incomplete while
+still reading as complete, and it handed a scope decision to the executor that
+this charter is supposed to have already made.

--- a/docs/SWE_AUDIT_CHARTER.md
+++ b/docs/SWE_AUDIT_CHARTER.md
@@ -43,6 +43,22 @@ no matrix row. It is listed above so its absence from the matrix is a recorded
 decision, not an oversight. Confirm it is still empty at audit time; if it has
 gained content, grade it and say so in the report.
 
+**Reading depth.** All 13 modules are graded and no cell is optional, but they
+do not cost the same, and this charter says where the time goes rather than
+leaving an executor to find out. Measured 2026-08-19: the four smallest modules
+hold 197 lines between them and consume 40 cells, while the two largest hold
+1,558 lines and consume 20. Effort tracks the matrix, not the code, so correct
+for it deliberately:
+
+| Depth | Modules | What it means |
+|---|---|---|
+| **Deep** | `orchestrator.py`, `routes.py`, `utils.py` | Read whole, more than once where the flow is hard to hold. Two of the three are what WP-7 modifies, so the migration verdict rests on them. This is where the session's time belongs. |
+| **Standard** | `lastfm.py`, `heatmap.py`, `repositories.py`, `cache.py`, `app.py`, `spotify.py` | Read whole once. Grade, cite what you find. |
+| **Light** | `domain.py`, `errors.py`, `worker.py`, `config.py` | 40 to 70 lines each. Read whole -- it takes a minute -- grade, move on. Do not hunt for findings in 40 lines of constants. |
+
+Depth directs attention; it is not permission to skip. Every cell is still
+filled.
+
 **Explicitly OUT of scope, each for a stated reason:**
 
 - `static/js/` and all templates and CSS -- Batch 21 rewrites them. Auditing
@@ -121,14 +137,23 @@ not a list to memorise -- it is a corpus to read:
 1. **All of `FINDINGS.md`.** Every open item, whatever its severity.
 2. **All of `docs/history/findings/FINDINGS_ARCHIVE.md`.** Resolved and
    no-action items stay part of the baseline and must not be re-raised.
-3. **Every report under `docs/history/reports/`** dated 2026-02 or later.
-   As of this amendment that includes `AUDIT_2026-02-27_MULTI_AGENT_SWEEP.md`
-   (lines 113-136 list prior runtime SoC/DRY/code-smell findings),
-   `ROUTES_SOC_AUDIT_2026-02-21.md` (Section 4 "What was NOT changed"
-   documents deliberate declines -- respect them),
-   `TEST_QUALITY_AUDIT_2026-02-21.md`, `GUARD_HARDENING_2026-08-11.md`, and
-   `REPOSITORY_SYNTHESIS_2026-08-11.md`. List the directory rather than
-   trusting this sentence to stay current.
+3. **These five reports, and only these five.** `docs/history/reports/` holds
+   25 files and roughly 5,600 lines, but most are changelogs, refactor plans
+   and implementation summaries that carry no findings; reading them is
+   bookkeeping, not baseline. The five that carry findings:
+   - `AUDIT_2026-02-27_MULTI_AGENT_SWEEP.md` -- lines 113-136 list the prior
+     runtime SoC/DRY/code-smell findings.
+   - `ROUTES_SOC_AUDIT_2026-02-21.md` -- Section 4 "What was NOT changed"
+     documents deliberate declines. Respect them.
+   - `TEST_QUALITY_AUDIT_2026-02-21.md`
+   - `GUARD_HARDENING_2026-08-11.md`
+   - `REPOSITORY_SYNTHESIS_2026-08-11.md`
+
+   A previous version of this section said "every report dated 2026-02 or
+   later". That was expensive and, worse, ambiguous: six files in the
+   directory carry no date in their name, so the rule quietly handed a scope
+   decision back to the executor -- the exact fault this charter was amended
+   to remove. If a sixth report starts carrying findings, add it here by name.
 
 Read the corpus by listing those locations, not by matching the ID list an
 earlier version of this charter carried. That list was closed and had already
@@ -158,10 +183,15 @@ not volume.
    by line number. F-MAS-4 tracks the broad-catch count; the audit grades
    whether each catch is justified, which F-MAS-4 never did.
 4. Fill the matrix -- 13 graded modules by the live principle count from
-   Section 3. Grade A/B/C/D per cell with a
-   one-line evidence citation (`file:line`). "Not applicable" is a valid cell
-   value (for example, Composition over Inheritance in a module with no
-   classes) -- grade what exists, and say why it does not apply.
+   Section 3. **Cite evidence only where evidence exists.** A B, C or D cell
+   carries a one-line `file:line` citation. An A cell carries the letter and
+   nothing else: an A means no counter-example was found after reading the
+   module whole, and an absence has no line number to cite. An N/A cell
+   carries a short reason in place of a citation (for example: no classes, so
+   Composition over Inheritance cannot apply). An earlier version demanded a
+   citation for every cell, which demanded evidence that most cells cannot
+   have, and made the cheap majority of the matrix as expensive as the
+   valuable minority.
 5. Apply the rubric in Section 5a. Every C or D cell either maps to an
    existing finding or becomes a net-new one, per Section 5b.
 6. Answer two summary questions in prose: (a) which principle is weakest

--- a/docs/SWE_AUDIT_CHARTER.md
+++ b/docs/SWE_AUDIT_CHARTER.md
@@ -149,7 +149,7 @@ not volume.
 3. Discover hotspots live rather than trusting written counts. The previous
    version of this charter hardcoded line numbers and an exception count that
    had already drifted; `AGENTS.md` anti-pattern 10 forbids repeating a number
-   without re-measuring it. Use symbol-based discovery:
+   without re-measuring it.
 
    Run both commands in Section 5c and record each command with its output in
    the report. The known-largest functions are `_fetch_and_process` in
@@ -176,48 +176,6 @@ not volume.
    but `AGENT_NOTES.md` mandates that every test must fail if the function
    under test is deleted. Any test that would survive deletion of its subject
    is a net-new finding in its own right, filed against the module it covers.
-
-## 5c. Discovery commands
-
-These sit at the left margin deliberately. A shell heredoc ends only when its
-terminator starts at column 0, so if these were indented inside the numbered
-list above, copying them would fail with `IndentationError`. Run them as they
-appear, from the repository root, and paste the real output into the report.
-
-Longest function definitions, parsed with `ast` rather than a regex -- a
-line-matching pattern miscounts decorators, nested definitions and multi-line
-signatures, and the count is the entire point:
-
-```bash
-python - <<'EOF'
-import ast, subprocess
-files = subprocess.run(["git", "ls-files", "scrobblescope/*.py", "app.py"],
-                       capture_output=True, text=True).stdout.split()
-rows = []
-for path in files:
-    tree = ast.parse(open(path, encoding="utf-8").read())
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            rows.append((node.end_lineno - node.lineno + 1, path, node.lineno, node.name))
-print(f"{len(files)} files, {len(rows)} function definitions")
-for length, path, line, name in sorted(rows, reverse=True)[:15]:
-    print(f"{length:4d}  {path}:{line}  {name}")
-EOF
-```
-
-Broad exception catches, with their real locations:
-
-```bash
-git grep -n "except Exception" -- 'scrobblescope/*.py' app.py
-```
-
-Both were run on 2026-08-19 against `bb187ae` and worked as written. The first
-reported 14 files and 99 function definitions, with the three known hotspots at
-151, 112 and 109 lines. The superseded version of this charter called them
-"~153", "~115" and "~111" -- a live demonstration of why anti-pattern 10
-forbids repeating a measured number without re-measuring it. Do not trust the
-figures in this paragraph either; they are here to show the drift, not to save
-you the run.
 
 ## 5a. Grading rubric
 
@@ -265,6 +223,48 @@ Each C or D cell resolves exactly one of these four ways:
 4. **Nothing covers it.** Write a net-new F-SWE-N finding per `AGENTS.md`
    Finding-Writing Rules (heading, one-sentence problem, `Status:`, and
    `Source: SWE_PRINCIPLES_AUDIT`).
+
+## 5c. Discovery commands
+
+These sit at the left margin deliberately. A shell heredoc ends only when its
+terminator starts at column 0, so if these were indented inside the numbered
+list above, copying them would fail with `IndentationError`. Run them as they
+appear, from the repository root, and paste the real output into the report.
+
+Longest function definitions, parsed with `ast` rather than a regex -- a
+line-matching pattern miscounts decorators, nested definitions and multi-line
+signatures, and the count is the entire point:
+
+```bash
+python - <<'EOF'
+import ast, subprocess
+files = subprocess.run(["git", "ls-files", "scrobblescope/*.py", "app.py"],
+                       capture_output=True, text=True).stdout.split()
+rows = []
+for path in files:
+    tree = ast.parse(open(path, encoding="utf-8").read())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            rows.append((node.end_lineno - node.lineno + 1, path, node.lineno, node.name))
+print(f"{len(files)} files, {len(rows)} function definitions")
+for length, path, line, name in sorted(rows, reverse=True)[:15]:
+    print(f"{length:4d}  {path}:{line}  {name}")
+EOF
+```
+
+Broad exception catches, with their real locations:
+
+```bash
+git grep -n "except Exception" -- 'scrobblescope/*.py' app.py
+```
+
+Both were run on 2026-08-19 against `bb187ae` and worked as written. The first
+reported 14 files and 99 function definitions, with the three known hotspots at
+151, 112 and 109 lines. The superseded version of this charter called them
+"~153", "~115" and "~111" -- a live demonstration of why anti-pattern 10
+forbids repeating a measured number without re-measuring it. Do not trust the
+figures in this paragraph either; they are here to show the drift, not to save
+you the run.
 
 ## 6. What blocks the migration
 

--- a/docs/SWE_AUDIT_CHARTER.md
+++ b/docs/SWE_AUDIT_CHARTER.md
@@ -17,8 +17,9 @@ status does not change while the audit runs (it is a read-only side-task).
 
 ## 2. Scope
 
-**In scope.** Exactly these 13 modules. The list is closed. Do not add to it,
-and do not drop from it.
+**In scope.** The 13 graded modules below. The list is closed -- do not add to
+it and do not drop from it. A fourteenth file, `scrobblescope/__init__.py`, is
+listed for completeness and is not graded.
 
 | Module | Graded |
 |---|---|
@@ -59,10 +60,13 @@ gained content, grade it and say so in the report.
 - **No code changes of any kind.** This is a read-only audit. Findings become
   F-SWE-N entries; fixes are future batch work.
 
-**Matrix size:** 13 modules x 10 principles = **130 cells**. There is no
-permission to cut coverage. If the audit cannot fit a single session, split it
-across sessions and say so in the report -- do not drop modules. A report that
-silently covers less than 130 cells implies coverage it does not have.
+**Matrix size:** 13 graded modules x the principle count in `AGENT_NOTES.md`.
+That count is ten at this writing, giving 130 cells -- confirm it at audit time
+per Section 3 and use the live product, not the number written here. There is
+no permission to cut coverage. If the audit cannot fit a single session, split
+it across sessions and say so in the report -- do not drop modules. A report
+covering fewer cells than that product, without saying so, implies coverage it
+does not have.
 
 ## 2a. Provenance (record before grading, publish in the report)
 
@@ -72,18 +76,21 @@ from this charter:
 ```bash
 git rev-parse --abbrev-ref HEAD          # audited branch
 git rev-parse HEAD                       # exact SHA graded
-git status --porcelain                   # must be empty, or list what is dirty
+git status --porcelain                   # must be empty before grading starts
 git ls-files 'scrobblescope/*.py' app.py # confirm the module list above
 ```
 
-A grade is a claim about one tree. Without the SHA the matrix cannot be
-rechecked, and every cell becomes unfalsifiable.
+A grade is a claim about one tree. **Grade a clean worktree only.** If
+`git status --porcelain` is not empty, stop and reconcile before grading: a SHA
+cannot reproduce uncommitted content, so a matrix built over a dirty tree is
+unfalsifiable however carefully its cells cite lines. Recording the dirt is not
+a substitute for removing it.
 
 **Staleness warning:** Batch 21 WP-7 modifies `routes.py` and `orchestrator.py`.
 Grades for those two modules expire when WP-7 lands. Say so in the report next
 to their rows rather than leaving a reader to discover it.
 
-## 3. The ten principles (grade each)
+## 3. The mandated principles (grade each)
 
 The canonical list and its definitions live in `AGENT_NOTES.md` Owner
 Preferences. Grade every principle named there, using that wording --
@@ -99,10 +106,12 @@ Two need audit-specific method:
 - **Clean Architecture:** check dependencies against the acyclic graph
   in SESSION_CONTEXT Section 4.
 - **Boy Scout Rule:** assess over a fixed window -- commits to each module
-  since the 2026-02 audits, that is `git log --since=2026-03-01 -- <module>`.
-  Judge whether touched code was left cleaner, not whether the module is
-  clean in absolute terms. Without a window this principle grades the whole
-  history of the file, which is not what it means.
+  since the 2026-02 audits, that is
+  `git log -p --since=2026-03-01 -- <module>`. Read the patches, not the
+  subject lines: this principle is about what each change left behind, which a
+  list of commits cannot show. Judge whether touched code was left cleaner,
+  not whether the module is clean in absolute terms. Without a window this
+  principle grades the whole history of the file, which is not what it means.
 
 ## 4. Differential baseline (do NOT re-report)
 
@@ -142,33 +151,73 @@ not volume.
    had already drifted; `AGENTS.md` anti-pattern 10 forbids repeating a number
    without re-measuring it. Use symbol-based discovery:
 
-   ```bash
-   # longest functions, by definition, across the in-scope set
-   git ls-files 'scrobblescope/*.py' app.py | xargs awk '/^(async )?def |^class /{...}'
-   # broad catches, with their real locations
-   git grep -n "except Exception" -- 'scrobblescope/*.py' app.py
-   ```
-
-   Record the command and its output in the report. The known-largest
-   functions are `_fetch_and_process` in `orchestrator.py`, `results_loading`
-   in `routes.py`, and `_fetch_and_process_heatmap` in `heatmap.py` -- locate
-   them by name, not by line number. F-MAS-4 tracks the broad-catch count; the
-   audit grades whether each catch is justified, which F-MAS-4 never did.
-4. Fill the 13-module x 10-principle matrix. Grade A/B/C/D per cell with a
+   Run both commands in Section 5c and record each command with its output in
+   the report. The known-largest functions are `_fetch_and_process` in
+   `orchestrator.py`, `results_loading` in `routes.py`, and
+   `_fetch_and_process_heatmap` in `heatmap.py` -- locate them by name, never
+   by line number. F-MAS-4 tracks the broad-catch count; the audit grades
+   whether each catch is justified, which F-MAS-4 never did.
+4. Fill the matrix -- 13 graded modules by the live principle count from
+   Section 3. Grade A/B/C/D per cell with a
    one-line evidence citation (`file:line`). "Not applicable" is a valid cell
    value (for example, Composition over Inheritance in a module with no
    classes) -- grade what exists, and say why it does not apply.
 5. Apply the rubric in Section 5a. Every C or D cell either maps to an
    existing finding or becomes a net-new one, per Section 5b.
 6. Answer two summary questions in prose: (a) which principle is weakest
-   repo-wide and what single change would most improve it; (b) has code
-   quality drifted since the 2026-02 audits, held, or improved -- with
-   evidence, and reckoning with `REPOSITORY_SYNTHESIS_2026-08-11.md` rather
-   than treating February as the last word.
+   **across the audited runtime modules** -- not repo-wide, because this audit
+   deliberately excludes the frontend, both script directories, and tests as
+   graded subjects, and cannot support a conclusion about code it never read;
+   name the single change that would most improve it. (b) Has code quality
+   drifted since the 2026-02 audits, held, or improved -- with evidence, and
+   reckoning with `REPOSITORY_SYNTHESIS_2026-08-11.md` rather than treating
+   February as the last word. Scope this answer the same way.
 7. Collect test-vacuity evidence while reading. Tests are not graded cells,
    but `AGENT_NOTES.md` mandates that every test must fail if the function
    under test is deleted. Any test that would survive deletion of its subject
    is a net-new finding in its own right, filed against the module it covers.
+
+## 5c. Discovery commands
+
+These sit at the left margin deliberately. A shell heredoc ends only when its
+terminator starts at column 0, so if these were indented inside the numbered
+list above, copying them would fail with `IndentationError`. Run them as they
+appear, from the repository root, and paste the real output into the report.
+
+Longest function definitions, parsed with `ast` rather than a regex -- a
+line-matching pattern miscounts decorators, nested definitions and multi-line
+signatures, and the count is the entire point:
+
+```bash
+python - <<'EOF'
+import ast, subprocess
+files = subprocess.run(["git", "ls-files", "scrobblescope/*.py", "app.py"],
+                       capture_output=True, text=True).stdout.split()
+rows = []
+for path in files:
+    tree = ast.parse(open(path, encoding="utf-8").read())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            rows.append((node.end_lineno - node.lineno + 1, path, node.lineno, node.name))
+print(f"{len(files)} files, {len(rows)} function definitions")
+for length, path, line, name in sorted(rows, reverse=True)[:15]:
+    print(f"{length:4d}  {path}:{line}  {name}")
+EOF
+```
+
+Broad exception catches, with their real locations:
+
+```bash
+git grep -n "except Exception" -- 'scrobblescope/*.py' app.py
+```
+
+Both were run on 2026-08-19 against `bb187ae` and worked as written. The first
+reported 14 files and 99 function definitions, with the three known hotspots at
+151, 112 and 109 lines. The superseded version of this charter called them
+"~153", "~115" and "~111" -- a live demonstration of why anti-pattern 10
+forbids repeating a measured number without re-measuring it. Do not trust the
+figures in this paragraph either; they are here to show the drift, not to save
+you the run.
 
 ## 5a. Grading rubric
 
@@ -183,23 +232,37 @@ and the C boundary matters most because it is the finding threshold.
 | **D** | Violated structurally; the module is organised against the principle. | The violation is the module's shape, not an instance in it. **Becomes a finding.** |
 | **N/A** | The principle has no purchase on this module. | Say why in one line (for example: no classes, so Composition over Inheritance cannot apply). |
 
-The B/C line is the judgment call this rubric exists to constrain: **B is an
-exception, C is a pattern.** If you can point at one place, it is B. If you
-would have to point at several, or at the way the module is laid out, it is C.
-When genuinely torn, grade C and let the finding be closed as no-action --
-an over-raised finding is cheap to decline, an under-raised one is invisible.
+The B/C line is the judgment call this rubric exists to constrain, and it turns
+on **cost, not count**. One occurrence can be C: a single leaked resource or a
+single silently wrong result earns C on its own. Five occurrences can stay B if
+each is contained and none costs a maintainer anything today. Ask what the
+violation costs right now -- if the answer is "nothing, and it is written
+down", that is B; if a maintainer has to work around it, that is C.
+
+When genuinely torn, say so in the cell and grade the lower severity. Do not
+raise a finding to be safe. Section 4 states that this audit's value is net-new
+findings and not volume, and a speculative finding costs a reviewer as much
+attention as a real one while teaching the next reader to skim the list.
 
 ## 5b. What happens to a C or D cell
 
-Each C or D cell resolves exactly one of three ways:
+Each C or D cell resolves exactly one of these four ways:
 
 1. **Maps to an open finding.** Cite the F-ID. No new entry.
-2. **Maps to a finding that is resolved or no-action.** Do **not** cite it as
-   live evidence, and do **not** re-raise it. Instead write a net-new finding
-   that says the earlier fix did not hold, and cite the old F-ID as history.
-   A `Status: resolved` finding cannot be the standing explanation for a
-   present-tense defect.
-3. **Nothing covers it.** Write a net-new F-SWE-N finding per `AGENTS.md`
+2. **Maps to a finding marked resolved.** The defect has recurred, so the
+   earlier fix did not hold. Write a net-new finding saying exactly that and
+   cite the old F-ID as history. A `Status: resolved` finding can never be the
+   live explanation for a present-tense defect.
+3. **Maps to a finding marked no-action.** Resolved and no-action are not the
+   same case and do not share a rule. Check whether the recorded rationale
+   still holds:
+   - **Still applies** -- do not re-raise. Note the F-ID in the cell and move
+     on. An unchanged condition that was deliberately accepted is not a
+     finding just because an audit walked past it again.
+   - **Assumptions have materially changed** -- write a net-new finding that
+     explains the delta (what the rationale assumed, what is now true) and
+     cite the old F-ID.
+4. **Nothing covers it.** Write a net-new F-SWE-N finding per `AGENTS.md`
    Finding-Writing Rules (heading, one-sentence problem, `Status:`, and
    `Source: SWE_PRINCIPLES_AUDIT`).
 
@@ -208,12 +271,22 @@ Each C or D cell resolves exactly one of three ways:
 This audit is read-only, but it is not consequence-free. It runs immediately
 before Batch 21 WP-1, and finishing it is not the same as passing it.
 
+**This gate applies only to net-new findings produced by this audit.** Existing
+findings retain their recorded severity and disposition unless the owner
+reclassifies them. That boundary is deliberate, and F-B21-1 is the case that
+proves it needs stating: a leaked job slot is a resource-release defect in
+`orchestrator.py` and `heatmap.py`, and WP-7 modifies `orchestrator.py`, so
+reading this gate as covering existing findings would block WP-1 today. The
+owner triaged that item as a P1 next-batch candidate with more context than
+this audit has. An audit does not silently re-triage decisions already made.
+
 Classify every net-new finding, then apply this policy:
 
-| Finding | Effect on WP-1 |
+| Net-new finding | Effect on WP-1 |
 |---|---|
 | **P0** by the FINDINGS.md severity key | **Stop.** Fix before WP-1 begins. |
-| Correctness defect in a module any Batch 21 WP modifies -- currently `routes.py` and `orchestrator.py` via WP-7 | **Stop.** Fix or get an explicit owner waiver before WP-1 begins. |
+| Correctness defect in a module any Batch 21 WP modifies -- currently `routes.py` and `orchestrator.py` via WP-7 | **Stop.** Fix, or obtain an explicit owner waiver, before WP-1 begins. |
+| P1 maintainability, not correctness, in a module Batch 21 modifies | **Record and continue**, and name it in the verdict line. WP-7 touches that code anyway, so it is cheapest to fix there -- reference it from the WP-7 commit. |
 | P1 in a module Batch 21 does not touch | Record and continue. |
 | P2 and below | Backlog. |
 
@@ -225,6 +298,11 @@ file list. Neither half requires interpretation.
 The report must state the verdict in one line near the top: **migration may
 proceed**, or **migration is blocked by `<F-IDs>`**. A report that finds blocking
 defects and does not say so has failed its main job.
+
+If the audit concludes that an *existing* finding should block WP-1 -- F-B21-1
+or any other -- it does not act on that conclusion. It records the
+recommendation in the verdict section, with its reasoning, and leaves the
+decision to the owner.
 
 ## 7. Output contract
 
@@ -248,8 +326,9 @@ defects and does not say so has failed its main job.
 ## 8. Budget guidance
 
 Target a single focused session. If the work does not fit, **split it across
-sessions and complete all 130 cells** -- record in the report which session
-covered which modules. Coverage is not negotiable; session count is.
+sessions and complete every cell** -- 13 graded modules by the live principle
+count -- and record in the report which session covered which modules.
+Coverage is not negotiable; session count is.
 
 The earlier version of this charter permitted cutting modules to fit. That
 permission is withdrawn: it let a "comprehensive" audit ship incomplete while

--- a/docs/SWE_AUDIT_CHARTER.md
+++ b/docs/SWE_AUDIT_CHARTER.md
@@ -1,7 +1,11 @@
 # SWE Principles Audit Charter
 
-**Status:** Chartered 2026-07-31. Amended 2026-08-19 (preflight review before
-Batch 21 WP-1). Execution pending. Tracked as FINDINGS.md F-SWE-1.
+**Status:** Executed 2026-08-20, report at
+`docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md`. **This charter is
+retired.** It is kept as the record of what the audit was asked to do, not as
+live work. Chartered 2026-07-31, amended 2026-08-19 after a preflight review.
+FINDINGS.md F-SWE-1 is resolved. The audit returned *migration blocked by
+F-SWE-2*; that decision is the owner's and is stated in the report.
 **Executor contract:** any dedicated, single-purpose agent session (Claude,
 Codex, or equivalent) can run this cold. The judgment is front-loaded into
 this charter; the executor's job is careful reading, evidence gathering,

--- a/docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md
+++ b/docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md
@@ -19,6 +19,43 @@ plainly as the case for the fix; the decision is the owner's.
 Five further net-new findings (F-SWE-3 to F-SWE-7) are record-and-continue.
 None of them blocks WP-1.
 
+## Owner review, 2026-08-20
+
+Added after the audit was filed. The body below is left as written, because a
+dated report that quietly corrects itself stops being a record of what the
+audit concluded. Two dispositions:
+
+**F-SWE-2 -- fix, do not waive.** The owner took the fix. It lands as its own
+commit before WP-1 starts, and it moves the test count: two lines in
+`orchestrator.py` plus a regression test that must fail against the naive
+window before it passes against the fixed one. The verdict above stands as
+written; this is how it clears.
+
+**F-SWE-3 -- rescoped, P1 to P2, and the audit was partly wrong.** This report
+filed it as a user-facing mislabelling and treated the `No Spotify match`
+reason as an inaccurate thing to show a user. That framing does not hold.
+Thousands of Last.fm-scrobbled albums genuinely have no Spotify release, so
+the label is accurate for the ordinary case and what the user sees is
+correct. The audit took a rare failure and wrote it up as if it were the
+common one.
+
+What survives is narrower and independent of labelling: `spotify.py:67-68`
+marks every non-200, non-429 response terminal, so a 500 ends the attempt
+loop after one try while `SPOTIFY_SEARCH_RETRIES` is 3. The configured
+retries only ever fire for 429. That is a gap between configuration and
+behaviour, not between label and truth, and it is P2.
+
+The UI need the owner raised -- the unmatched modal and page should say
+plainly that an album had no Spotify match -- is already Batch 21 WP-7 scope
+(`BATCH21_DEFINITION.md:297-308`), which introduces the `no_spotify_match`
+reason code and two reason cards with human copy. No new work is tracked
+for it.
+
+The rest of the matrix and the two summary answers are unaffected: F-SWE-3
+contributed one C cell (`spotify.py` Fail Fast), and that cell stands on the
+`assert`-based credential check and the bypassed retries regardless of how
+the reason string reads.
+
 ## Provenance
 
 Recorded from live commands, per charter Section 2a.
@@ -431,6 +468,10 @@ siblings when one instance gets fixed.
 
 Six, written into `FINDINGS.md` as `F-SWE-N` entries with
 `Source: SWE_PRINCIPLES_AUDIT`.
+
+The table below is as filed. Owner review the same day took the fix on
+F-SWE-2 and moved F-SWE-3 to P2 -- see "Owner review, 2026-08-20" near the
+top of this report, and `FINDINGS.md` for the current severities.
 
 | ID | Module | Severity | Effect on WP-1 |
 |---|---|---|---|

--- a/docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md
+++ b/docs/history/reports/SWE_PRINCIPLES_AUDIT_2026-08-20.md
@@ -1,0 +1,513 @@
+# SWE Principles Audit -- ScrobbleScope runtime modules
+
+Executed 2026-08-20 against the charter in `docs/SWE_AUDIT_CHARTER.md`.
+Closes FINDINGS.md F-SWE-1.
+
+## Verdict
+
+**Migration is blocked by F-SWE-2.** One net-new correctness defect sits in
+`orchestrator.py`, which Batch 21 WP-7 modifies. Charter Section 6 sends that
+combination to "fix, or obtain an explicit owner waiver, before WP-1 begins".
+
+The block is narrow and cheap to clear. The defect does not affect the live
+site, because the Fly.io container runs UTC and the bug only shows on a
+non-UTC host. It does affect every local development machine, including the
+owner's. The fix is two lines plus a regression test that mirrors one the
+repository already has. The finding below states the case for a waiver as
+plainly as the case for the fix; the decision is the owner's.
+
+Five further net-new findings (F-SWE-3 to F-SWE-7) are record-and-continue.
+None of them blocks WP-1.
+
+## Provenance
+
+Recorded from live commands, per charter Section 2a.
+
+```
+git rev-parse --abbrev-ref HEAD          -> wip/batch-21
+git rev-parse HEAD                       -> 1994673878020e3fe612e1eaff925b17fba96567
+git status --porcelain                   -> (empty)
+git ls-files 'scrobblescope/*.py' app.py -> 14 files
+```
+
+The worktree was clean before grading began and clean after it finished.
+
+**The graded tree is the same code as `bb187ae`.** `git diff --name-only
+bb187ae HEAD -- 'scrobblescope/*.py' app.py tests/` returns nothing. The five
+commits between `main` and this SHA change documentation only. A grade
+recorded here therefore also describes `main` as it stands today.
+
+**Module list confirmed.** 13 graded modules, plus `scrobblescope/__init__.py`
+which is still 0 bytes and correctly carries no matrix row.
+
+**Principle count confirmed.** `AGENT_NOTES.md` Owner Preferences names ten:
+DRY, SoC, SRP, KISS, Dependency Inversion, Composition over Inheritance, Clean
+Architecture, Boy Scout Rule, Least Knowledge, Fail Fast. 13 x 10 = **130
+cells, all filled.**
+
+**Staleness warning.** WP-7 modifies `routes.py` and `orchestrator.py`. The
+rows for those two modules expire when WP-7 lands and must be re-graded, not
+carried forward.
+
+## Discovery commands and their output
+
+Both commands from charter Section 5c were run from the repository root,
+exactly as written.
+
+Longest function definitions:
+
+```
+14 files, 99 function definitions
+ 151  scrobblescope/orchestrator.py:719  _fetch_and_process
+ 112  scrobblescope/routes.py:405  results_loading
+ 109  scrobblescope/heatmap.py:89  _fetch_and_process_heatmap
+ 108  scrobblescope/orchestrator.py:274  _run_spotify_batch_detail_phase
+ 107  scrobblescope/orchestrator.py:513  process_albums
+  89  scrobblescope/routes.py:268  results_complete
+  81  scrobblescope/routes.py:520  heatmap_loading
+  79  scrobblescope/orchestrator.py:193  _run_spotify_search_phase
+  78  scrobblescope/orchestrator.py:433  _build_results
+  78  scrobblescope/lastfm.py:169  fetch_all_recent_tracks_async
+  73  scrobblescope/lastfm.py:72  fetch_recent_tracks_page_async
+  71  scrobblescope/orchestrator.py:56  fetch_top_albums_async
+  61  scrobblescope/utils.py:286  retry_with_semaphore
+  55  scrobblescope/spotify.py:91  fetch_spotify_album_details_batch
+  50  scrobblescope/heatmap.py:37  _aggregate_daily_counts
+```
+
+Broad exception catches: **17**, matching the 2026-07-24 recount in F-MAS-4.
+Locations are listed under "Broad catches" below, with a judgment on each,
+which is the part F-MAS-4 never carried.
+
+## The matrix
+
+13 graded modules by 10 principles. Grades follow charter Section 5a. An A
+carries the letter alone, because an A records the absence of a
+counter-example and an absence has no line to cite. B, C, D and N/A cells
+carry their evidence in "Cell evidence" below.
+
+Key: DI = Dependency Inversion, CoI = Composition over Inheritance,
+CA = Clean Architecture, BSR = Boy Scout Rule, LoD = Least Knowledge,
+FF = Fail Fast.
+
+| Module | DRY | SoC | SRP | KISS | DI | CoI | CA | BSR | LoD | FF |
+|---|---|---|---|---|---|---|---|---|---|---|
+| `app.py` | A | B | B | A | B | N/A | A | A | A | **C** |
+| `cache.py` | A | A | A | A | B | N/A | A | A | A | B |
+| `config.py` | A | A | A | A | A | N/A | A | A | A | **C** |
+| `domain.py` | B | A | A | A | N/A | N/A | A | N/A | A | B |
+| `errors.py` | A | A | A | A | N/A | A | A | A | A | A |
+| `heatmap.py` | B | A | A | A | B | N/A | A | A | A | **C** |
+| `lastfm.py` | A | A | A | A | B | N/A | A | N/A | A | B |
+| `orchestrator.py` | **C** | **D** | **D** | B | B | N/A | A | A | B | **C** |
+| `repositories.py` | A | A | **C** | A | B | N/A | A | A | A | B |
+| `routes.py` | B | B | B | A | B | N/A | A | A | B | B |
+| `spotify.py` | A | A | A | A | B | N/A | A | N/A | A | **C** |
+| `utils.py` | A | **C** | B | A | B | A | A | N/A | B | B |
+| `worker.py` | A | A | A | A | B | N/A | A | N/A | A | A |
+
+Distribution: **A 74, B 28, C 8, D 2, N/A 18 = 130.**
+
+Ten C and D cells. Two map to an existing open finding; eight produce six
+net-new findings. No cell was graded C or D without a disposition.
+
+## Cell evidence
+
+Only B, C, D and N/A cells appear here. Every unlisted cell is an A.
+
+### `app.py`
+
+- **SoC B, SRP B** -- `app.py:12-75` runs `load_dotenv`, console
+  reconfiguration, `os.system("")`, `os.makedirs` and full logging setup at
+  import, before the factory is reached. Known: AUDIT_2026-02-27 item 3,
+  "app.py performs side-effectful logging/config setup at import time". Not
+  re-raised.
+- **DI B** -- `create_app` imports `scrobblescope.routes` inside the function
+  body (`app.py:131`) rather than at module scope. A deliberate cycle-break,
+  contained to one line.
+- **CoI N/A** -- no classes.
+- **BSR A** -- two commits in the window. `21a3b4c` widened log rotation and
+  documented the reason inline; the SECRET_KEY validator arrived with tests.
+  Both left the file better than they found it.
+- **FF C** -- `ensure_api_keys()` is called only under the `__main__` guard
+  (`app.py:140-145`), and production starts with `gunicorn app:app`
+  (`Dockerfile:15`). See **F-SWE-4**.
+
+### `cache.py`
+
+- **DI B** -- `_DATABASE_URL` is captured at import (`cache.py:18`). Already
+  declined, with the Windows reason recorded at `cache.py:13-17` and in
+  REPOSITORY_SYNTHESIS 7.8.
+- **CoI N/A** -- no classes.
+- **FF B** -- `_get_db_connection` returns `None` on every failure instead of
+  raising (`cache.py:36-69`). Fail-open by intent, the three failure classes
+  are logged under distinct labels, and callers degrade correctly.
+
+### `config.py`
+
+- **CoI N/A** -- no classes.
+- **FF C** -- `ensure_api_keys` is defined at `config.py:37` and never reached
+  in production. Same defect as the `app.py` FF cell. See **F-SWE-4**. The
+  module's other startup behaviour is correct: `int(os.getenv(...))` at import
+  raises immediately on a malformed override, which is what Fail Fast asks
+  for.
+
+### `domain.py`
+
+- **DRY B** -- `normalize_track_name` (`domain.py:65-69`) repeats the
+  NFKC-normalize, punctuation-translate, split-and-rejoin sequence that the
+  inner `clean` already implements (`domain.py:37-48`). A change to the
+  normalization rule must be made in both places. Five lines, obvious on
+  sight, and the two functions have genuinely different signatures. Graded to
+  the lower severity per the rubric's tie-break.
+- **DI N/A, CoI N/A** -- a two-function leaf with no dependencies and no
+  classes.
+- **BSR N/A** -- no commits since 2026-03-01, so the principle has no window
+  to judge.
+- **FF B** -- an album named entirely from metadata words normalizes to the
+  empty string rather than raising. Contained, and the dating consequence is
+  already tracked as F-DATA-1.
+
+### `errors.py`
+
+The cleanest module in the matrix alongside `worker.py`. It is a data table
+plus one exception class, it declares its leaf status in its own docstring
+(`errors.py:6`), and the code matches the claim.
+
+- **DI N/A** -- imports nothing.
+- **CoI A** -- `SpotifyUnavailableError(RuntimeError)` at `errors.py:45`.
+  Subclassing an exception is the correct use of inheritance; composition has
+  no purchase here, so this is an A rather than an N/A.
+
+### `heatmap.py`
+
+- **DRY B** -- the win32 event-loop guard at `heatmap.py:211-215` duplicates
+  `orchestrator.py:892-896`. Known as F-B18-7, absorbed into F-B20-2. Not
+  re-raised.
+- **DI B** -- concrete module imports throughout, consistent with the project.
+- **BSR A** -- three commits. `ccb000f` is the model case: it fixed the naive
+  timezone bug and added `test_utc_decode_invariant_against_local_tz_drift`
+  as a pinned regression.
+- **FF C** -- `heatmap.py:218-221` catches every exception and reports it as
+  `lastfm_unavailable`. `_fetch_and_process_heatmap` has no inner handler, so
+  this is the only handler on the path. See **F-SWE-5**. F-B21-1 also lives in
+  this function (`heatmap.py:211-216`, loop built outside the `try`); it is
+  open and is not re-raised here.
+
+### `lastfm.py`
+
+- **DI B** -- concrete imports.
+- **BSR N/A** -- no commits in the window.
+- **FF B** -- `check_user_exists` returns `exists=True` when the lookup fails
+  (`lastfm.py:66-69`), so a broken check does not block a search. The choice is
+  commented at the site. One inconsistency is worth a reader's attention: the
+  same HTTP 404 produces `exists=False` here and a raised `ValueError` in
+  `fetch_recent_tracks_page_async` (`lastfm.py:111-114`). Both are defensible
+  in isolation, and nothing today has to work around the difference.
+
+### `orchestrator.py`
+
+- **DRY C** -- the Last.fm fetch window is built twice, and the two copies
+  disagree. `orchestrator.py:70-71` uses naive `datetime`; `heatmap.py:116-122`
+  uses explicit UTC. See **F-SWE-2**.
+- **SoC D, SRP D** -- 916 lines carrying workflow control, business rules,
+  result shaping and error classification. This is the module's shape, not an
+  instance in it. Maps to open **F-B20-2**; no new entry.
+- **KISS B** -- `orchestrator.py:827-835` writes progress 60, 80 and 90 with no
+  work between the three calls. Harmless, but it makes the progress bar report
+  stages that do not exist.
+- **DI B** -- concrete imports.
+- **CoI N/A** -- no classes.
+- **CA A** -- the import set matches SESSION_CONTEXT Section 4 exactly, and the
+  graph stays acyclic.
+- **BSR A** -- one commit in the window, `01a7904`, which fixed nested-dict
+  aliasing and cited the finding it closed.
+- **LoD B** -- `orchestrator.py:11-16` imports four underscore-prefixed names
+  from `cache.py`. Reaching past a module's public surface normally earns a C,
+  but every function in `cache.py` is underscore-prefixed, so there is no
+  public surface to prefer, there is exactly one importer, and the direction
+  agrees with the documented graph. Contained; stated rather than raised.
+- **FF C** -- `background_task` (`orchestrator.py:912-913`) logs an unhandled
+  error and leaves the job non-terminal. See **F-SWE-5**.
+
+### `repositories.py`
+
+- **SRP C** -- `get_job_progress`, `get_job_unmatched` and `get_job_context`
+  each write `updated_at` while their docstrings claim only to return a copy
+  (`repositories.py:163`, `:175`, `:199`). See **F-SWE-6**.
+- **DI B** -- `JOBS` and `jobs_lock` are module-level globals
+  (`repositories.py:10-11`). Known as F-MAS-5 and accepted for the
+  single-worker deployment.
+- **CoI N/A** -- no classes.
+- **FF B** -- every mutator returns `False` for an unknown job rather than
+  raising. The contract is uniform across all eight mutators and each
+  docstring states it.
+
+### `routes.py`
+
+- **DRY B** -- `results_loading` (`routes.py:458-502`) and `heatmap_loading`
+  (`routes.py:568-598`) repeat the same protocol: clean up expired jobs,
+  acquire a slot, create a job, start a thread, delete the job if the start
+  fails. The bodies differ because one renders HTML and the other returns
+  JSON, and the shared part is about eight lines.
+- **SoC B, SRP B** -- `results_loading` is 112 lines covering form parsing,
+  three validation passes, slot acquisition, job creation, thread start and
+  template rendering. ROUTES_SOC_AUDIT_2026-02-21 extracted four helpers from
+  this file and recorded in its Section 4 what it deliberately left. The
+  remaining shape is readable and linear.
+- **DI B** -- `background_task` and `heatmap_task` are imported concretely
+  (`routes.py:6-8`), so the HTTP layer names its background workers directly.
+- **CoI N/A** -- no classes.
+- **LoD B** -- `_extract_job_params` (`routes.py:34-46`) knows the internal
+  shape of the `params` sub-dict. Contained to one helper, which is why the
+  helper exists.
+- **FF B** -- `unmatched_view` calls `int(year)` at `routes.py:384` without the
+  `None` guard that `results_complete` applies to the same field at
+  `routes.py:301-302`. A heatmap job has no `year`, so posting a heatmap
+  `job_id` to `/unmatched_view` returns HTTP 500; verified against a live test
+  client. No link in the app produces that request, and the 500 handler renders
+  a friendly page, so the cost today is a generic error page instead of a
+  specific one.
+
+### `spotify.py`
+
+- **DI B** -- concrete imports.
+- **BSR N/A** -- no commits in the window.
+- **FF C** -- two problems in one cell. `spotify.py:26-27` validates
+  credentials with `assert`, which `python -O` removes, and `spotify.py:67-68`
+  collapses every non-200, non-429 response into the same value a genuine
+  empty result produces. See **F-SWE-3** and **F-SWE-4**.
+
+### `utils.py`
+
+- **SoC C** -- one module holds five unrelated concerns: rate limiting
+  (`utils.py:29-121`), HTTP session construction (`:155-188`), an in-memory
+  response cache (`:192-242`), duration formatting for display (`:245-283`)
+  and a generic async retry loop (`:286-346`). See **F-SWE-7**.
+- **SRP B** -- the module mixes concerns, but each individual function does one
+  job and does it clearly.
+- **DI B** -- `_LASTFM_THROTTLE` and `_SPOTIFY_THROTTLE` are constructed at
+  import (`utils.py:81-82`).
+- **CoI A** -- `_ThrottledLimiter` (`utils.py:59-78`) wraps a throttle and a
+  limiter instead of subclassing `AsyncLimiter`. This is the cleanest single
+  design decision in the audited code, and the reason the per-loop limiter
+  problem stayed solvable.
+- **BSR N/A** -- no commits in the window.
+- **LoD B** -- `get_cached_response` returns a live reference into the cache
+  (`utils.py:200-212`). The docstring says so, and no current caller mutates
+  it.
+- **FF B** -- `retry_with_semaphore` swallows every exception outside the
+  `reraise` tuple (`utils.py:340-341`). The behaviour is a parameter, and
+  `lastfm.py:142` uses it to let `ValueError` through.
+
+### `worker.py`
+
+42 lines, one concern, and the resource protocol is correct:
+`start_job_thread` releases the slot and re-raises so the caller can react
+without leaking (`worker.py:37-42`).
+
+- **DI B** -- imports `MAX_ACTIVE_JOBS` concretely to size the semaphore.
+- **CoI N/A** -- no classes.
+- **BSR N/A** -- no commits in the window.
+
+## Broad catches: is each one justified?
+
+F-MAS-4 counts these. The charter asks whether each is earned. All 17 were
+read in context. **Fifteen are justified. Two are not.**
+
+| Location | Verdict |
+|---|---|
+| `cache.py:51` | Justified -- connection retry, logged, degrades to `None`. |
+| `cache.py:126` | Justified -- cleanup is explicitly non-fatal. |
+| `heatmap.py:218` | **Not justified** -- relabels every error as a Last.fm outage. F-SWE-5. |
+| `lastfm.py:66` | Justified -- fail-open user check, commented at the site. |
+| `lastfm.py:126` | Justified -- malformed JSON, logs the body prefix. |
+| `orchestrator.py:546` | Justified -- DB lookup failure, records a job stat. |
+| `orchestrator.py:599` | Justified -- DB persist failure, records a job stat. |
+| `orchestrator.py:851` | Justified -- top-level handler that classifies before reporting. |
+| `orchestrator.py:912` | **Not justified** -- logs only, leaves the job non-terminal. F-SWE-5. |
+| `routes.py:156` | Justified -- returns 503. |
+| `routes.py:453` | Justified -- optional check, proceeds and logs. |
+| `routes.py:496` | Justified -- deletes the orphaned job, renders an error. |
+| `routes.py:542` | Justified -- returns 503. |
+| `routes.py:586` | Justified -- deletes the orphaned job, returns 500. |
+| `utils.py:138` | Justified -- captures for the caller, which re-raises. |
+| `utils.py:340` | Justified -- the retry loop's purpose, with `reraise` as the escape. |
+| `worker.py:40` | Justified -- releases the slot and re-raises. |
+
+The pattern is worth recording. Every catch that classifies the failure before
+reporting it is sound, and both unjustified catches are the ones that report a
+cause they never established.
+
+## Test vacuity
+
+`AGENT_NOTES.md` requires that every test fail if the function under test is
+deleted. The charter makes any test that survives such a deletion a net-new
+finding.
+
+This was measured, not judged. A copy of the tree was made outside the
+repository. Each top-level function in the 13 graded modules was replaced in
+turn with `raise AssertionError("DELETED")`, and the 237 runtime tests were run
+against each mutation.
+
+**81 functions mutated. 0 deletions went unnoticed.**
+
+No net-new vacuity finding. The audited worktree was untouched by this
+procedure and verified clean afterwards.
+
+One process note for whoever repeats this. A first run was killed by a timeout
+and left one module mutated on disk, which silently shifted the line numbers
+reported for the next module. That module was re-run from a verified-clean
+copy. Compare each mutated file against the repository before trusting a
+result.
+
+## Two summary questions
+
+### Which principle is weakest across the audited runtime modules?
+
+**Fail Fast**, and not narrowly. It holds five of the eight C grades and earns
+only two A grades across 13 modules, the worst ratio of any principle. Every
+other principle is either broadly upheld or fails in one module for one
+recorded reason.
+
+The failures share a shape. The code is careful about catching problems and
+careless about preserving what the problem was. A Spotify server error becomes
+the same `None` as "no such album" (F-SWE-3). Any heatmap failure becomes
+"Last.fm is currently unavailable" (F-SWE-5). A missing API key becomes a
+per-request failure hours after a startup check would have caught it
+(F-SWE-4). In each case the information needed to report the truth existed at
+the point of the catch and was discarded there.
+
+**The single change that would most improve it:** make a transient upstream
+failure distinguishable from a terminal negative result, and route both
+through the `ERROR_CODES` table in `errors.py` that already exists for exactly
+this purpose. Concretely, give the `retry_with_semaphore` callers a third state
+besides "done" and "retry after N seconds", and have each background entry
+point report the code that matches what actually failed. That one change
+addresses three of the five Fail Fast C cells.
+
+The cheapest single change is a different one and worth doing regardless: call
+`ensure_api_keys()` from `create_app()`. One line closes two C cells.
+
+### Has code quality drifted, held, or improved since the 2026-02 audits?
+
+**Held on the old problems; improved on everything new.** Three independent
+lines of evidence point the same way.
+
+*The February findings are all still open, and none has worsened.* The four
+runtime items in AUDIT_2026-02-27 -- the oversized orchestrator, the global
+`JOBS` state, `app.py` import-time side effects, and the broad catches -- are
+each still present and each still tracked (F-B20-2, F-MAS-5, the un-numbered
+`app.py` item, F-MAS-4). `orchestrator.py` measured about 906 lines in February
+and 916 now: ten lines of drift over six months, against a module that gained
+no new responsibility. That is a stable defect, not a growing one.
+
+*Code written since February grades better than code written before it.*
+`heatmap.py`, `worker.py` and `errors.py` all post-date the February sweep.
+`errors.py` and `worker.py` are the two cleanest modules in this matrix, and
+`heatmap.py` carries one C. The newest code is also the best documented: the
+`heatmap.py` module docstring states its own dependency chain, and
+`config.py:22-30` explains a constant by citing the load test that set it.
+
+*Test discipline improved measurably, not just by reputation.*
+TEST_QUALITY_AUDIT_2026-02-21 found and repaired five vacuous tests. The
+mutation run above found zero across 81 functions. The suite grew from 576
+passing at the 2026-08-11 synthesis to 590 now, and the F-B19-6 fix shipped
+with a named regression test that still pins the behaviour it protects.
+
+This reckons with REPOSITORY_SYNTHESIS_2026-08-11 rather than treating February
+as the last word. That synthesis recorded six live discrepancies in its
+Section 3; all six were remediated within three days, and its own status note
+says so. Its Section 7 structural risks remain accurate and remain open, which
+is consistent with the reading above: the known structural debt is stable and
+tracked, while the delivery process around it has tightened.
+
+One qualification. F-SWE-2 is a bug that was fixed in one module in February
+and left standing in its twin, and nothing caught that for six months. The
+February-era defects are not growing, but neither is anyone sweeping for
+siblings when one instance gets fixed.
+
+## Net-new findings
+
+Six, written into `FINDINGS.md` as `F-SWE-N` entries with
+`Source: SWE_PRINCIPLES_AUDIT`.
+
+| ID | Module | Severity | Effect on WP-1 |
+|---|---|---|---|
+| **F-SWE-2** | `orchestrator.py` | P1 | **Blocks.** Correctness defect in a module WP-7 modifies. |
+| **F-SWE-3** | `spotify.py` | P1 | Record and continue -- module untouched by Batch 21. |
+| **F-SWE-4** | `app.py`, `config.py` | P1 | Record and continue -- modules untouched. |
+| **F-SWE-5** | `heatmap.py`, `orchestrator.py` | P1 | Record and continue -- see the note below. |
+| **F-SWE-6** | `repositories.py` | P2 | Record and continue. |
+| **F-SWE-7** | `utils.py` | P2 | Backlog. |
+
+Two of these needed a judgment call about where the defect lives. Both calls
+are stated here so the owner can overrule either one.
+
+**F-SWE-3** is filed against `spotify.py`, not `orchestrator.py`. The user sees
+the wrong label at `orchestrator.py:253-262`, which WP-7 modifies, but
+`orchestrator.py` behaves correctly given what it receives: the distinction is
+already gone by then, discarded at `spotify.py:67-68`. Filing it against the
+module that loses the information keeps the gate honest. Reading it the other
+way would make it blocking.
+
+**F-SWE-5** spans `heatmap.py` and `orchestrator.py`, and `orchestrator.py` is
+a WP-7 module. It is filed as record-and-continue because the
+`orchestrator.py` half needs the inner handler at `orchestrator.py:851` to fail
+first, which nothing observed can cause. The `heatmap.py` half is the reachable
+one, and `heatmap.py` is untouched by the batch. If the owner reads the
+orchestrator half as independently reachable, this finding blocks too.
+
+### F-SWE-2: the album year window is built from naive datetimes
+
+`orchestrator.py:70-71` builds the Last.fm fetch window with naive
+`datetime(year, 1, 1)` and `datetime(year, 12, 31, 23, 59, 59)`. Calling
+`.timestamp()` on a naive datetime applies the host's local zone, so the window
+shifts by the host's UTC offset. The same timestamps are reused at
+`orchestrator.py:100` to filter individual scrobbles, so the shift is applied
+twice.
+
+Measured on the development host, which runs UTC-5:
+
+```
+orchestrator from_ts : 1704085200 -> 2024-01-01 05:00:00+00:00 UTC
+UTC-correct  from_ts : 1704067200 -> 2024-01-01 00:00:00+00:00 UTC
+window start skew    : +18000 seconds (+5.0 hours)
+```
+
+Five hours of scrobbles are attributed to the wrong year at each boundary.
+
+This is the defect F-B19-6 fixed in `heatmap.py`. `git show --stat ccb000f`
+confirms that fix touched `scrobblescope/heatmap.py` and `tests/test_heatmap.py`
+and nothing else. `heatmap.py:116-122` has used explicit UTC ever since;
+`orchestrator.py` was never revisited. `AGENTS.md` anti-pattern 6 has since
+registered the naive-timezone pattern repository-wide, citing the heatmap
+regression test as the canonical example.
+
+Production is unaffected today. The Fly.io container runs UTC, so the offset is
+zero there. Every non-UTC host is affected, which includes the owner's Windows
+development machine, so local verification of album results has been running
+against a shifted window.
+
+Fix: add `tzinfo=timezone.utc` to both constructors and pin it with a test
+modelled on `test_utc_decode_invariant_against_local_tz_drift`.
+
+**Case for a waiver:** no live user is affected, WP-7 opens this file anyway,
+and the change is two lines. **Case against:** the two lines are smaller than
+the paperwork, `orchestrator.py` is about to be edited by an agent that will
+read the surrounding code as correct, and the last time this bug was
+half-fixed it survived six months.
+
+## Charter compliance
+
+- 130 of 130 cells filled. No module dropped, no coverage cut.
+- Single session. Charter Section 8's split provision was not needed.
+- Read-only. No production code was changed. The mutation testing ran on a copy
+  outside the repository; the audited worktree was verified clean before and
+  after.
+- Baseline honoured. F-B20-2, F-B18-7, F-MAS-4, F-MAS-5, F-DATA-1, F-B21-1 and
+  the AUDIT_2026-02-27 `app.py` item were each recognised and cited rather than
+  re-reported. The deliberate declines in ROUTES_SOC_AUDIT Section 4 and in the
+  `AGENT_NOTES.md` architectural constraints were respected.
+- F-B21-1 keeps its recorded P1 disposition. This audit does not re-triage it,
+  and it does not block WP-1.

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,40 @@ Read helpers:
 - `rg -n "^### 20" docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-08-15 - PR #171 round-5 review threads remediated (side-task)
+
+- Scope: three new Codex threads on `37ca4a9` -- one on the development-cycle
+  diagram and two on the Top Albums sequence. All three were verified against
+  the code before any edit and all three were valid.
+- Verification:
+  - `AGENTS.md` L29-44 defines the review-comment fast path (fetch the thread
+    first, stop if not actionable, else read only the scoped files), but the
+    development-cycle diagram routed every review finding through the full
+    bootstrap gates. The diagram and the rules it documents were written in
+    the same PR and disagreed.
+  - `_fetch_and_process()` stores an empty result, marks progress 100%, and
+    returns before pre-slicing, cache access, or Spotify enrichment when
+    `filtered_albums` is empty. The Top Albums sequence sent every successful
+    page fetch into those stages.
+  - `process_albums()` catches `_batch_lookup_metadata()` exceptions, records
+    `db_cache_warning`, treats every album as a miss, and continues to Spotify
+    (possibly persisting via the open connection). The diagram's connected
+    path presented lookup as unconditional and its unavailable path said
+    persistence was skipped.
+- Plan vs implementation: the development-cycle diagram now branches on
+  review-finding/comment-job before full bootstrap (fetch thread, stop if not
+  actionable, else read scoped files); the Top Albums sequence now stops after
+  an empty filtered set and adds a fail-open cache-lookup-error continuation.
+- Deviations: none. No production behavior changed and no tests were added;
+  existing tests already cover the empty-filtered-set and fail-open lookup
+  paths.
+- Validation: both updated diagrams pass Mermaid validation and open in
+  preview. `pytest -q` -- **590 passed**, 3 known warnings. `pre-commit run
+  --all-files` -- all hooks pass. `doc_state_sync.py --check` -- exit 0 with
+  the expected active-root `BATCH21_DEFINITION.md` warning.
+- Forward guidance: commit and push this remediation, then resolve the three
+  threads. PR #171 remains unmerged pending separate owner instruction.
+
 ### 2026-08-15 - PR #171 final four review threads remediated (side-task)
 
 - Scope: the four remaining unresolved review threads on `e73540d` -- two

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,59 @@ Read helpers:
 - `rg -n "^### 20" docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-08-15 - PR #171 round-6 threads fixed and all five diagrams audited (side-task)
+
+- Scope: the two unresolved Codex threads on `00c0adb`, both on the Top Albums
+  sequence. A prior GLM-5.2 session had left uncommitted diagram edits and a
+  list of findings, then stopped before it finished. I checked the two threads
+  and every edit that session made against the code, then audited all five
+  diagrams with three independent verification agents.
+- Verification of the two threads: both are correct. `fetch_top_albums_async`
+  groups, normalizes, and thresholds the albums before it returns
+  (`orchestrator.py:112-116`), so all of that runs before the empty-result
+  check at `orchestrator.py:784`. `process_albums` writes to the cache only
+  under `if conn and new_metadata_rows` (`orchestrator.py:591`).
+- Verification of the prior session: three of its six edits were wrong. It put
+  the hit/miss partition inside the DB-connected branch, but the code
+  partitions with or without a connection (`orchestrator.py:567`). It drew
+  `cleanup_expired_cache()` as a call to `repositories.py`, but that helper
+  comes from `utils.py` (`orchestrator.py:40`). It put the total Spotify match
+  failure after the store step, but the check runs first
+  (`orchestrator.py:824` before `orchestrator.py:842`).
+- Plan vs implementation:
+  - Top Albums sequence: rewrote the background-task block and the browser
+    block. Grouping now sits before every downstream branch. Persistence is
+    conditional and records `db_cache_persisted`. The partition sits outside
+    the DB branch. New: the connection close and its `finally` ordering
+    against `SpotifyUnavailableError`, the `get_job_context` read behind the
+    total-match-failure check, the six `results_complete` outcomes, the
+    `/progress` 404, and the two unhandled-exception states.
+  - Heatmap sequence: added the housekeeping calls, the page-count stats, the
+    5% and 80% progress writes, and the unhandled-exception path. Rebuilt the
+    render block: the client requests `/heatmap_data` only at 100%, so the 202
+    is a narrow race that restarts polling, not a peer alternative.
+  - Development cycle: split the merged fast path so the actionability stop
+    applies to comment jobs only, added the push-authorization gate that
+    `AGENTS.md` requires between commit and PR, and dropped the E2E claim that
+    no rule file makes.
+  - Runtime diagram and `docs/ARCHITECTURE.md`: named the eight nodes that
+    import `config.py`, corrected the arrow-semantics paragraph, and repointed
+    the module-graph reference to SESSION_CONTEXT Section 4 alone.
+  - Both structural diagrams passed their audit with no change to the graphs.
+- Deviations: the prior session said the fix needed a full rewrite of the
+  parallel block. It did not. The corrections are local, but they reach more
+  branches than that session touched. The audit also found a real code gap and
+  it is recorded as F-B21-1 rather than fixed here: `background_task` and
+  `heatmap_task` build the event loop outside the `try`, so a failure there
+  leaks a job slot. No production code changed in this commit.
+- Validation: all four changed diagrams pass Mermaid validation, checked
+  against the exact text now in the files. `pytest -q` -- **590 passed**, 3
+  known warnings. `pre-commit run --all-files` -- all hooks pass.
+  `doc_state_sync.py --check` -- exit 0 with the expected active-root
+  `BATCH21_DEFINITION.md` warning.
+- Forward guidance: push, then reply to the two threads and resolve them.
+  PR #171 stays open until the owner says otherwise.
+
 ### 2026-08-15 - PR #171 round-5 review threads remediated (side-task)
 
 - Scope: three new Codex threads on `37ca4a9` -- one on the development-cycle

--- a/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
+++ b/docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md
@@ -9,6 +9,34 @@ Read helpers:
 - `rg -n "^### 20" docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 - `rg -n "<keyword>" docs/logarchive/PLAYBOOK_EXECUTION_LOG_ARCHIVE.md`
 
+### 2026-08-19 - PR #171 round-7 threads fixed (side-task)
+
+- Scope: the three unresolved Codex threads left on `3d15849` after the
+  diagram audit. All three are P2 and all three were checked against the
+  source before any edit. All three are correct.
+- Verification and fixes:
+  - `top-albums-sequence.md` drew `Close connection` unconditionally, but
+    `process_albums` closes inside `if conn` (`orchestrator.py:603-604`), so
+    the no-connection branch never closes anything. Wrapped in an `opt DB
+    connected` block.
+  - The same diagram claimed the browser never posts `results_complete` on an
+    error payload. `loading.js:209-229` shows only the retryable branch stays
+    on the page; a non-retryable error waits three seconds and calls
+    `redirectToResults()`, which does post. Split the branch by `retryable`
+    and routed the non-retryable case to the processing-error page.
+  - `FINDINGS.md` F-B21-1 stated `MAX_ACTIVE_JOBS` is 5 as an absolute.
+    `config.py:31` reads it from the environment with 5 as the default, and
+    the literal contradicted F-LOAD-1 in the same file. Reworded to name 5 as
+    the default and tie the failure count to configured capacity.
+- Deviations: none. No code changed; F-B21-1 stays open and unfixed, because
+  it is a code change for a code batch.
+- Validation: `pytest -q` -- **590 passed**. `pre-commit run --files` on both
+  edited files -- all hooks pass. `doc_state_sync.py --check` -- exit 0 with
+  the expected root BATCH warning. The edited Mermaid diagram was validated
+  through the Mermaid Chart validator: `valid = true`, type `sequence`.
+- Forward guidance: the next action is unchanged -- the F-SWE-1 audit, then
+  Batch 21 WP-1.
+
 ### 2026-08-15 - PR #171 round-6 threads fixed and all five diagrams audited (side-task)
 
 - Scope: the two unresolved Codex threads on `00c0adb`, both on the Top Albums

--- a/scrobblescope/orchestrator.py
+++ b/scrobblescope/orchestrator.py
@@ -4,7 +4,7 @@ import sys
 import threading
 import time
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from math import ceil
 from typing import Any, cast
 
@@ -67,8 +67,8 @@ async def fetch_top_albums_async(
             ``fetch_all_recent_tracks_async`` for per-page progress.
     """
     logging.debug(f"Start fetch_top_albums_async(user={username}, year={year})")
-    from_ts = int(datetime(year, 1, 1).timestamp())
-    to_ts = int(datetime(year, 12, 31, 23, 59, 59).timestamp())
+    from_ts = int(datetime(year, 1, 1, tzinfo=timezone.utc).timestamp())
+    to_ts = int(datetime(year, 12, 31, 23, 59, 59, tzinfo=timezone.utc).timestamp())
     pages, fetch_metadata = await fetch_all_recent_tracks_async(
         username, from_ts, to_ts, progress_cb=progress_cb
     )

--- a/tests/services/test_lastfm_logic.py
+++ b/tests/services/test_lastfm_logic.py
@@ -5,7 +5,7 @@ enforcement, the now-playing sentinel, non-Latin track deduplication,
 and fetch-metadata stat reporting.  Network calls are fully mocked.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -19,8 +19,8 @@ from scrobblescope.orchestrator import fetch_top_albums_async
 
 
 def _track(artist, album, name, year=2023, month=6, day=15):
-    """Build a minimal Last.fm track dict with a timestamp in the given year."""
-    ts = int(datetime(year, month, day).timestamp())
+    """Build a minimal Last.fm track dict with a UTC timestamp."""
+    ts = int(datetime(year, month, day, tzinfo=timezone.utc).timestamp())
     return {
         "artist": {"#text": artist},
         "album": {"#text": album},
@@ -150,6 +150,35 @@ async def test_fetch_top_albums_skips_out_of_bounds_timestamps():
 
     artist_keys = {v["original_artist"] for v in result.values()}
     assert "Artist X" not in artist_keys
+
+
+@pytest.mark.asyncio
+async def test_fetch_top_albums_uses_utc_year_window_on_non_utc_host():
+    """The Last.fm year window stays on UTC boundaries on a UTC-5 host.
+
+    Adversarial: the injected constructor gives naive datetimes fixed UTC-5
+    semantics while preserving any explicit ``tzinfo``. The expected epoch
+    values are UTC literals, independent of the production construction.
+    """
+
+    def utc_minus_five_datetime(*args, **kwargs):
+        """Simulate UTC-5 only when production omits an explicit timezone."""
+        kwargs.setdefault("tzinfo", timezone(-timedelta(hours=5)))
+        return datetime(*args, **kwargs)
+
+    fetch_tracks = AsyncMock(return_value=([], {"status": "ok"}))
+    with (
+        patch("scrobblescope.orchestrator.datetime", new=utc_minus_five_datetime),
+        patch(
+            "scrobblescope.orchestrator.fetch_all_recent_tracks_async",
+            new=fetch_tracks,
+        ),
+    ):
+        await fetch_top_albums_async("testuser", 2024)
+
+    fetch_tracks.assert_awaited_once_with(
+        "testuser", 1704067200, 1735689599, progress_cb=None
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Strengthen the Batch 21 preflight and frontend gates, execute the 130-cell SWE principles audit, and publish its report plus F-SWE-2 through F-SWE-7 with the owner's dispositions.
- Clear the only WP-1 migration blocker by constructing both Last.fm album-year boundaries in UTC. The deterministic UTC-5 regression failed the naive implementation by 18,000 seconds before passing against the fix.
- Add the agent document map, trim duplicated handoff prose, ignore Playwright MCP scratch output, and synchronize the live test-count and Batch 21 documentation. WP-1 remains unstarted and next; F-SWE-3 remains P2 and F-B21-1 remains unchanged.

## Validation

- `pytest -q` -- 591 passed, 3 warnings
- `pre-commit run --all-files` -- all 10 hooks passed; all 97 tracked Markdown hashes matched before and after
- `python scripts/doc_state_sync.py --check` -- passed with the expected active-root `BATCH21_DEFINITION.md` warning
- `python scripts/dev/check_worktree_alignment.py` -- WT000, 0 behind and 9 ahead of `origin/main`

## Checklist

- [x] `pytest -q` passes (SESSION_CONTEXT Section 1 updated for the new count)
- [x] `pre-commit run --all-files` passes (all hooks)
- [x] `python scripts/doc_state_sync.py --check` exits 0
- [x] PLAYBOOK Section 3 reflects current WP/task state
- [x] PLAYBOOK Section 4 has the dated current-batch and side-task entries in their required locations
- [x] Changes are within the active Batch 21 scope or recorded as approved prerequisites/side tasks